### PR TITLE
Add admin APIs for course tree management

### DIFF
--- a/src/app/api/admin/courses/[courseId]/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/admin/courses/[courseId]/nodes/[nodeId]/blocks/route.ts
@@ -1,0 +1,325 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+import {
+  NotFoundError,
+  ValidationError,
+  fetchNormalizedCourse,
+  getNodeWithCourseCheck,
+} from '../../../../utils';
+
+import type { AnySupabaseClient } from '../../../../utils';
+
+type RouteContext = {
+  params: Promise<{
+    courseId?: string | string[] | undefined;
+    nodeId?: string | string[] | undefined;
+  }>;
+};
+
+function jsonError(message: string, status = 400, details?: unknown) {
+  return NextResponse.json({ error: message, details }, { status });
+}
+
+async function resolveParams(context: RouteContext) {
+  const raw = await context.params;
+  const courseId = Array.isArray(raw?.courseId) ? raw?.courseId[0] : raw?.courseId;
+  const nodeId = Array.isArray(raw?.nodeId) ? raw?.nodeId[0] : raw?.nodeId;
+  return {
+    courseId: typeof courseId === 'string' ? courseId : null,
+    nodeId: typeof nodeId === 'string' ? nodeId : null,
+  };
+}
+
+async function parseBody(request: NextRequest) {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+async function computeNextPosition(
+  supa: AnySupabaseClient,
+  nodeId: string,
+): Promise<number> {
+  const { data, error } = await supa
+    .from('course_blocks')
+    .select('position')
+    .eq('node_id', nodeId)
+    .order('position', { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data || data.length === 0) {
+    return Date.now();
+  }
+
+  const value = data[0]?.position;
+  const base = typeof value === 'number' ? value : Date.now();
+  return base + 1;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const { courseId, nodeId } = await resolveParams(context);
+  if (!courseId || !nodeId) {
+    return jsonError('Invalid course or node id', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await getNodeWithCourseCheck(supa, courseId, nodeId);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 400, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const { courseId, nodeId } = await resolveParams(context);
+  if (!courseId || !nodeId) {
+    return jsonError('Invalid course or node id', 400);
+  }
+
+  const body = await parseBody(request);
+  if (!body || typeof body !== 'object') {
+    return jsonError('Invalid JSON payload', 400);
+  }
+
+  const { type, data, position, is_required } = body as Partial<Record<string, unknown>> & {
+    type?: string;
+    position?: number;
+    is_required?: boolean;
+  };
+
+  if (!type || typeof type !== 'string') {
+    return jsonError('Block type is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await getNodeWithCourseCheck(supa, courseId, nodeId);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 400, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  let defaultPosition: number;
+  try {
+    defaultPosition = typeof position === 'number'
+      ? position
+      : await computeNextPosition(supa, nodeId);
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+
+  const payload: Record<string, unknown> = {
+    node_id: nodeId,
+    type: type.trim(),
+    data: data ?? {},
+    position: defaultPosition,
+    is_required: is_required ?? true,
+  };
+
+  const { error: insertErr } = await supa
+    .from('course_blocks')
+    .insert(payload);
+
+  if (insertErr) {
+    return jsonError(insertErr.message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized }, { status: 201 });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const { courseId, nodeId } = await resolveParams(context);
+  if (!courseId || !nodeId) {
+    return jsonError('Invalid course or node id', 400);
+  }
+
+  const body = await parseBody(request);
+  if (!body || typeof body !== 'object') {
+    return jsonError('Invalid JSON payload', 400);
+  }
+
+  const { id, type, data, position, is_required } = body as Partial<Record<string, unknown>> & {
+    id?: string;
+    position?: number;
+    is_required?: boolean;
+  };
+
+  if (!id || typeof id !== 'string') {
+    return jsonError('Block id is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await getNodeWithCourseCheck(supa, courseId, nodeId);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 400, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  const { data: blockRows, error: blockErr } = await supa
+    .from('course_blocks')
+    .select('id, node_id')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (blockErr) {
+    return jsonError(blockErr.message, 400);
+  }
+
+  if (!blockRows) {
+    return jsonError('Block not found', 404);
+  }
+
+  if (`${blockRows.node_id}` !== `${nodeId}`) {
+    return jsonError('Block does not belong to the specified node', 400);
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (typeof type === 'string') {
+    updates.type = type.trim();
+  }
+  if ('data' in body) {
+    updates.data = data ?? {};
+  }
+  if (typeof position === 'number') {
+    updates.position = position;
+  }
+  if (typeof is_required === 'boolean') {
+    updates.is_required = is_required;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return jsonError('No changes provided', 400);
+  }
+
+  const { error: updateErr } = await supa
+    .from('course_blocks')
+    .update(updates)
+    .eq('id', id);
+
+  if (updateErr) {
+    return jsonError(updateErr.message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const { courseId, nodeId } = await resolveParams(context);
+  if (!courseId || !nodeId) {
+    return jsonError('Invalid course or node id', 400);
+  }
+
+  const body = await parseBody(request);
+  if (!body || typeof body !== 'object') {
+    return jsonError('Invalid JSON payload', 400);
+  }
+
+  const { id } = body as { id?: string };
+  if (!id || typeof id !== 'string') {
+    return jsonError('Block id is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await getNodeWithCourseCheck(supa, courseId, nodeId);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 400, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  const { data: blockRows, error: blockErr } = await supa
+    .from('course_blocks')
+    .select('id, node_id')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (blockErr) {
+    return jsonError(blockErr.message, 400);
+  }
+
+  if (!blockRows) {
+    return jsonError('Block not found', 404);
+  }
+
+  if (`${blockRows.node_id}` !== `${nodeId}`) {
+    return jsonError('Block does not belong to the specified node', 400);
+  }
+
+  const { error: deleteErr } = await supa
+    .from('course_blocks')
+    .delete()
+    .eq('id', id);
+
+  if (deleteErr) {
+    return jsonError(deleteErr.message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}

--- a/src/app/api/admin/courses/[courseId]/nodes/route.ts
+++ b/src/app/api/admin/courses/[courseId]/nodes/route.ts
@@ -1,0 +1,487 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+import {
+  NotFoundError,
+  ValidationError,
+  ensureEdgeAllowed,
+  ensureUniqueNodeSlug,
+  fetchNormalizedCourse,
+  getNodeEdge,
+  getNodeWithCourseCheck,
+  listDescendantNodeIds,
+  deleteNodesCascade,
+} from '../../utils';
+
+import type { AnySupabaseClient, NodeChildRecord } from '../../utils';
+
+type RouteContext = { params: Promise<{ courseId?: string | string[] | undefined }> };
+
+type MutableNodeChild = Pick<NodeChildRecord, 'parent_id' | 'position' | 'is_locked' | 'is_optional'>;
+
+function jsonError(message: string, status = 400, details?: unknown) {
+  return NextResponse.json({ error: message, details }, { status });
+}
+
+async function resolveCourseId(context: RouteContext): Promise<string | null> {
+  const raw = await context.params;
+  const value = Array.isArray(raw?.courseId) ? raw?.courseId[0] : raw?.courseId;
+  return typeof value === 'string' ? value : null;
+}
+
+async function parseBody(request: NextRequest) {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+async function computeDefaultPosition(
+  supa: AnySupabaseClient,
+  courseId: string,
+  parentId: string | null,
+): Promise<number> {
+  const query = supa
+    .from('node_children')
+    .select('position, child_id')
+    .order('position', { ascending: false })
+    .limit(1);
+
+  if (parentId) {
+    query.eq('parent_id', parentId);
+  } else {
+    const { data: nodeRows, error } = await supa
+      .from('course_nodes')
+      .select('id')
+      .eq('course_id', courseId);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const ids = (nodeRows ?? []).map((row) => row.id);
+    if (ids.length === 0) {
+      return Date.now();
+    }
+
+    query.in('child_id', ids).is('parent_id', null);
+  }
+
+  const { data, error: posErr } = await query;
+  if (posErr) {
+    throw new Error(posErr.message);
+  }
+
+  if (!data || data.length === 0) {
+    return Date.now();
+  }
+
+  const first = data[0];
+  const position = typeof first?.position === 'number' ? first.position : Date.now();
+  return position + 1;
+}
+
+function buildEdgePayload(
+  edge: NodeChildRecord | null,
+  overrides: Partial<MutableNodeChild>,
+  defaultPosition: number,
+) {
+  return {
+    parent_id: overrides.parent_id ?? edge?.parent_id ?? null,
+    child_id: edge?.child_id,
+    position: overrides.position ?? edge?.position ?? defaultPosition,
+    is_optional: overrides.is_optional ?? edge?.is_optional ?? false,
+    is_locked: overrides.is_locked ?? edge?.is_locked ?? false,
+  };
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const courseId = await resolveCourseId(context);
+  if (!courseId) {
+    return jsonError('Invalid course id', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized });
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const courseId = await resolveCourseId(context);
+  if (!courseId) {
+    return jsonError('Invalid course id', 400);
+  }
+
+  const body = await parseBody(request);
+  if (!body || typeof body !== 'object') {
+    return jsonError('Invalid JSON payload', 400);
+  }
+
+  const {
+    title,
+    type,
+    slug,
+    description,
+    metadata,
+    parentId,
+    position,
+    is_optional,
+    is_locked,
+  } = body as Partial<Record<string, unknown>> & {
+    title?: string;
+    type?: string;
+    slug?: string;
+    parentId?: string | null;
+    position?: number;
+    is_optional?: boolean;
+    is_locked?: boolean;
+  };
+
+  if (!title || typeof title !== 'string') {
+    return jsonError('Node title is required', 400);
+  }
+  if (!type || typeof type !== 'string') {
+    return jsonError('Node type is required', 400);
+  }
+  if (!slug || typeof slug !== 'string') {
+    return jsonError('Node slug is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await ensureUniqueNodeSlug(supa, courseId, slug);
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 409, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  let parentNode: { id: string; type: string } | null = null;
+  if (typeof parentId === 'string' && parentId.length > 0) {
+    try {
+      const node = await getNodeWithCourseCheck(supa, courseId, parentId);
+      parentNode = { id: node.id, type: node.type };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        return jsonError('Parent node not found', 404);
+      }
+      if (err instanceof ValidationError) {
+        return jsonError(err.message, 400, err.details);
+      }
+      return jsonError((err as Error).message, 400);
+    }
+  }
+
+  if (parentNode) {
+    try {
+      await ensureEdgeAllowed(supa, parentNode.type, type);
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        return jsonError(err.message, 400, err.details);
+      }
+      return jsonError((err as Error).message, 400);
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    course_id: courseId,
+    title: title.trim(),
+    type: type.trim(),
+    slug: slug.trim(),
+    description: typeof description === 'string' ? description : null,
+    metadata: metadata ?? null,
+  };
+
+  const { data: node, error: insertErr } = await supa
+    .from('course_nodes')
+    .insert(payload)
+    .select('id')
+    .single();
+
+  if (insertErr) {
+    return jsonError(insertErr.message, 400);
+  }
+
+  const nodeId = node.id as string;
+
+  const parentForEdge = parentNode?.id ?? null;
+  let defaultPosition: number;
+  try {
+    defaultPosition = typeof position === 'number'
+      ? position
+      : await computeDefaultPosition(supa, courseId, parentForEdge);
+  } catch (err) {
+    await supa.from('course_nodes').delete().eq('id', nodeId);
+    return jsonError((err as Error).message, 400);
+  }
+
+  const edgePayload: Record<string, unknown> = {
+    parent_id: parentForEdge,
+    child_id: nodeId,
+    position: defaultPosition,
+    is_optional: Boolean(is_optional ?? false),
+    is_locked: Boolean(is_locked ?? false),
+  };
+
+  const { error: linkErr } = await supa.from('node_children').insert(edgePayload);
+  if (linkErr) {
+    await supa.from('course_nodes').delete().eq('id', nodeId);
+    return jsonError(linkErr.message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized }, { status: 201 });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const courseId = await resolveCourseId(context);
+  if (!courseId) {
+    return jsonError('Invalid course id', 400);
+  }
+
+  const body = await parseBody(request);
+  if (!body || typeof body !== 'object') {
+    return jsonError('Invalid JSON payload', 400);
+  }
+
+  const {
+    id,
+    title,
+    slug,
+    description,
+    metadata,
+    parentId,
+    position,
+    is_optional,
+    is_locked,
+  } = body as Partial<Record<string, unknown>> & { id?: string };
+
+  if (!id || typeof id !== 'string') {
+    return jsonError('Node id is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  let node;
+  try {
+    node = await getNodeWithCourseCheck(supa, courseId, id);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 400, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (typeof title === 'string' && title.trim() !== (node.title ?? '').trim()) {
+    updates.title = title.trim();
+  }
+  if (typeof description === 'string') {
+    updates.description = description;
+  } else if ('description' in body && description == null) {
+    updates.description = null;
+  }
+  if ('metadata' in body) {
+    updates.metadata = metadata ?? null;
+  }
+
+  if (typeof slug === 'string' && slug.trim() !== (node.slug ?? '').trim()) {
+    try {
+      await ensureUniqueNodeSlug(supa, courseId, slug, id);
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        return jsonError(err.message, 409, err.details);
+      }
+      return jsonError((err as Error).message, 400);
+    }
+    updates.slug = slug.trim();
+  }
+
+  if (Object.keys(updates).length > 0) {
+    const { error: updateErr } = await supa
+      .from('course_nodes')
+      .update(updates)
+      .eq('id', id);
+
+    if (updateErr) {
+      return jsonError(updateErr.message, 400);
+    }
+  }
+
+  const edge = await getNodeEdge(supa, id);
+
+  const currentParentId = edge?.parent_id ?? null;
+  let nextParentId = currentParentId;
+  let parentChanges = false;
+
+  if ('parentId' in body) {
+    if (parentId == null || (typeof parentId === 'string' && parentId.length === 0)) {
+      nextParentId = null;
+      parentChanges = nextParentId !== currentParentId;
+    } else if (typeof parentId === 'string') {
+      if (parentId === id) {
+        return jsonError('Node cannot be its own parent', 400);
+      }
+      try {
+        const parentNode = await getNodeWithCourseCheck(supa, courseId, parentId);
+        const descendants = await listDescendantNodeIds(supa, [id]);
+        if (descendants.includes(parentId)) {
+          return jsonError('Cannot move node under one of its descendants', 400);
+        }
+        await ensureEdgeAllowed(supa, parentNode.type, node.type);
+        nextParentId = parentNode.id;
+        parentChanges = nextParentId !== currentParentId;
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return jsonError('Parent node not found', 404);
+        }
+        if (err instanceof ValidationError) {
+          return jsonError(err.message, 400, err.details);
+        }
+        return jsonError((err as Error).message, 400);
+      }
+    } else {
+      return jsonError('Invalid parent id', 400);
+    }
+  }
+
+  const edgeUpdates: Partial<MutableNodeChild> = {};
+  if (typeof position === 'number') {
+    edgeUpdates.position = position;
+  }
+  if (typeof is_optional === 'boolean') {
+    edgeUpdates.is_optional = is_optional;
+  }
+  if (typeof is_locked === 'boolean') {
+    edgeUpdates.is_locked = is_locked;
+  }
+
+  if (parentChanges || Object.keys(edgeUpdates).length > 0) {
+    const defaultPosition = typeof edgeUpdates.position === 'number'
+      ? edgeUpdates.position
+      : await computeDefaultPosition(supa, courseId, nextParentId);
+
+    if (parentChanges || !edge) {
+      if (edge) {
+        const { error: deleteErr } = await supa
+          .from('node_children')
+          .delete()
+          .eq('child_id', id);
+        if (deleteErr) {
+          return jsonError(deleteErr.message, 400);
+        }
+      }
+
+      const insertPayload = {
+        parent_id: nextParentId,
+        child_id: id,
+        position: defaultPosition,
+        is_optional: edgeUpdates.is_optional ?? edge?.is_optional ?? false,
+        is_locked: edgeUpdates.is_locked ?? edge?.is_locked ?? false,
+      };
+
+      const { error: insertErr } = await supa.from('node_children').insert(insertPayload);
+      if (insertErr) {
+        return jsonError(insertErr.message, 400);
+      }
+    } else {
+      const updatePayload = buildEdgePayload(edge, edgeUpdates, defaultPosition);
+      const { error: edgeErr } = await supa
+        .from('node_children')
+        .update({
+          parent_id: updatePayload.parent_id,
+          position: updatePayload.position,
+          is_optional: updatePayload.is_optional,
+          is_locked: updatePayload.is_locked,
+        })
+        .eq('child_id', id);
+
+      if (edgeErr) {
+        return jsonError(edgeErr.message, 400);
+      }
+    }
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const courseId = await resolveCourseId(context);
+  if (!courseId) {
+    return jsonError('Invalid course id', 400);
+  }
+
+  const body = await parseBody(request);
+  if (!body || typeof body !== 'object') {
+    return jsonError('Invalid JSON payload', 400);
+  }
+
+  const { id } = body as { id?: string };
+  if (!id || typeof id !== 'string') {
+    return jsonError('Node id is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await getNodeWithCourseCheck(supa, courseId, id);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 400, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  const descendants = await listDescendantNodeIds(supa, [id]);
+
+  try {
+    await deleteNodesCascade(supa, descendants);
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, courseId);
+    return NextResponse.json({ item: normalized });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}

--- a/src/app/api/admin/courses/route.ts
+++ b/src/app/api/admin/courses/route.ts
@@ -1,0 +1,209 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+import {
+  ValidationError,
+  NotFoundError,
+  fetchCourseOrThrow,
+  fetchNormalizedCourse,
+  ensureUniqueCourseSlug,
+  deleteNodesCascade,
+} from './utils';
+
+function jsonError(message: string, status = 400, details?: unknown) {
+  return NextResponse.json({ error: message, details }, { status });
+}
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.res;
+
+  const supa = getAdminClient();
+
+  const { data: courses, error } = await supa
+    .from('courses')
+    .select('id, slug, name, description, metadata, created_at, updated_at')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    return jsonError(error.message, 400);
+  }
+
+  const items = [];
+  for (const course of courses ?? []) {
+    try {
+      const normalized = await fetchNormalizedCourse(supa, course.id, course);
+      items.push(normalized);
+    } catch (err) {
+      return jsonError((err as Error).message, 400);
+    }
+  }
+
+  return NextResponse.json({ items });
+}
+
+export async function POST(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const body = await request.json();
+  const { name, slug, description, metadata } = body ?? {};
+
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    return jsonError('Course name is required', 400);
+  }
+
+  if (!slug || typeof slug !== 'string') {
+    return jsonError('Course slug is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await ensureUniqueCourseSlug(supa, slug);
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 409, err.details);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  const payload: Record<string, unknown> = {
+    name: name.trim(),
+    slug: slug.trim(),
+    description: typeof description === 'string' ? description : null,
+    metadata: metadata ?? null,
+  };
+
+  const { data, error } = await supa
+    .from('courses')
+    .insert(payload)
+    .select('id')
+    .single();
+
+  if (error) {
+    return jsonError(error.message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, data.id);
+    return NextResponse.json({ item: normalized }, { status: 201 });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const body = await request.json();
+  const { id, name, slug, description, metadata } = body ?? {};
+
+  if (!id) {
+    return jsonError('Course id is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  let course;
+  try {
+    course = await fetchCourseOrThrow(supa, id);
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      return jsonError(err.message, 400, err.details);
+    }
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  if (slug && typeof slug === 'string' && slug.trim() !== (course.slug ?? '').trim()) {
+    try {
+      await ensureUniqueCourseSlug(supa, slug, course.id);
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        return jsonError(err.message, 409, err.details);
+      }
+      return jsonError((err as Error).message, 400);
+    }
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (typeof name === 'string') updates.name = name.trim();
+  if (typeof slug === 'string') updates.slug = slug.trim();
+  if ('description' in body) updates.description = typeof description === 'string' ? description : null;
+  if ('metadata' in body) updates.metadata = metadata ?? null;
+
+  if (Object.keys(updates).length === 0) {
+    return jsonError('No changes provided', 400);
+  }
+
+  const { error } = await supa
+    .from('courses')
+    .update(updates)
+    .eq('id', id);
+
+  if (error) {
+    return jsonError(error.message, 400);
+  }
+
+  try {
+    const normalized = await fetchNormalizedCourse(supa, id);
+    return NextResponse.json({ item: normalized });
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const body = await request.json();
+  const { id } = body ?? {};
+
+  if (!id) {
+    return jsonError('Course id is required', 400);
+  }
+
+  const supa = getAdminClient();
+
+  try {
+    await fetchCourseOrThrow(supa, id);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return jsonError(err.message, 404);
+    }
+    return jsonError((err as Error).message, 400);
+  }
+
+  const { data: nodeRows, error: nodeErr } = await supa
+    .from('course_nodes')
+    .select('id')
+    .eq('course_id', id);
+
+  if (nodeErr) {
+    return jsonError(nodeErr.message, 400);
+  }
+
+  const nodeIds = (nodeRows ?? []).map((row) => row.id).filter((value): value is string => typeof value === 'string');
+
+  try {
+    await deleteNodesCascade(supa, nodeIds);
+  } catch (err) {
+    return jsonError((err as Error).message, 400);
+  }
+
+  const { error: deleteErr } = await supa
+    .from('courses')
+    .delete()
+    .eq('id', id);
+
+  if (deleteErr) {
+    return jsonError(deleteErr.message, 400);
+  }
+
+  return NextResponse.json({ deletedId: id });
+}

--- a/src/app/api/admin/courses/utils.ts
+++ b/src/app/api/admin/courses/utils.ts
@@ -1,0 +1,404 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type AnySupabaseClient = SupabaseClient<any, 'public', any>;
+
+export type CourseRecord = {
+  id: number | string;
+  slug: string | null;
+  name: string | null;
+  description: string | null;
+  metadata?: Record<string, unknown> | null;
+  created_at?: string;
+  updated_at?: string;
+  [key: string]: unknown;
+};
+
+export type NodeRecord = {
+  id: string;
+  course_id: number | string;
+  type: string;
+  slug: string | null;
+  title: string | null;
+  description: string | null;
+  metadata?: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+export type NodeChildRecord = {
+  parent_id: string | null;
+  child_id: string;
+  position: number | null;
+  is_optional?: boolean | null;
+  is_locked?: boolean | null;
+  [key: string]: unknown;
+};
+
+export type BlockRecord = {
+  id: string;
+  node_id: string;
+  type: string;
+  data: unknown;
+  position: number | null;
+  is_required?: boolean | null;
+  [key: string]: unknown;
+};
+
+export type NormalizedNode = NodeRecord & {
+  parentId: string | null;
+  position: number;
+  isOptional: boolean;
+  isLocked: boolean;
+  childIds: string[];
+  blockIds: string[];
+};
+
+export type NormalizedBlock = BlockRecord & {
+  nodeId: string;
+  position: number;
+};
+
+export type NormalizedCourse = {
+  course: CourseRecord;
+  nodes: Record<string, NormalizedNode>;
+  blocks: Record<string, NormalizedBlock>;
+  rootNodeIds: string[];
+};
+
+export class NotFoundError extends Error {}
+
+export class ValidationError extends Error {
+  constructor(message: string, readonly details?: unknown) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+export async function fetchCourseOrThrow(
+  supa: AnySupabaseClient,
+  courseId: string | number,
+): Promise<CourseRecord> {
+  const { data, error } = await supa
+    .from('courses')
+    .select('id, slug, name, description, metadata, created_at, updated_at')
+    .eq('id', courseId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data) {
+    throw new NotFoundError(`Course ${courseId} was not found`);
+  }
+
+  return data as CourseRecord;
+}
+
+export async function fetchNormalizedCourse(
+  supa: AnySupabaseClient,
+  courseId: string | number,
+  existingCourse?: CourseRecord,
+): Promise<NormalizedCourse> {
+  const course = existingCourse ?? (await fetchCourseOrThrow(supa, courseId));
+
+  const { data: nodeRows, error: nodeErr } = await supa
+    .from('course_nodes')
+    .select('*')
+    .eq('course_id', course.id);
+
+  if (nodeErr) {
+    throw new Error(nodeErr.message);
+  }
+
+  const nodes = (nodeRows ?? []) as NodeRecord[];
+  const nodeIds = nodes.map((node) => node.id);
+
+  const { data: edgeRows, error: edgeErr } = nodeIds.length
+    ? await supa.from('node_children').select('*').in('child_id', nodeIds)
+    : { data: [], error: null };
+
+  if (edgeErr) {
+    throw new Error(edgeErr.message);
+  }
+
+  const edges = (edgeRows ?? []) as NodeChildRecord[];
+
+  const { data: blockRows, error: blockErr } = nodeIds.length
+    ? await supa.from('course_blocks').select('*').in('node_id', nodeIds)
+    : { data: [], error: null };
+
+  if (blockErr) {
+    throw new Error(blockErr.message);
+  }
+
+  const blocks = (blockRows ?? []) as BlockRecord[];
+
+  const edgesByChild = new Map<string, NodeChildRecord>();
+  const childrenByParent = new Map<string, NodeChildRecord[]>();
+
+  for (const edge of edges) {
+    edgesByChild.set(edge.child_id, edge);
+    if (edge.parent_id) {
+      const list = childrenByParent.get(edge.parent_id) ?? [];
+      list.push(edge);
+      childrenByParent.set(edge.parent_id, list);
+    }
+  }
+
+  const nodesById: Record<string, NormalizedNode> = {};
+
+  for (const node of nodes) {
+    const edge = edgesByChild.get(node.id);
+    nodesById[node.id] = {
+      ...node,
+      parentId: edge?.parent_id ?? null,
+      position: edge?.position ?? 0,
+      isOptional: Boolean(edge?.is_optional ?? false),
+      isLocked: Boolean(edge?.is_locked ?? false),
+      childIds: [],
+      blockIds: [],
+    };
+  }
+
+  for (const [parentId, edgeList] of childrenByParent.entries()) {
+    const parent = nodesById[parentId];
+    if (!parent) continue;
+    const sorted = [...edgeList].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+    parent.childIds = sorted.map((edge) => edge.child_id).filter((id) => id in nodesById);
+  }
+
+  const blocksById: Record<string, NormalizedBlock> = {};
+  for (const block of blocks) {
+    const normalized: NormalizedBlock = {
+      ...block,
+      nodeId: block.node_id,
+      position: block.position ?? 0,
+    };
+    blocksById[block.id] = normalized;
+    const node = nodesById[block.node_id];
+    if (node) {
+      node.blockIds.push(block.id);
+    }
+  }
+
+  for (const node of Object.values(nodesById)) {
+    node.blockIds.sort((a, b) => (blocksById[a]?.position ?? 0) - (blocksById[b]?.position ?? 0));
+  }
+
+  const rootNodeIds = Object.values(nodesById)
+    .filter((node) => !node.parentId)
+    .sort((a, b) => a.position - b.position)
+    .map((node) => node.id);
+
+  return {
+    course,
+    nodes: nodesById,
+    blocks: blocksById,
+    rootNodeIds,
+  };
+}
+
+export async function ensureUniqueCourseSlug(
+  supa: AnySupabaseClient,
+  slug: string,
+  excludeId?: string | number,
+): Promise<void> {
+  const trimmed = slug.trim();
+  if (!trimmed) {
+    throw new ValidationError('Course slug is required');
+  }
+
+  const query = supa
+    .from('courses')
+    .select('id', { count: 'exact', head: true })
+    .eq('slug', trimmed);
+
+  if (excludeId !== undefined) {
+    query.neq('id', excludeId);
+  }
+
+  const { error, count } = await query;
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if ((count ?? 0) > 0) {
+    throw new ValidationError(`Slug \"${trimmed}\" is already in use`);
+  }
+}
+
+export async function ensureUniqueNodeSlug(
+  supa: AnySupabaseClient,
+  courseId: string | number,
+  slug: string,
+  excludeId?: string,
+): Promise<void> {
+  const trimmed = slug.trim();
+  if (!trimmed) {
+    throw new ValidationError('Node slug is required');
+  }
+
+  const query = supa
+    .from('course_nodes')
+    .select('id', { count: 'exact', head: true })
+    .eq('course_id', courseId)
+    .eq('slug', trimmed);
+
+  if (excludeId) {
+    query.neq('id', excludeId);
+  }
+
+  const { error, count } = await query;
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if ((count ?? 0) > 0) {
+    throw new ValidationError(`Node slug \"${trimmed}\" is already in use for this course`);
+  }
+}
+
+export async function ensureEdgeAllowed(
+  supa: AnySupabaseClient,
+  parentType: string | null,
+  childType: string,
+): Promise<void> {
+  if (!parentType) return;
+
+  const { data, error } = await supa
+    .from('node_edge_rules')
+    .select('id, is_allowed, is_enabled, allow')
+    .eq('parent_type', parentType)
+    .eq('child_type', childType)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const allowed = Boolean(data && (data.is_allowed ?? data.is_enabled ?? data.allow ?? true));
+
+  if (!data || !allowed) {
+    throw new ValidationError(`Cannot attach ${childType} to parent type ${parentType}`);
+  }
+}
+
+export async function getNodeWithCourseCheck(
+  supa: AnySupabaseClient,
+  courseId: string | number,
+  nodeId: string,
+): Promise<NodeRecord> {
+  const { data, error } = await supa
+    .from('course_nodes')
+    .select('*')
+    .eq('id', nodeId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data) {
+    throw new NotFoundError(`Node ${nodeId} was not found`);
+  }
+
+  if (`${data.course_id}` !== `${courseId}`) {
+    throw new ValidationError('Node does not belong to the specified course');
+  }
+
+  return data as NodeRecord;
+}
+
+export async function getNodeEdge(
+  supa: AnySupabaseClient,
+  nodeId: string,
+): Promise<NodeChildRecord | null> {
+  const { data, error } = await supa
+    .from('node_children')
+    .select('*')
+    .eq('child_id', nodeId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data as NodeChildRecord | null) ?? null;
+}
+
+export async function listDescendantNodeIds(
+  supa: AnySupabaseClient,
+  nodeIds: string[],
+): Promise<string[]> {
+  const toProcess = [...nodeIds];
+  const visited = new Set<string>(toProcess);
+
+  while (toProcess.length > 0) {
+    const chunk = toProcess.splice(0, 50);
+    const { data, error } = await supa
+      .from('node_children')
+      .select('child_id')
+      .in('parent_id', chunk);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    for (const row of data ?? []) {
+      const childId = row?.child_id;
+      if (childId && !visited.has(childId)) {
+        visited.add(childId);
+        toProcess.push(childId);
+      }
+    }
+  }
+
+  return Array.from(visited);
+}
+
+export async function deleteNodesCascade(
+  supa: AnySupabaseClient,
+  nodeIds: string[],
+): Promise<void> {
+  if (nodeIds.length === 0) return;
+
+  const ids = Array.from(new Set(nodeIds));
+
+  const { error: blockErr } = await supa
+    .from('course_blocks')
+    .delete()
+    .in('node_id', ids);
+
+  if (blockErr) {
+    throw new Error(blockErr.message);
+  }
+
+  const { error: childErr } = await supa
+    .from('node_children')
+    .delete()
+    .in('child_id', ids);
+
+  if (childErr) {
+    throw new Error(childErr.message);
+  }
+
+  const { error: parentErr } = await supa
+    .from('node_children')
+    .delete()
+    .in('parent_id', ids);
+
+  if (parentErr) {
+    throw new Error(parentErr.message);
+  }
+
+  const { error: nodeErr } = await supa
+    .from('course_nodes')
+    .delete()
+    .in('id', ids);
+
+  if (nodeErr) {
+    throw new Error(nodeErr.message);
+  }
+}


### PR DESCRIPTION
## Summary
- add shared utilities for normalizing course trees, validating slugs, and cascading deletions
- implement /api/admin/courses handlers to list, create, update, and delete course metadata with normalized payloads
- add nested node and block CRUD routes that enforce edge rules, ordering, and return updated trees

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de91144efc833288f9d0403844f299