### PR TITLE
Add action required admin tab for user cleanup

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,6 +10,7 @@ import AssignCoachPanel from '@/components/admin/AssignCoachPanel';
 import CoachRosters from '@/components/admin/CoachRosters';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import ResourceLibraryAdmin from '@/components/admin/ResourceLibraryAdmin';
+import AdminActionRequired from '@/components/admin/AdminActionRequired';
 
 
 import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js';
@@ -173,6 +174,7 @@ export default function AdminPage() {
             <Tab label="Assign / Change Coach" />
             <Tab label="Coach Rosters" />
             <Tab label="Resource Library" />
+            <Tab label="Action Required" />
           </Tabs>
 
           <Box sx={{ p: 3 }}>
@@ -188,6 +190,9 @@ export default function AdminPage() {
             <TabPanel value={tab} index={3}>
               {/* New admin panel for resources */}
               <ResourceLibraryAdmin />
+            </TabPanel>
+            <TabPanel value={tab} index={4}>
+              <AdminActionRequired />
             </TabPanel>
           </Box>
         </Paper>

--- a/src/app/api/admin/action-required/route.ts
+++ b/src/app/api/admin/action-required/route.ts
@@ -1,0 +1,212 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+type CourseRow = { id: number; name: string | null; start_date: string | null; created_at: string };
+type ProfileRow = { id: string; first_name: string | null; last_name: string | null; looker_link: string | null };
+
+type CourseItem = { id: number; name: string; start_date: string | null };
+type UserSummary = { id: string; name: string; email: string };
+
+type LookerSummary = UserSummary & { looker_link: string | null };
+type PhoneSummary = UserSummary & { phone: string | null };
+
+function formatName(profile: ProfileRow | undefined) {
+  const first = profile?.first_name?.trim() ?? '';
+  const last = profile?.last_name?.trim() ?? '';
+  const full = `${first} ${last}`.trim();
+  return full || 'Unnamed user';
+}
+
+export async function GET(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const supa = getAdminClient();
+
+  const { searchParams } = new URL(request.url);
+  const courseParam = searchParams.get('course_id');
+  const parsedCourseId = courseParam ? Number.parseInt(courseParam, 10) : Number.NaN;
+  const requestedCourseId = Number.isFinite(parsedCourseId) ? parsedCourseId : null;
+
+  const { data: courseRows, error: courseErr } = await supa
+    .from('courses')
+    .select('id, name, start_date, created_at')
+    .order('start_date', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false });
+
+  if (courseErr) {
+    return NextResponse.json({ error: courseErr.message }, { status: 400 });
+  }
+
+  const courses: CourseItem[] = (courseRows ?? []).map((row: CourseRow) => ({
+    id: row.id,
+    name: row.name?.trim() || `Course #${row.id}`,
+    start_date: row.start_date,
+  }));
+
+  const defaultCourseId = courses.length > 0 ? courses[0].id : null;
+  const courseId = requestedCourseId && courses.some((c) => c.id === requestedCourseId)
+    ? requestedCourseId
+    : defaultCourseId;
+
+  const { data: roleRow, error: roleErr } = await supa
+    .from('roles')
+    .select('id')
+    .eq('code', 'user')
+    .maybeSingle();
+
+  if (roleErr) {
+    return NextResponse.json({ error: roleErr.message }, { status: 400 });
+  }
+
+  const roleId = roleRow?.id;
+
+  if (!roleId) {
+    return NextResponse.json({
+      courses,
+      defaultCourseId,
+      selectedCourseId: courseId,
+      missingCoachUsers: [],
+      missingLookerUsers: [],
+      missingPhoneUsers: [],
+    });
+  }
+
+  const { data: userRoleRows, error: userRoleErr } = await supa
+    .from('user_roles')
+    .select('user_id')
+    .eq('role_id', roleId);
+
+  if (userRoleErr) {
+    return NextResponse.json({ error: userRoleErr.message }, { status: 400 });
+  }
+
+  const userIds = (userRoleRows ?? [])
+    .map((row) => row.user_id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  if (userIds.length === 0) {
+    return NextResponse.json({
+      courses,
+      defaultCourseId,
+      selectedCourseId: courseId,
+      missingCoachUsers: [],
+      missingLookerUsers: [],
+      missingPhoneUsers: [],
+    });
+  }
+
+  const { data: profileRows, error: profileErr } = await supa
+    .from('profiles')
+    .select('id, first_name, last_name, looker_link')
+    .in('id', userIds);
+
+  if (profileErr) {
+    return NextResponse.json({ error: profileErr.message }, { status: 400 });
+  }
+
+  const profileMap = new Map<string, ProfileRow>();
+  for (const row of profileRows ?? []) {
+    if (row?.id) profileMap.set(row.id, row as ProfileRow);
+  }
+
+  const userIdSet = new Set(userIds);
+
+  const assignedSet = new Set<string>();
+  if (courseId !== null) {
+    const { data: assignmentRows, error: assignmentErr } = await supa
+      .from('user_coaches')
+      .select('user_id')
+      .eq('course_id', courseId)
+      .eq('is_active', true);
+
+    if (assignmentErr) {
+      return NextResponse.json({ error: assignmentErr.message }, { status: 400 });
+    }
+
+    for (const row of assignmentRows ?? []) {
+      if (row?.user_id) assignedSet.add(row.user_id);
+    }
+  }
+
+  const missingCoachIds = courseId === null
+    ? []
+    : userIds.filter((id) => !assignedSet.has(id));
+
+  const missingLookerRows = (profileRows ?? []).filter((row) => {
+    if (!row?.id) return false;
+    const link = (row.looker_link ?? '').trim();
+    return link.length === 0;
+  });
+
+  const authMap = new Map<string, { email: string; phone: string | null }>();
+
+  let page = 1;
+  const perPage = 1000; // ← prefer-const
+  for (;;) {
+    const { data, error } = await supa.auth.admin.listUsers({ page, perPage });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    for (const usr of data.users) {
+      if (userIdSet.has(usr.id)) {
+        authMap.set(usr.id, {
+          email: (usr.email || '').toLowerCase(),
+          phone: usr.phone ?? null,
+        });
+      }
+    }
+    if (data.users.length < perPage || authMap.size >= userIdSet.size) break;
+    page++;
+  }
+
+  const missingCoachUsers: UserSummary[] = missingCoachIds.map((id) => {
+    const profile = profileMap.get(id);
+    const auth = authMap.get(id);
+    return {
+      id,
+      name: formatName(profile),
+      email: auth?.email ?? '',
+    };
+  }).sort((a, b) => a.name.localeCompare(b.name) || a.email.localeCompare(b.email));
+
+  const missingLookerUsers: LookerSummary[] = missingLookerRows
+    .map((row) => {
+      const auth = row?.id ? authMap.get(row.id) : undefined;
+      return {
+        id: row.id,
+        name: formatName(row as ProfileRow),
+        email: auth?.email ?? '',
+        looker_link: row.looker_link ?? null,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name) || a.email.localeCompare(b.email));
+
+  const missingPhoneUsers: PhoneSummary[] = userIds
+    .filter((id) => {
+      const auth = authMap.get(id);
+      const phone = auth?.phone ?? '';
+      return !phone || phone.trim().length === 0;
+    })
+    .map((id) => {
+      const profile = profileMap.get(id);
+      const auth = authMap.get(id);
+      return {
+        id,
+        name: formatName(profile),
+        email: auth?.email ?? '',
+        phone: auth?.phone ?? null,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name) || a.email.localeCompare(b.email));
+
+  return NextResponse.json({
+    courses,
+    defaultCourseId,
+    selectedCourseId: courseId,
+    missingCoachUsers,
+    missingLookerUsers,
+    missingPhoneUsers,
+  });
+}

--- a/src/app/api/admin/users/[userId]/reset-password/route.ts
+++ b/src/app/api/admin/users/[userId]/reset-password/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+type Params = { params: { userId: string } };
+
+function isUuid(id: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+}
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const userId = params.userId;
+  if (!userId || !isUuid(userId)) {
+    return NextResponse.json({ error: 'Invalid user id' }, { status: 400 });
+  }
+
+  const supa = getAdminClient();
+
+  const { data, error } = await supa.auth.admin.getUserById(userId);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  const email = data.user?.email;
+  if (!email) {
+    return NextResponse.json({ error: 'User has no email on record' }, { status: 400 });
+  }
+
+  const { error: resetErr } = await supa.auth.resetPasswordForEmail(email);
+  if (resetErr) {
+    return NextResponse.json({ error: resetErr.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/users/[userId]/route.ts
+++ b/src/app/api/admin/users/[userId]/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+type Params = { params: { userId: string } };
+
+function isUuid(id: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+}
+
+async function fetchUserPayload(userId: string) {
+  const supa = getAdminClient();
+
+  const [{ data: profile, error: profileErr }, { data: authData, error: authErr }] = await Promise.all([
+    supa
+      .from('profiles')
+      .select('first_name, last_name, looker_link')
+      .eq('id', userId)
+      .maybeSingle(),
+    supa.auth.admin.getUserById(userId),
+  ]);
+
+  if (profileErr) {
+    return { error: profileErr.message, status: 400 } as const;
+  }
+  if (authErr) {
+    return { error: authErr.message, status: 400 } as const;
+  }
+
+  const user = authData.user;
+  if (!profile || !user) {
+    return { error: 'User not found', status: 404 } as const;
+  }
+
+  return {
+    payload: {
+      id: userId,
+      email: (user.email || '').toLowerCase(),
+      phone: user.phone && user.phone.trim().length > 0 ? user.phone : null,
+      first_name: profile.first_name ?? '',
+      last_name: profile.last_name ?? '',
+      looker_link: profile.looker_link?.trim() ?? '',
+    },
+  } as const;
+}
+
+export async function GET(request: NextRequest, { params }: Params) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const userId = params.userId;
+  if (!userId || !isUuid(userId)) {
+    return NextResponse.json({ error: 'Invalid user id' }, { status: 400 });
+  }
+
+  const result = await fetchUserPayload(userId);
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.payload);
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const userId = params.userId;
+  if (!userId || !isUuid(userId)) {
+    return NextResponse.json({ error: 'Invalid user id' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { first_name, last_name, looker_link, phone } = body as Partial<{
+    first_name: string;
+    last_name: string;
+    looker_link: string | null;
+    phone: string | null;
+  }>;
+
+  const profileUpdates: Record<string, string | null> = {};
+
+  if (typeof first_name === 'string') {
+    profileUpdates.first_name = first_name.trim();
+  }
+  if (typeof last_name === 'string') {
+    profileUpdates.last_name = last_name.trim();
+  }
+  if (typeof looker_link === 'string') {
+    profileUpdates.looker_link = looker_link.trim();
+  } else if (looker_link === null) {
+    profileUpdates.looker_link = '';
+  }
+
+  const supa = getAdminClient();
+
+  if (Object.keys(profileUpdates).length > 0) {
+    const { error: updateErr } = await supa
+      .from('profiles')
+      .update(profileUpdates)
+      .eq('id', userId);
+
+    if (updateErr) {
+      return NextResponse.json({ error: updateErr.message }, { status: 400 });
+    }
+  }
+
+  if (typeof phone === 'string' || phone === null) {
+    const nextPhone = phone === null ? '' : phone.trim();
+    const { error: phoneErr } = await supa.auth.admin.updateUserById(userId, { phone: nextPhone });
+    if (phoneErr) {
+      return NextResponse.json({ error: phoneErr.message }, { status: 400 });
+    }
+  }
+
+  const result = await fetchUserPayload(userId);
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.payload);
+}

--- a/src/components/admin/AdminActionRequired.tsx
+++ b/src/components/admin/AdminActionRequired.tsx
@@ -1,0 +1,729 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Divider,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Snackbar,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import Autocomplete from '@mui/material/Autocomplete';
+import { LoadingButton } from '@mui/lab';
+
+type Course = { id: number; name: string; start_date: string | null };
+type UserSummary = { id: string; name: string; email: string };
+type LookerSummary = UserSummary & { looker_link: string | null };
+type PhoneSummary = UserSummary & { phone: string | null };
+
+type ActionRequiredResponse = {
+  courses: Course[];
+  defaultCourseId: number | null;
+  selectedCourseId: number | null;
+  missingCoachUsers: UserSummary[];
+  missingLookerUsers: LookerSummary[];
+  missingPhoneUsers: PhoneSummary[];
+};
+
+type Person = { id: string; name: string; email: string };
+
+type UserDetails = {
+  id: string;
+  email: string;
+  phone: string | null;
+  first_name: string;
+  last_name: string;
+  looker_link: string;
+};
+
+const emptyDetails: UserDetails = {
+  id: '',
+  email: '',
+  phone: '',
+  first_name: '',
+  last_name: '',
+  looker_link: '',
+};
+
+function sortSummaries<T extends UserSummary>(items: T[]) {
+  return [...items].sort((a, b) => a.name.localeCompare(b.name) || a.email.localeCompare(b.email));
+}
+
+function buildName(first: string, last: string, fallback: string) {
+  const full = `${first?.trim() ?? ''} ${last?.trim() ?? ''}`.trim();
+  return full || fallback || 'Unnamed user';
+}
+
+function formatDate(date: string | null) {
+  if (!date) return null;
+  const d = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString();
+}
+
+function isValidUrl(value: string) {
+  if (!value) return false;
+  return /^https?:\/\//i.test(value.trim());
+}
+
+export default function AdminActionRequired() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [selectedCourseId, setSelectedCourseId] = useState<number | null>(null);
+  const [missingCoaches, setMissingCoaches] = useState<UserSummary[]>([]);
+  const [missingLooker, setMissingLooker] = useState<LookerSummary[]>([]);
+  const [missingPhone, setMissingPhone] = useState<PhoneSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadedOnce, setLoadedOnce] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [snack, setSnack] = useState<{ open: boolean; message: string; severity: 'success' | 'error' | 'info' }>(
+    { open: false, message: '', severity: 'success' }
+  );
+
+  const [lookerInputs, setLookerInputs] = useState<Record<string, string>>({});
+  const [savingLookerIds, setSavingLookerIds] = useState<string[]>([]);
+  const [phoneInputs, setPhoneInputs] = useState<Record<string, string>>({});
+  const [savingPhoneIds, setSavingPhoneIds] = useState<string[]>([]);
+
+  const [userOptions, setUserOptions] = useState<Person[]>([]);
+  const [userOptionsLoading, setUserOptionsLoading] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<Person | null>(null);
+  const [userDetails, setUserDetails] = useState<UserDetails | null>(null);
+  const [detailsLoading, setDetailsLoading] = useState(false);
+  const [detailsError, setDetailsError] = useState<string | null>(null);
+  const [savingDetails, setSavingDetails] = useState(false);
+  const [sendingReset, setSendingReset] = useState(false);
+
+  const [detailsForm, setDetailsForm] = useState(emptyDetails);
+
+  const editorLookerInvalid =
+    !!userDetails && detailsForm.looker_link.trim().length > 0 && !isValidUrl(detailsForm.looker_link);
+
+  async function loadActionData(courseId?: number) {
+    setLoading(true);
+    setError(null);
+    try {
+      const query = typeof courseId === 'number' ? `?course_id=${courseId}` : '';
+      const res = await fetch(`/api/admin/action-required${query}`);
+      const data: ActionRequiredResponse = await res.json();
+      if (!res.ok) throw new Error((data as { error?: string })?.error || res.statusText);
+
+      setCourses(data.courses ?? []);
+      setMissingCoaches(sortSummaries(data.missingCoachUsers ?? []));
+      setMissingLooker(sortSummaries(data.missingLookerUsers ?? []));
+      setMissingPhone(sortSummaries(data.missingPhoneUsers ?? []));
+      setLookerInputs({});
+      setPhoneInputs({});
+
+      const effectiveCourse =
+        typeof courseId === 'number'
+          ? data.selectedCourseId ?? courseId
+          : data.selectedCourseId ?? data.defaultCourseId ?? null;
+      setSelectedCourseId(effectiveCourse ?? null);
+
+      setLoadedOnce(true);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to load action data';
+      setError(message);
+      setSnack({ open: true, message, severity: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadActionData().catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    setUserOptionsLoading(true);
+    fetch('/api/admin/list-users')
+      .then(async (res) => {
+        const data = await res.json();
+        if (!res.ok) throw new Error(data?.error || res.statusText);
+        const items = Array.isArray(data?.items) ? data.items : [];
+        setUserOptions(items);
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Failed to load users';
+        setSnack({ open: true, message, severity: 'error' });
+      })
+      .finally(() => setUserOptionsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!userDetails || !userDetails.id) {
+      setDetailsForm(emptyDetails);
+      return;
+    }
+    setDetailsForm({
+      id: userDetails.id,
+      email: userDetails.email,
+      phone: userDetails.phone ?? '',
+      first_name: userDetails.first_name,
+      last_name: userDetails.last_name,
+      looker_link: userDetails.looker_link ?? '',
+    });
+  }, [userDetails]);
+
+  const coachCountLabel = useMemo(
+    () => `${missingCoaches.length} user${missingCoaches.length === 1 ? '' : 's'}`,
+    [missingCoaches.length]
+  );
+
+  const lookerCountLabel = useMemo(
+    () => `${missingLooker.length} user${missingLooker.length === 1 ? '' : 's'}`,
+    [missingLooker.length]
+  );
+
+  const phoneCountLabel = useMemo(
+    () => `${missingPhone.length} user${missingPhone.length === 1 ? '' : 's'}`,
+    [missingPhone.length]
+  );
+
+  async function updateLookerLink(user: LookerSummary, value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setSnack({ open: true, message: 'Link cannot be empty', severity: 'error' });
+      return;
+    }
+    if (!isValidUrl(trimmed)) {
+      setSnack({ open: true, message: 'Link must start with http:// or https://', severity: 'error' });
+      return;
+    }
+
+    setSavingLookerIds((prev) => [...prev, user.id]);
+    try {
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(user.id)}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ looker_link: trimmed }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || res.statusText);
+
+      setMissingLooker((prev) => prev.filter((item) => item.id !== user.id));
+      setLookerInputs((prev) => {
+        const next = { ...prev };
+        delete next[user.id];
+        return next;
+      });
+      if (userDetails?.id === user.id) {
+        setUserDetails({
+          ...userDetails,
+          looker_link: trimmed,
+        });
+      }
+      setSnack({ open: true, message: `Saved Looker link for ${user.name}`, severity: 'success' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to update Looker link';
+      setSnack({ open: true, message, severity: 'error' });
+    } finally {
+      setSavingLookerIds((prev) => prev.filter((id) => id !== user.id));
+    }
+  }
+
+  async function updatePhone(user: PhoneSummary, value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setSnack({ open: true, message: 'Phone cannot be empty', severity: 'error' });
+      return;
+    }
+
+    setSavingPhoneIds((prev) => [...prev, user.id]);
+    try {
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(user.id)}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ phone: trimmed }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || res.statusText);
+
+      setMissingPhone((prev) => prev.filter((item) => item.id !== user.id));
+      setPhoneInputs((prev) => {
+        const next = { ...prev };
+        delete next[user.id];
+        return next;
+      });
+      if (userDetails?.id === user.id) {
+        setUserDetails({
+          ...userDetails,
+          phone: trimmed,
+        });
+      }
+      setSnack({ open: true, message: `Saved phone number for ${user.name}`, severity: 'success' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to update phone number';
+      setSnack({ open: true, message, severity: 'error' });
+    } finally {
+      setSavingPhoneIds((prev) => prev.filter((id) => id !== user.id));
+    }
+  }
+
+  async function loadUserDetails(id: string) {
+    setDetailsLoading(true);
+    setDetailsError(null);
+    try {
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(id)}`);
+      const data: UserDetails = await res.json();
+      if (!res.ok) throw new Error((data as { error?: string })?.error || res.statusText);
+      setUserDetails(data);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to load user details';
+      setDetailsError(message);
+      setUserDetails(null);
+    } finally {
+      setDetailsLoading(false);
+    }
+  }
+
+  async function saveUserDetails() {
+    if (!userDetails?.id) return;
+
+    const trimmedLooker = detailsForm.looker_link.trim();
+    if (trimmedLooker && !isValidUrl(trimmedLooker)) {
+      setSnack({ open: true, message: 'Looker link must start with http:// or https://', severity: 'error' });
+      return;
+    }
+
+    setSavingDetails(true);
+    try {
+      const payload = {
+        first_name: detailsForm.first_name.trim(),
+        last_name: detailsForm.last_name.trim(),
+        looker_link: trimmedLooker,
+        phone: detailsForm.phone.trim(),
+      };
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(userDetails.id)}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data: UserDetails = await res.json();
+      if (!res.ok) throw new Error((data as { error?: string })?.error || res.statusText);
+
+      setUserDetails(data);
+      setSnack({ open: true, message: 'User details updated', severity: 'success' });
+
+      const name = buildName(data.first_name, data.last_name, data.email);
+      setSelectedUser((prev) => (prev && prev.id === data.id ? { ...prev, name, email: data.email } : prev));
+      setUserOptions((prev) =>
+        prev.map((item) => (item.id === data.id ? { ...item, name, email: data.email } : item))
+      );
+      setMissingCoaches((prev) => {
+        if (!prev.some((item) => item.id === data.id)) return prev;
+        const updated = prev.map((item) =>
+          item.id === data.id ? { ...item, name, email: data.email } : item
+        );
+        return sortSummaries(updated);
+      });
+
+      const lookerValue = data.looker_link?.trim() ?? '';
+      const hasLooker = lookerValue.length > 0;
+      setMissingLooker((prev) => {
+        const idx = prev.findIndex((item) => item.id === data.id);
+        if (hasLooker) {
+          if (idx === -1) return prev;
+          const next = [...prev];
+          next.splice(idx, 1);
+          return next;
+        }
+        const nextItem: LookerSummary = {
+          id: data.id,
+          name,
+          email: data.email,
+          looker_link: hasLooker ? lookerValue : null,
+        };
+        if (idx !== -1) {
+          const next = [...prev];
+          next[idx] = nextItem;
+          return sortSummaries(next);
+        }
+        return sortSummaries([...prev, nextItem]);
+      });
+
+      const phoneValue = data.phone?.trim() ?? '';
+      setMissingPhone((prev) => {
+        const idx = prev.findIndex((item) => item.id === data.id);
+        if (phoneValue) {
+          if (idx === -1) return prev;
+          const next = [...prev];
+          next.splice(idx, 1);
+          return next;
+        }
+        const nextItem: PhoneSummary = {
+          id: data.id,
+          name,
+          email: data.email,
+          phone: phoneValue ? phoneValue : null,
+        };
+        if (idx !== -1) {
+          const next = [...prev];
+          next[idx] = nextItem;
+          return sortSummaries(next);
+        }
+        return sortSummaries([...prev, nextItem]);
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to update user';
+      setSnack({ open: true, message, severity: 'error' });
+    } finally {
+      setSavingDetails(false);
+    }
+  }
+
+  async function sendResetEmail() {
+    if (!userDetails?.id) return;
+    setSendingReset(true);
+    try {
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(userDetails.id)}/reset-password`, {
+        method: 'POST',
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || res.statusText);
+      setSnack({ open: true, message: 'Password reset email sent', severity: 'success' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to send password reset email';
+      setSnack({ open: true, message, severity: 'error' });
+    } finally {
+      setSendingReset(false);
+    }
+  }
+
+  const handleCourseChange = (value: string) => {
+    if (!value) {
+      setSelectedCourseId(null);
+      return;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed)) return;
+    setSelectedCourseId(parsed);
+    loadActionData(parsed).catch(() => {});
+  };
+
+  const lookerInputValue = (id: string) => lookerInputs[id] ?? '';
+  const phoneInputValue = (id: string) => phoneInputs[id] ?? '';
+
+    const invalidLookerIds = new Set(
+      Object.entries(lookerInputs)
+        .filter(([, value]) => value.trim().length > 0 && !isValidUrl(value))
+        .map(([id]) => id)
+    );
+
+  const showGlobalSpinner = !loadedOnce && loading;
+
+  const handleSnackClose = () => setSnack((prev) => ({ ...prev, open: false }));
+
+  return (
+    <Box sx={{ display: 'grid', gap: 3 }}>
+      {showGlobalSpinner ? (
+        <Paper sx={{ p: 4, display: 'grid', placeItems: 'center' }}>
+          <CircularProgress />
+          <Typography sx={{ mt: 2 }} color="text.secondary">
+            Loading admin data…
+          </Typography>
+        </Paper>
+      ) : (
+        <>
+          <Paper elevation={0} sx={{ p: 3, border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+            <Stack spacing={2}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                <Typography variant="h6" fontWeight={600}>
+                  Course coverage
+                </Typography>
+                <Chip label={coachCountLabel} size="small" />
+                <Box sx={{ flex: 1 }} />
+                <LoadingButton
+                  size="small"
+                  variant="outlined"
+                  loading={loading}
+                  onClick={() => loadActionData(selectedCourseId ?? undefined)}
+                >
+                  Refresh
+                </LoadingButton>
+              </Box>
+
+              {courses.length > 0 ? (
+                <TextField
+                  select
+                  label="Course"
+                  value={selectedCourseId ?? ''}
+                  onChange={(event) => handleCourseChange(event.target.value)}
+                  helperText="Select a course to see users without an assigned coach."
+                  sx={{ maxWidth: 360 }}
+                >
+                  {courses.map((course) => {
+                    const date = formatDate(course.start_date);
+                    return (
+                      <MenuItem key={course.id} value={course.id}>
+                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                          <Typography>{course.name}</Typography>
+                          {date && (
+                            <Typography variant="caption" color="text.secondary">
+                              Starts {date}
+                            </Typography>
+                          )}
+                        </Box>
+                      </MenuItem>
+                    );
+                  })}
+                </TextField>
+              ) : (
+                <Alert severity="info">No courses available.</Alert>
+              )}
+
+              {loading && loadedOnce && <LinearProgress />}
+
+              {error && (
+                <Alert severity="error">{error}</Alert>
+              )}
+
+              {missingCoaches.length === 0 ? (
+                <Alert severity="success">All users for this course have an assigned coach.</Alert>
+              ) : (
+                <Box sx={{ display: 'grid', gap: 1 }}>
+                  {missingCoaches.map((user) => (
+                    <Paper key={user.id} variant="outlined" sx={{ p: 1.5 }}>
+                      <Typography fontWeight={600}>{user.name}</Typography>
+                      <Typography color="text.secondary">{user.email || 'No email on file'}</Typography>
+                    </Paper>
+                  ))}
+                </Box>
+              )}
+            </Stack>
+          </Paper>
+
+          <Paper elevation={0} sx={{ p: 3, border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+            <Stack spacing={2}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <Typography variant="h6" fontWeight={600}>
+                  Missing Looker links
+                </Typography>
+                <Chip label={lookerCountLabel} size="small" />
+              </Box>
+
+              {missingLooker.length === 0 ? (
+                <Alert severity="success">Everyone has a Looker link.</Alert>
+              ) : (
+                <Stack spacing={1.5}>
+                  {missingLooker.map((user) => {
+                    const value = lookerInputValue(user.id);
+                    const invalid = invalidLookerIds.has(user.id);
+                    const saving = savingLookerIds.includes(user.id);
+                    return (
+                      <Paper key={user.id} variant="outlined" sx={{ p: 2 }}>
+                        <Stack spacing={1.5}>
+                          <Box>
+                            <Typography fontWeight={600}>{user.name}</Typography>
+                            <Typography color="text.secondary">{user.email || 'No email on file'}</Typography>
+                          </Box>
+                          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems={{ md: 'center' }}>
+                            <TextField
+                              fullWidth
+                              label="Looker link"
+                              placeholder="https://..."
+                              value={value}
+                              onChange={(event) =>
+                                setLookerInputs((prev) => ({ ...prev, [user.id]: event.target.value }))
+                              }
+                              error={invalid}
+                              helperText={invalid ? 'Must start with http:// or https://' : ' '}
+                            />
+                            <LoadingButton
+                              variant="contained"
+                              onClick={() => updateLookerLink(user, value)}
+                              disabled={!value.trim() || invalid}
+                              loading={saving}
+                            >
+                              Save
+                            </LoadingButton>
+                          </Stack>
+                        </Stack>
+                      </Paper>
+                    );
+                  })}
+                </Stack>
+              )}
+            </Stack>
+          </Paper>
+
+          <Paper elevation={0} sx={{ p: 3, border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+            <Stack spacing={2}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <Typography variant="h6" fontWeight={600}>
+                  Missing phone numbers
+                </Typography>
+                <Chip label={phoneCountLabel} size="small" />
+              </Box>
+
+              {missingPhone.length === 0 ? (
+                <Alert severity="success">All users have a phone number.</Alert>
+              ) : (
+                <Stack spacing={1.5}>
+                  {missingPhone.map((user) => {
+                    const value = phoneInputValue(user.id);
+                    const saving = savingPhoneIds.includes(user.id);
+                    return (
+                      <Paper key={user.id} variant="outlined" sx={{ p: 2 }}>
+                        <Stack spacing={1.5}>
+                          <Box>
+                            <Typography fontWeight={600}>{user.name}</Typography>
+                            <Typography color="text.secondary">{user.email || 'No email on file'}</Typography>
+                          </Box>
+                          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems={{ md: 'center' }}>
+                            <TextField
+                              fullWidth
+                              label="Phone number"
+                              placeholder="(555) 123-4567"
+                              value={value}
+                              onChange={(event) =>
+                                setPhoneInputs((prev) => ({ ...prev, [user.id]: event.target.value }))
+                              }
+                            />
+                            <LoadingButton
+                              variant="contained"
+                              onClick={() => updatePhone(user, value)}
+                              disabled={!value.trim()}
+                              loading={saving}
+                            >
+                              Save
+                            </LoadingButton>
+                          </Stack>
+                        </Stack>
+                      </Paper>
+                    );
+                  })}
+                </Stack>
+              )}
+            </Stack>
+          </Paper>
+
+          <Paper elevation={0} sx={{ p: 3, border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6" fontWeight={600}>
+                User editor
+              </Typography>
+
+              <Autocomplete<Person>
+                options={userOptions}
+                loading={userOptionsLoading}
+                getOptionLabel={(option) => `${option.name} — ${option.email}`.trim()}
+                value={selectedUser}
+                onChange={(_, value) => {
+                  setSelectedUser(value);
+                  if (value?.id) {
+                    loadUserDetails(value.id).catch(() => {});
+                  } else {
+                    setUserDetails(null);
+                  }
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Select user"
+                    helperText="Search by name or email to manage a user."
+                  />
+                )}
+              />
+
+              {detailsLoading ? (
+                <Box sx={{ display: 'grid', placeItems: 'center', py: 4 }}>
+                  <CircularProgress size={28} />
+                </Box>
+              ) : detailsError ? (
+                <Alert severity="error">{detailsError}</Alert>
+              ) : !userDetails ? (
+                <Alert severity="info">Select a user to edit their details.</Alert>
+              ) : (
+                <Stack spacing={2} divider={<Divider flexItem />}>
+                      <Stack spacing={1.5}>
+                        <Typography fontWeight={600}>Profile information</Typography>
+                        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                          <TextField
+                            label="First name"
+                        value={detailsForm.first_name}
+                        onChange={(event) =>
+                          setDetailsForm((prev) => ({ ...prev, first_name: event.target.value }))
+                        }
+                        fullWidth
+                      />
+                      <TextField
+                        label="Last name"
+                        value={detailsForm.last_name}
+                        onChange={(event) =>
+                          setDetailsForm((prev) => ({ ...prev, last_name: event.target.value }))
+                        }
+                        fullWidth
+                      />
+                    </Stack>
+                        <TextField
+                          label="Looker link"
+                          value={detailsForm.looker_link}
+                          onChange={(event) =>
+                            setDetailsForm((prev) => ({ ...prev, looker_link: event.target.value }))
+                          }
+                          helperText={editorLookerInvalid ? 'Must start with http:// or https://' : 'Leave blank to remove the link.'}
+                          error={editorLookerInvalid}
+                          fullWidth
+                        />
+                      </Stack>
+
+                      <Stack spacing={1.5}>
+                    <Typography fontWeight={600}>Contact</Typography>
+                    <TextField
+                      label="Email"
+                      value={userDetails.email}
+                      InputProps={{ readOnly: true }}
+                      helperText="Email cannot be changed."
+                      fullWidth
+                    />
+                    <TextField
+                      label="Phone number"
+                      value={detailsForm.phone}
+                      onChange={(event) =>
+                        setDetailsForm((prev) => ({ ...prev, phone: event.target.value }))
+                      }
+                      helperText="Leave blank to remove the phone number."
+                      fullWidth
+                    />
+                  </Stack>
+
+                  <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                    <LoadingButton
+                      variant="contained"
+                      onClick={saveUserDetails}
+                      loading={savingDetails}
+                      disabled={editorLookerInvalid}
+                    >
+                      Save changes
+                    </LoadingButton>
+                    <LoadingButton
+                      variant="outlined"
+                      onClick={sendResetEmail}
+                      loading={sendingReset}
+                    >
+                      Send reset password email
+                    </LoadingButton>
+                  </Stack>
+                </Stack>
+              )}
+            </Stack>
+          </Paper>
+        </>
+      )}
+
+      <Snackbar open={snack.open} autoHideDuration={4000} onClose={handleSnackClose}>
+        <Alert onClose={handleSnackClose} severity={snack.severity} sx={{ width: '100%' }}>
+          {snack.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Admin Action Required dashboard tab with course coverage reporting, missing Looker/phone queues, and an inline user editor
- expose supporting admin APIs to retrieve action-required data, patch user contact details, and trigger password reset emails
- wire the new panel into the admin page navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95d93f5048332889045d0288f7e10