### PR TITLE
Add Course Builder tab to admin dashboard

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,6 +11,7 @@ import CoachRosters from '@/components/admin/CoachRosters';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import ResourceLibraryAdmin from '@/components/admin/ResourceLibraryAdmin';
 import AdminActionRequired from '@/components/admin/AdminActionRequired';
+import CourseBuilderAdmin from '@/components/admin/CourseBuilderAdmin';
 
 
 import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js';
@@ -173,6 +174,7 @@ export default function AdminPage() {
             <Tab label="Add User" />
             <Tab label="Assign / Change Coach" />
             <Tab label="Coach Rosters" />
+            <Tab label="Course Builder" />
             <Tab label="Resource Library" />
             <Tab label="Action Required" />
           </Tabs>
@@ -188,10 +190,13 @@ export default function AdminPage() {
               <CoachRosters />
             </TabPanel>
             <TabPanel value={tab} index={3}>
+              <CourseBuilderAdmin />
+            </TabPanel>
+            <TabPanel value={tab} index={4}>
               {/* New admin panel for resources */}
               <ResourceLibraryAdmin />
             </TabPanel>
-            <TabPanel value={tab} index={4}>
+            <TabPanel value={tab} index={5}>
               <AdminActionRequired />
             </TabPanel>
           </Box>


### PR DESCRIPTION
## Summary
- import the CourseBuilderAdmin panel and expose it through a new Course Builder tab
- update admin tab panel indexing so the new section mounts correctly alongside existing panels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de914aee048332b4cb640fdc5cd5b8