### PR TITLE
Revamp search experience

### DIFF
--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1017,6 +1017,8 @@ export default function Search() {
         _q: debouncedQ,
         _types: _typesArg,
         _tag_ids: selectedTagIds.length ? selectedTagIds : null,
+        _duration: durationFilter ?? null,
+        _date_range: dateRange && dateRange !== 'all' ? dateRange : null,
         _sort: sort,
         _limit: PAGE,
         _offset: page * PAGE,
@@ -1073,7 +1075,7 @@ export default function Search() {
     return () => {
       cancelled = true;
     };
-  }, [debouncedQ, _typesArg, selectedTagIds, sort, page, mode]);
+  }, [debouncedQ, _typesArg, selectedTagIds, durationFilter, dateRange, sort, page, mode]);
 
   const toggleType = (type: ResourceRow['type']) => {
     setPage(0);


### PR DESCRIPTION
## Summary
- redesign the search bar with sticky pill layout, shortcut handling, quick dropdowns, and an advanced popover for sort and fuzziness controls
- add reusable filter chips with a "more filters" popover for duration, date, and tag selection alongside reset handling
- refresh results rendering with dedicated list/grid components, responsive actions, skeleton loading states, and a guided empty state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6aa241b1c8332968d4859445435c2