### PR TITLE
Add course builder admin APIs and viewer endpoints

### DIFF
--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/[blockId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/[blockId]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+function parseId(value: string | string[] | undefined) {
+  if (!value || Array.isArray(value)) return null;
+  const num = Number.parseInt(value, 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string; blockId: string } }
+) {
+  console.log('📦 admin-node-block PATCH:', params.nodeId, params.blockId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  const blockId = parseId(params.blockId);
+
+  if (!nodeId || !blockId) {
+    return NextResponse.json({ error: 'Invalid nodeId or blockId' }, { status: 400 });
+  }
+
+  try {
+    const payload = await request.json();
+    const updateData: Record<string, unknown> = {};
+
+    for (const key of [
+      'position',
+      'block_type',
+      'text_md',
+      'resource_id',
+      'start_ms',
+      'end_ms',
+      'image_url',
+      'alt_text',
+      'embed_url',
+      'embed_html',
+      'link_url',
+      'link_label',
+      'label',
+      'notes',
+      'settings',
+    ]) {
+      if (key in payload) {
+        updateData[key] = payload[key];
+      }
+    }
+
+    if (!Object.keys(updateData).length) {
+      return NextResponse.json({ error: 'No fields provided' }, { status: 400 });
+    }
+
+    const supa = getAdminClient();
+    const { data, error } = await supa
+      .from('content_blocks')
+      .update(updateData)
+      .eq('node_id', nodeId)
+      .eq('id', blockId)
+      .select('*')
+      .single();
+
+    if (error) {
+      console.error('❌ admin-node-block PATCH error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.log('✅ admin-node-block PATCH: updated block');
+    return NextResponse.json({ item: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-node-block PATCH unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { nodeId: string; blockId: string } }
+) {
+  console.log('📦 admin-node-block DELETE:', params.nodeId, params.blockId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  const blockId = parseId(params.blockId);
+
+  if (!nodeId || !blockId) {
+    return NextResponse.json({ error: 'Invalid nodeId or blockId' }, { status: 400 });
+  }
+
+  const supa = getAdminClient();
+  const { error } = await supa
+    .from('content_blocks')
+    .delete()
+    .eq('node_id', nodeId)
+    .eq('id', blockId);
+
+  if (error) {
+    console.error('❌ admin-node-block DELETE error:', error);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  console.log('🗑️ admin-node-block DELETE: removed block');
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/[blockId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/[blockId]/route.ts
@@ -2,23 +2,31 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/requireAdmin';
 import { getAdminClient } from '@/lib/supabaseAdmin';
 
-function parseId(value: string | string[] | undefined) {
-  if (!value || Array.isArray(value)) return null;
-  const num = Number.parseInt(value, 10);
+type Params = {
+  params: Promise<{
+    nodeId?: string | string[] | undefined;
+    blockId?: string | string[] | undefined;
+  }>;
+};
+
+async function resolveNumericId(context: Params, key: 'nodeId' | 'blockId') {
+  const rawParams = await context.params;
+  const value = rawParams?.[key];
+  const stringValue = Array.isArray(value) ? value[0] : value;
+  if (!stringValue) return null;
+
+  const num = Number.parseInt(stringValue, 10);
   return Number.isFinite(num) ? num : null;
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: { nodeId: string; blockId: string } }
-) {
-  console.log('📦 admin-node-block PATCH:', params.nodeId, params.blockId);
+export async function PATCH(request: NextRequest, context: Params) {
+  const nodeId = await resolveNumericId(context, 'nodeId');
+  const blockId = await resolveNumericId(context, 'blockId');
+
+  console.log('📦 admin-node-block PATCH:', nodeId, blockId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
-
-  const nodeId = parseId(params.nodeId);
-  const blockId = parseId(params.blockId);
 
   if (!nodeId || !blockId) {
     return NextResponse.json({ error: 'Invalid nodeId or blockId' }, { status: 400 });
@@ -77,17 +85,14 @@ export async function PATCH(
   }
 }
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: { nodeId: string; blockId: string } }
-) {
-  console.log('📦 admin-node-block DELETE:', params.nodeId, params.blockId);
+export async function DELETE(request: NextRequest, context: Params) {
+  const nodeId = await resolveNumericId(context, 'nodeId');
+  const blockId = await resolveNumericId(context, 'blockId');
+
+  console.log('📦 admin-node-block DELETE:', nodeId, blockId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
-
-  const nodeId = parseId(params.nodeId);
-  const blockId = parseId(params.blockId);
 
   if (!nodeId || !blockId) {
     return NextResponse.json({ error: 'Invalid nodeId or blockId' }, { status: 400 });

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+function parseId(value: string | string[] | undefined) {
+  if (!value || Array.isArray(value)) return null;
+  const num = Number.parseInt(value, 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('📦 admin-node-blocks GET: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  const supa = getAdminClient();
+  const { data, error } = await supa
+    .from('content_blocks')
+    .select('*')
+    .eq('node_id', nodeId)
+    .order('position');
+
+  if (error) {
+    console.error('❌ admin-node-blocks GET error:', error);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ items: data ?? [] });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('📦 admin-node-blocks POST: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  try {
+    const payload = await request.json();
+    if (!payload?.block_type) {
+      return NextResponse.json({ error: 'block_type is required' }, { status: 400 });
+    }
+
+    const insertData = {
+      node_id: nodeId,
+      position: Number.isFinite(payload.position)
+        ? payload.position
+        : Number.parseInt(String(payload.position ?? 0), 10) || 0,
+      block_type: payload.block_type,
+      text_md: payload.text_md ?? null,
+      resource_id: payload.resource_id ?? null,
+      start_ms: payload.start_ms ?? null,
+      end_ms: payload.end_ms ?? null,
+      image_url: payload.image_url ?? null,
+      alt_text: payload.alt_text ?? null,
+      embed_url: payload.embed_url ?? null,
+      embed_html: payload.embed_html ?? null,
+      link_url: payload.link_url ?? null,
+      link_label: payload.link_label ?? null,
+      label: payload.label ?? null,
+      notes: payload.notes ?? null,
+      settings: payload.settings ?? null,
+    };
+
+    const supa = getAdminClient();
+    const { data, error } = await supa
+      .from('content_blocks')
+      .insert(insertData)
+      .select('*')
+      .single();
+
+    if (error) {
+      console.error('❌ admin-node-blocks POST error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.log('✅ admin-node-blocks POST: created block', data.id);
+    return NextResponse.json({ item: data }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-node-blocks POST unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('📦 admin-node-blocks PATCH: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  try {
+    const payload = await request.json();
+    if (!Array.isArray(payload) || !payload.length) {
+      return NextResponse.json({ error: 'Array of { id, position } is required' }, { status: 400 });
+    }
+
+    const supa = getAdminClient();
+    for (const item of payload) {
+      const blockId = Number.parseInt(String(item.id), 10);
+      const position = Number.parseInt(String(item.position), 10);
+      if (!Number.isFinite(blockId) || blockId <= 0) {
+        return NextResponse.json({ error: 'Invalid id in payload' }, { status: 400 });
+      }
+      if (!Number.isFinite(position)) {
+        return NextResponse.json({ error: 'Invalid position in payload' }, { status: 400 });
+      }
+
+      const { error } = await supa
+        .from('content_blocks')
+        .update({ position })
+        .eq('node_id', nodeId)
+        .eq('id', blockId);
+
+      if (error) {
+        console.error('❌ admin-node-blocks PATCH error:', error, { blockId, position });
+        return NextResponse.json({ error: error.message, id: blockId }, { status: 400 });
+      }
+    }
+
+    console.log('✅ admin-node-blocks PATCH: reordered', payload.length, 'blocks');
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-node-blocks PATCH unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
@@ -2,22 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/requireAdmin';
 import { getAdminClient } from '@/lib/supabaseAdmin';
 
-function parseId(value: string | string[] | undefined) {
-  if (!value || Array.isArray(value)) return null;
+type Params = {
+  params: Promise<{ nodeId?: string | string[] | undefined }>;
+};
+
+async function resolveNodeId(context: Params) {
+  const rawParams = await context.params;
+  const value = Array.isArray(rawParams?.nodeId) ? rawParams?.nodeId[0] : rawParams?.nodeId;
+  if (!value) return null;
   const num = Number.parseInt(value, 10);
   return Number.isFinite(num) ? num : null;
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('📦 admin-node-blocks GET: start', params.nodeId);
+export async function GET(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('📦 admin-node-blocks GET: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }
@@ -37,16 +41,14 @@ export async function GET(
   return NextResponse.json({ items: data ?? [] });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('📦 admin-node-blocks POST: start', params.nodeId);
+export async function POST(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('📦 admin-node-blocks POST: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }
@@ -99,16 +101,14 @@ export async function POST(
   }
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('📦 admin-node-blocks PATCH: start', params.nodeId);
+export async function PATCH(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('📦 admin-node-blocks PATCH: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/[childId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/[childId]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+function parseId(value: string | string[] | undefined) {
+  if (!value || Array.isArray(value)) return null;
+  const num = Number.parseInt(value, 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string; childId: string } }
+) {
+  console.log('🧱 admin-node-child PATCH:', params.nodeId, params.childId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  const childId = parseId(params.childId);
+
+  if (!nodeId || !childId) {
+    return NextResponse.json({ error: 'Invalid nodeId or childId' }, { status: 400 });
+  }
+
+  try {
+    const payload = await request.json();
+    const updateData: Record<string, unknown> = {};
+
+    for (const key of ['is_required', 'label', 'notes']) {
+      if (key in payload) {
+        updateData[key] = payload[key];
+      }
+    }
+
+    if (!Object.keys(updateData).length) {
+      return NextResponse.json({ error: 'No fields provided' }, { status: 400 });
+    }
+
+    const supa = getAdminClient();
+    const { data, error } = await supa
+      .from('node_children')
+      .update(updateData)
+      .eq('parent_id', nodeId)
+      .eq('child_id', childId)
+      .select(
+        `parent_id, child_id, position, is_required, label, notes, child:content_nodes(id, node_type, title, slug, state, owner_id, description, metadata, hero_image, icon, objectives)`
+      )
+      .single();
+
+    if (error) {
+      console.error('❌ admin-node-child PATCH error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.log('✅ admin-node-child PATCH: updated link');
+    return NextResponse.json({ item: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-node-child PATCH unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { nodeId: string; childId: string } }
+) {
+  console.log('🧱 admin-node-child DELETE:', params.nodeId, params.childId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  const childId = parseId(params.childId);
+
+  if (!nodeId || !childId) {
+    return NextResponse.json({ error: 'Invalid nodeId or childId' }, { status: 400 });
+  }
+
+  const supa = getAdminClient();
+  const { error } = await supa
+    .from('node_children')
+    .delete()
+    .eq('parent_id', nodeId)
+    .eq('child_id', childId);
+
+  if (error) {
+    console.error('❌ admin-node-child DELETE error:', error);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  console.log('🗑️ admin-node-child DELETE: removed link');
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/[childId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/[childId]/route.ts
@@ -2,23 +2,31 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/requireAdmin';
 import { getAdminClient } from '@/lib/supabaseAdmin';
 
-function parseId(value: string | string[] | undefined) {
-  if (!value || Array.isArray(value)) return null;
-  const num = Number.parseInt(value, 10);
+type Params = {
+  params: Promise<{
+    nodeId?: string | string[] | undefined;
+    childId?: string | string[] | undefined;
+  }>;
+};
+
+async function resolveNumericId(context: Params, key: 'nodeId' | 'childId') {
+  const rawParams = await context.params;
+  const value = rawParams?.[key];
+  const stringValue = Array.isArray(value) ? value[0] : value;
+  if (!stringValue) return null;
+
+  const num = Number.parseInt(stringValue, 10);
   return Number.isFinite(num) ? num : null;
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: { nodeId: string; childId: string } }
-) {
-  console.log('🧱 admin-node-child PATCH:', params.nodeId, params.childId);
+export async function PATCH(request: NextRequest, context: Params) {
+  const nodeId = await resolveNumericId(context, 'nodeId');
+  const childId = await resolveNumericId(context, 'childId');
+
+  console.log('🧱 admin-node-child PATCH:', nodeId, childId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
-
-  const nodeId = parseId(params.nodeId);
-  const childId = parseId(params.childId);
 
   if (!nodeId || !childId) {
     return NextResponse.json({ error: 'Invalid nodeId or childId' }, { status: 400 });
@@ -63,17 +71,14 @@ export async function PATCH(
   }
 }
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: { nodeId: string; childId: string } }
-) {
-  console.log('🧱 admin-node-child DELETE:', params.nodeId, params.childId);
+export async function DELETE(request: NextRequest, context: Params) {
+  const nodeId = await resolveNumericId(context, 'nodeId');
+  const childId = await resolveNumericId(context, 'childId');
+
+  console.log('🧱 admin-node-child DELETE:', nodeId, childId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
-
-  const nodeId = parseId(params.nodeId);
-  const childId = parseId(params.childId);
 
   if (!nodeId || !childId) {
     return NextResponse.json({ error: 'Invalid nodeId or childId' }, { status: 400 });

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
@@ -2,22 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/requireAdmin';
 import { getAdminClient } from '@/lib/supabaseAdmin';
 
-function parseId(value: string | string[] | undefined) {
-  if (!value || Array.isArray(value)) return null;
+type Params = {
+  params: Promise<{ nodeId?: string | string[] | undefined }>;
+};
+
+async function resolveNodeId(context: Params) {
+  const rawParams = await context.params;
+  const value = Array.isArray(rawParams?.nodeId) ? rawParams?.nodeId[0] : rawParams?.nodeId;
+  if (!value) return null;
   const num = Number.parseInt(value, 10);
   return Number.isFinite(num) ? num : null;
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('🧱 admin-node-children GET: start', params.nodeId);
+export async function GET(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('🧱 admin-node-children GET: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }
@@ -39,16 +43,14 @@ export async function GET(
   return NextResponse.json({ items: data ?? [] });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('🧱 admin-node-children POST: start', params.nodeId);
+export async function POST(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('🧱 admin-node-children POST: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }
@@ -138,16 +140,14 @@ export async function POST(
   }
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('🧱 admin-node-children PATCH: start', params.nodeId);
+export async function PATCH(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('🧱 admin-node-children PATCH: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+function parseId(value: string | string[] | undefined) {
+  if (!value || Array.isArray(value)) return null;
+  const num = Number.parseInt(value, 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('🧱 admin-node-children GET: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  const supa = getAdminClient();
+  const { data, error } = await supa
+    .from('node_children')
+    .select(
+      `child_id, position, is_required, label, notes, child:content_nodes(id, node_type, title, slug, state, owner_id, description, metadata, hero_image, icon, objectives)`
+    )
+    .eq('parent_id', nodeId)
+    .order('position');
+
+  if (error) {
+    console.error('❌ admin-node-children GET error:', error);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ items: data ?? [] });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('🧱 admin-node-children POST: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  try {
+    const payload = await request.json();
+    const supa = getAdminClient();
+
+    let childId: number | null = null;
+    if (payload?.child_id) {
+      childId = Number.parseInt(String(payload.child_id), 10);
+    }
+
+    if (!childId && payload?.create) {
+      const newNodePayload = payload.create as Record<string, unknown>;
+      const title = newNodePayload?.title as string | undefined;
+      const nodeType = newNodePayload?.node_type as string | undefined;
+      if (!title || !nodeType) {
+        return NextResponse.json({ error: 'create.title and create.node_type are required' }, { status: 400 });
+      }
+
+      const insertData = {
+        title,
+        node_type: nodeType,
+        slug: (newNodePayload?.slug as string | undefined) ?? null,
+        description: (newNodePayload?.description as string | undefined) ?? null,
+        state: (newNodePayload?.state as string | undefined) ?? 'draft',
+        metadata: newNodePayload?.metadata ?? null,
+        owner_id: (newNodePayload?.owner_id as string | undefined) ?? null,
+        hero_image: (newNodePayload?.hero_image as string | undefined) ?? null,
+        icon: (newNodePayload?.icon as string | undefined) ?? null,
+        objectives: (newNodePayload?.objectives as string | undefined) ?? null,
+        created_by: guard.user.id,
+        updated_by: guard.user.id,
+      };
+
+      const { data: newNode, error } = await supa
+        .from('content_nodes')
+        .insert(insertData)
+        .select('*')
+        .single();
+
+      if (error) {
+        console.error('❌ admin-node-children POST create node error:', error);
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+
+      childId = newNode.id;
+    }
+
+    if (!childId) {
+      return NextResponse.json({ error: 'child_id is required' }, { status: 400 });
+    }
+
+    if (childId === nodeId) {
+      return NextResponse.json({ error: 'A node cannot be its own child' }, { status: 400 });
+    }
+
+    const insertChild = {
+      parent_id: nodeId,
+      child_id: childId,
+      position: Number.isFinite(payload?.position) ? payload.position : Number.parseInt(String(payload?.position ?? 0), 10) || 0,
+      is_required: payload?.is_required ?? false,
+      label: payload?.label ?? null,
+      notes: payload?.notes ?? null,
+    };
+
+    const { data, error } = await supa
+      .from('node_children')
+      .insert(insertChild)
+      .select(
+        `parent_id, child_id, position, is_required, label, notes, child:content_nodes(id, node_type, title, slug, state, owner_id, description, metadata, hero_image, icon, objectives)`
+      )
+      .single();
+
+    if (error) {
+      console.error('❌ admin-node-children POST link error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.log('✅ admin-node-children POST: linked child', childId, 'to', nodeId);
+    return NextResponse.json({ item: data }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-node-children POST unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('🧱 admin-node-children PATCH: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  try {
+    const payload = await request.json();
+    if (!Array.isArray(payload) || !payload.length) {
+      return NextResponse.json({ error: 'Array of { child_id, position } is required' }, { status: 400 });
+    }
+
+    const supa = getAdminClient();
+    for (const item of payload) {
+      const childId = Number.parseInt(String(item.child_id), 10);
+      const position = Number.parseInt(String(item.position), 10);
+      if (!Number.isFinite(childId) || childId <= 0) {
+        return NextResponse.json({ error: 'Invalid child_id in payload' }, { status: 400 });
+      }
+      if (!Number.isFinite(position)) {
+        return NextResponse.json({ error: 'Invalid position in payload' }, { status: 400 });
+      }
+
+      const { error } = await supa
+        .from('node_children')
+        .update({ position })
+        .eq('parent_id', nodeId)
+        .eq('child_id', childId);
+
+      if (error) {
+        console.error('❌ admin-node-children PATCH error:', error, { childId, position });
+        return NextResponse.json({ error: error.message, child_id: childId }, { status: 400 });
+      }
+    }
+
+    console.log('✅ admin-node-children PATCH: updated ordering for', payload.length, 'items');
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-node-children PATCH unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
@@ -2,22 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/requireAdmin';
 import { getAdminClient } from '@/lib/supabaseAdmin';
 
-function parseId(value: string | string[] | undefined) {
-  if (!value || Array.isArray(value)) return null;
+type Params = {
+  params: Promise<{ nodeId?: string | string[] | undefined }>;
+};
+
+async function resolveNodeId(context: Params) {
+  const rawParams = await context.params;
+  const value = Array.isArray(rawParams?.nodeId) ? rawParams?.nodeId[0] : rawParams?.nodeId;
+  if (!value) return null;
   const num = Number.parseInt(value, 10);
   return Number.isFinite(num) ? num : null;
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('📚 admin-course-node detail GET: start', params.nodeId);
+export async function GET(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('📚 admin-course-node detail GET: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }
@@ -61,16 +65,14 @@ export async function GET(
   return NextResponse.json({ item: { ...node, children: children ?? [] } });
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('📚 admin-course-node PATCH: start', params.nodeId);
+export async function PATCH(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('📚 admin-course-node PATCH: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }
@@ -124,16 +126,14 @@ export async function PATCH(
   }
 }
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: { nodeId: string } }
-) {
-  console.log('📚 admin-course-node DELETE: start', params.nodeId);
+export async function DELETE(request: NextRequest, context: Params) {
+  const nodeId = await resolveNodeId(context);
+
+  console.log('📚 admin-course-node DELETE: start', nodeId);
 
   const guard = await requireAdmin(request);
   if (!guard.ok) return guard.res;
 
-  const nodeId = parseId(params.nodeId);
   if (!nodeId) {
     return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
   }

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
@@ -1,0 +1,169 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+function parseId(value: string | string[] | undefined) {
+  if (!value || Array.isArray(value)) return null;
+  const num = Number.parseInt(value, 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('📚 admin-course-node detail GET: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  const supa = getAdminClient();
+  const { searchParams } = new URL(request.url);
+  const includeChildren = searchParams.get('includeChildren') === 'true';
+
+  const { data: node, error } = await supa
+    .from('content_nodes')
+    .select('*')
+    .eq('id', nodeId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('❌ admin-course-node detail GET error:', error);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  if (!node) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  if (!includeChildren) {
+    return NextResponse.json({ item: node });
+  }
+
+  const { data: children, error: childErr } = await supa
+    .from('node_children')
+    .select(
+      `child_id, position, is_required, label, notes, child:content_nodes(id, node_type, title, slug, state, owner_id, description, metadata, hero_image, icon, objectives)`
+    )
+    .eq('parent_id', nodeId)
+    .order('position');
+
+  if (childErr) {
+    console.error('❌ admin-course-node children fetch error:', childErr);
+    return NextResponse.json({ error: childErr.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ item: { ...node, children: children ?? [] } });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('📚 admin-course-node PATCH: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  try {
+    const payload = await request.json();
+    const updateData: Record<string, unknown> = {};
+
+    for (const key of [
+      'title',
+      'slug',
+      'description',
+      'state',
+      'metadata',
+      'owner_id',
+      'hero_image',
+      'icon',
+      'objectives',
+      'node_type',
+    ]) {
+      if (key in payload) {
+        updateData[key] = payload[key];
+      }
+    }
+
+    if (!Object.keys(updateData).length) {
+      return NextResponse.json({ error: 'No fields provided' }, { status: 400 });
+    }
+
+    updateData.updated_by = guard.user.id;
+
+    const supa = getAdminClient();
+    const { data, error } = await supa
+      .from('content_nodes')
+      .update(updateData)
+      .eq('id', nodeId)
+      .select('*')
+      .single();
+
+    if (error) {
+      console.error('❌ admin-course-node PATCH error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.log('✅ admin-course-node PATCH: updated', nodeId);
+    return NextResponse.json({ item: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-course-node PATCH unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } }
+) {
+  console.log('📚 admin-course-node DELETE: start', params.nodeId);
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeId = parseId(params.nodeId);
+  if (!nodeId) {
+    return NextResponse.json({ error: 'Invalid nodeId' }, { status: 400 });
+  }
+
+  const supa = getAdminClient();
+  const { searchParams } = new URL(request.url);
+  const force = searchParams.get('force') === 'true';
+
+  if (force) {
+    const { error } = await supa.from('content_nodes').delete().eq('id', nodeId);
+    if (error) {
+      console.error('❌ admin-course-node DELETE force error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    console.log('🗑️ admin-course-node DELETE: permanently removed', nodeId);
+    return NextResponse.json({ ok: true });
+  }
+
+  const { data, error } = await supa
+    .from('content_nodes')
+    .update({ state: 'archived', updated_by: guard.user.id })
+    .eq('id', nodeId)
+    .select('*')
+    .single();
+
+  if (error) {
+    console.error('❌ admin-course-node DELETE soft error:', error);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  console.log('📦 admin-course-node DELETE: archived', nodeId);
+  return NextResponse.json({ item: data });
+}

--- a/src/app/api/admin/course-builder/nodes/route.ts
+++ b/src/app/api/admin/course-builder/nodes/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getAdminClient } from '@/lib/supabaseAdmin';
+
+export async function GET(request: NextRequest) {
+  console.log('📚 admin-course-nodes GET: start');
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  const supa = getAdminClient();
+  const { searchParams } = new URL(request.url);
+
+  let query = supa
+    .from('content_nodes')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  const nodeType = searchParams.get('node_type');
+  if (nodeType) {
+    query = query.eq('node_type', nodeType);
+  }
+
+  const state = searchParams.get('state');
+  if (state) {
+    query = query.eq('state', state);
+  }
+
+  const ownerId = searchParams.get('owner_id');
+  if (ownerId) {
+    query = query.eq('owner_id', ownerId);
+  }
+
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+  if (limit && Number.isFinite(limit)) {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    console.error('❌ admin-course-nodes GET error:', error);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  console.log('✅ admin-course-nodes GET: returning', data?.length ?? 0, 'rows');
+  return NextResponse.json({ items: data ?? [] });
+}
+
+export async function POST(request: NextRequest) {
+  console.log('📚 admin-course-nodes POST: start');
+
+  const guard = await requireAdmin(request);
+  if (!guard.ok) return guard.res;
+
+  try {
+    const payload = await request.json();
+    const { title, node_type: nodeType, slug, description, state, metadata, owner_id: ownerId, hero_image: heroImage, icon, objectives } =
+      payload ?? {};
+
+    if (!title || !nodeType) {
+      return NextResponse.json(
+        { error: 'title and node_type are required' },
+        { status: 400 }
+      );
+    }
+
+    const supa = getAdminClient();
+    const insertData = {
+      title,
+      node_type: nodeType,
+      slug: slug ?? null,
+      description: description ?? null,
+      state: state ?? 'draft',
+      metadata: metadata ?? null,
+      owner_id: ownerId ?? null,
+      hero_image: heroImage ?? null,
+      icon: icon ?? null,
+      objectives: objectives ?? null,
+      created_by: guard.user.id,
+      updated_by: guard.user.id,
+    };
+
+    const { data, error } = await supa
+      .from('content_nodes')
+      .insert(insertData)
+      .select('*')
+      .single();
+
+    if (error) {
+      console.error('❌ admin-course-nodes POST error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.log('✅ admin-course-nodes POST: created node', data.id);
+    return NextResponse.json({ item: data }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 admin-course-nodes POST unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/courses/[courseId]/lessons/[lessonId]/blocks/route.ts
+++ b/src/app/api/courses/[courseId]/lessons/[lessonId]/blocks/route.ts
@@ -1,21 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerAnonClient } from '@/lib/supabaseServer';
 
-function parseId(value: string | string[] | undefined) {
-  if (!value || Array.isArray(value)) return null;
-  const num = Number.parseInt(value, 10);
+type Params = {
+  params: Promise<{
+    courseId?: string | string[] | undefined;
+    lessonId?: string | string[] | undefined;
+  }>;
+};
+
+async function resolveNumericId(context: Params, key: 'courseId' | 'lessonId') {
+  const rawParams = await context.params;
+  const value = rawParams?.[key];
+  const stringValue = Array.isArray(value) ? value[0] : value;
+  if (!stringValue) return null;
+  const num = Number.parseInt(stringValue, 10);
   return Number.isFinite(num) ? num : null;
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { courseId: string; lessonId: string } }
-) {
-  console.log('🎓 lesson blocks GET:', params.courseId, params.lessonId);
+export async function GET(request: NextRequest, context: Params) {
+  const courseId = await resolveNumericId(context, 'courseId');
+  const lessonId = await resolveNumericId(context, 'lessonId');
+
+  console.log('🎓 lesson blocks GET:', courseId, lessonId);
 
   try {
-    const courseId = parseId(params.courseId);
-    const lessonId = parseId(params.lessonId);
     if (!courseId || !lessonId) {
       return NextResponse.json({ error: 'Invalid courseId or lessonId' }, { status: 400 });
     }

--- a/src/app/api/courses/[courseId]/lessons/[lessonId]/blocks/route.ts
+++ b/src/app/api/courses/[courseId]/lessons/[lessonId]/blocks/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerAnonClient } from '@/lib/supabaseServer';
+
+function parseId(value: string | string[] | undefined) {
+  if (!value || Array.isArray(value)) return null;
+  const num = Number.parseInt(value, 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { courseId: string; lessonId: string } }
+) {
+  console.log('🎓 lesson blocks GET:', params.courseId, params.lessonId);
+
+  try {
+    const courseId = parseId(params.courseId);
+    const lessonId = parseId(params.lessonId);
+    if (!courseId || !lessonId) {
+      return NextResponse.json({ error: 'Invalid courseId or lessonId' }, { status: 400 });
+    }
+
+    const supa = await getServerAnonClient();
+
+    const { data: course, error: courseErr } = await supa
+      .from('content_nodes')
+      .select('id')
+      .eq('id', courseId)
+      .eq('node_type', 'course')
+      .eq('state', 'published')
+      .maybeSingle();
+
+    if (courseErr) {
+      console.error('❌ lesson blocks course lookup error:', courseErr);
+      return NextResponse.json({ error: courseErr.message }, { status: 400 });
+    }
+
+    if (!course) {
+      return NextResponse.json({ error: 'Course not found' }, { status: 404 });
+    }
+
+    const { data: link, error: linkErr } = await supa
+      .from('node_children')
+      .select('child_id')
+      .eq('parent_id', courseId)
+      .eq('child_id', lessonId)
+      .maybeSingle();
+
+    if (linkErr) {
+      console.error('❌ lesson blocks link lookup error:', linkErr);
+      return NextResponse.json({ error: linkErr.message }, { status: 400 });
+    }
+
+    if (!link) {
+      return NextResponse.json({ error: 'Lesson not found in course' }, { status: 404 });
+    }
+
+    const { data: lesson, error: lessonErr } = await supa
+      .from('content_nodes')
+      .select('id, node_type, title, slug, state, description, metadata, hero_image, icon, objectives')
+      .eq('id', lessonId)
+      .maybeSingle();
+
+    if (lessonErr) {
+      console.error('❌ lesson blocks lesson lookup error:', lessonErr);
+      return NextResponse.json({ error: lessonErr.message }, { status: 400 });
+    }
+
+    if (!lesson) {
+      return NextResponse.json({ error: 'Lesson not found' }, { status: 404 });
+    }
+
+    const { data: blocks, error: blockErr } = await supa
+      .from('content_blocks')
+      .select('*')
+      .eq('node_id', lessonId)
+      .order('position');
+
+    if (blockErr) {
+      console.error('❌ lesson blocks fetch error:', blockErr);
+      return NextResponse.json({ error: blockErr.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ lesson, blocks: blocks ?? [] });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 lesson blocks GET unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/courses/[courseId]/route.ts
+++ b/src/app/api/courses/[courseId]/route.ts
@@ -23,15 +23,27 @@ type NodeChildRow = {
   } | null;
 };
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { courseId: string } }
-) {
-  const { courseId } = params;
+type Params = {
+  params: Promise<{ courseId?: string | string[] | undefined }>;
+};
+
+async function resolveCourseIdentifier(context: Params) {
+  const rawParams = await context.params;
+  const value = Array.isArray(rawParams?.courseId) ? rawParams?.courseId[0] : rawParams?.courseId;
+  return typeof value === 'string' ? value : null;
+}
+
+export async function GET(request: NextRequest, context: Params) {
+  const courseId = await resolveCourseIdentifier(context);
   console.log('🎓 course detail GET:', courseId);
 
   try {
     const supa = await getServerAnonClient();
+
+    if (!courseId) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
     const isNumeric = /^\d+$/.test(courseId);
 
     let query = supa

--- a/src/app/api/courses/[courseId]/route.ts
+++ b/src/app/api/courses/[courseId]/route.ts
@@ -25,14 +25,14 @@ type NodeChildRow = {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { identifier: string } }
+  { params }: { params: { courseId: string } }
 ) {
-  const { identifier } = params;
-  console.log('🎓 course detail GET:', identifier);
+  const { courseId } = params;
+  console.log('🎓 course detail GET:', courseId);
 
   try {
     const supa = await getServerAnonClient();
-    const isNumeric = /^\d+$/.test(identifier);
+    const isNumeric = /^\d+$/.test(courseId);
 
     let query = supa
       .from('content_nodes')
@@ -41,9 +41,9 @@ export async function GET(
       .eq('state', 'published');
 
     if (isNumeric) {
-      query = query.eq('id', Number.parseInt(identifier, 10));
+      query = query.eq('id', Number.parseInt(courseId, 10));
     } else {
-      query = query.eq('slug', identifier);
+      query = query.eq('slug', courseId);
     }
 
     const { data: course, error } = await query.maybeSingle();

--- a/src/app/api/courses/[courseId]/route.ts
+++ b/src/app/api/courses/[courseId]/route.ts
@@ -27,6 +27,58 @@ type Params = {
   params: Promise<{ courseId?: string | string[] | undefined }>;
 };
 
+type RawChildRowChild = {
+  id: number | string;
+  node_type: string;
+  title: string;
+  slug: string | null;
+  state: string;
+  owner_id: string | null;
+  description: string | null;
+  metadata: unknown;
+  hero_image: string | null;
+  icon: string | null;
+  objectives: string | null;
+};
+
+type RawChildRow = {
+  parent_id: number | string | null;
+  child_id: number | string | null;
+  position: number | string | null;
+  is_required: boolean | string | null;
+  label: string | null;
+  notes: string | null;
+  child: RawChildRowChild | RawChildRowChild[] | null | undefined;
+};
+
+function normalizeChildRow(row: RawChildRow): NodeChildRow {
+  const normalizedChild = Array.isArray(row.child) ? row.child[0] ?? null : row.child ?? null;
+
+  return {
+    parent_id: Number(row.parent_id ?? 0),
+    child_id: Number(row.child_id ?? 0),
+    position: Number(row.position ?? 0),
+    is_required: row.is_required === null ? false : row.is_required === true || row.is_required === 'true',
+    label: row.label ?? null,
+    notes: row.notes ?? null,
+    child: normalizedChild
+      ? {
+          id: Number(normalizedChild.id ?? 0),
+          node_type: normalizedChild.node_type,
+          title: normalizedChild.title,
+          slug: normalizedChild.slug ?? null,
+          state: normalizedChild.state,
+          owner_id: normalizedChild.owner_id ?? null,
+          description: normalizedChild.description ?? null,
+          metadata: normalizedChild.metadata ?? null,
+          hero_image: normalizedChild.hero_image ?? null,
+          icon: normalizedChild.icon ?? null,
+          objectives: normalizedChild.objectives ?? null,
+        }
+      : null,
+  } satisfies NodeChildRow;
+}
+
 async function resolveCourseIdentifier(context: Params) {
   const rawParams = await context.params;
   const value = Array.isArray(rawParams?.courseId) ? rawParams?.courseId[0] : rawParams?.courseId;
@@ -82,7 +134,7 @@ export async function GET(request: NextRequest, context: Params) {
       return NextResponse.json({ error: childErr.message }, { status: 400 });
     }
 
-    const childRowsTyped = (childRows ?? []) as NodeChildRow[];
+    const childRowsTyped = (childRows ?? []).map(normalizeChildRow);
     const visibleChildren = childRowsTyped.filter((row) => row.child);
     const childIds = Array.from(
       new Set(
@@ -109,7 +161,9 @@ export async function GET(request: NextRequest, context: Params) {
 
       if (nestedRows) {
         const grouped = new Map<number, NodeChildRow[]>();
-        for (const row of (nestedRows ?? []) as NodeChildRow[]) {
+        for (const rawRow of nestedRows ?? []) {
+          const row = normalizeChildRow(rawRow);
+
           if (!row.child) continue;
           const parentId = row.parent_id as number;
           if (!grouped.has(parentId)) grouped.set(parentId, []);

--- a/src/app/api/courses/[identifier]/route.ts
+++ b/src/app/api/courses/[identifier]/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerAnonClient } from '@/lib/supabaseServer';
+
+type NodeChildRow = {
+  parent_id: number;
+  child_id: number;
+  position: number;
+  is_required: boolean;
+  label: string | null;
+  notes: string | null;
+  child: {
+    id: number;
+    node_type: string;
+    title: string;
+    slug: string | null;
+    state: string;
+    owner_id: string | null;
+    description: string | null;
+    metadata: unknown;
+    hero_image: string | null;
+    icon: string | null;
+    objectives: string | null;
+  } | null;
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { identifier: string } }
+) {
+  const { identifier } = params;
+  console.log('🎓 course detail GET:', identifier);
+
+  try {
+    const supa = await getServerAnonClient();
+    const isNumeric = /^\d+$/.test(identifier);
+
+    let query = supa
+      .from('content_nodes')
+      .select('id, node_type, title, slug, description, owner_id, metadata, hero_image, icon, objectives, state, created_at, updated_at')
+      .eq('node_type', 'course')
+      .eq('state', 'published');
+
+    if (isNumeric) {
+      query = query.eq('id', Number.parseInt(identifier, 10));
+    } else {
+      query = query.eq('slug', identifier);
+    }
+
+    const { data: course, error } = await query.maybeSingle();
+
+    if (error) {
+      console.error('❌ course detail GET error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    if (!course) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const { data: childRows, error: childErr } = await supa
+      .from('node_children')
+      .select(
+        `parent_id, child_id, position, is_required, label, notes, child:content_nodes(id, node_type, title, slug, state, owner_id, description, metadata, hero_image, icon, objectives)`
+      )
+      .eq('parent_id', course.id)
+      .order('position');
+
+    if (childErr) {
+      console.error('❌ course detail children error:', childErr);
+      return NextResponse.json({ error: childErr.message }, { status: 400 });
+    }
+
+    const childRowsTyped = (childRows ?? []) as NodeChildRow[];
+    const visibleChildren = childRowsTyped.filter((row) => row.child);
+    const childIds = Array.from(
+      new Set(
+        visibleChildren
+          .map((row) => row.child?.id)
+          .filter((id): id is number => typeof id === 'number')
+      )
+    );
+
+    let nestedMap = new Map<number, NodeChildRow[]>();
+    if (childIds.length) {
+      const { data: nestedRows, error: nestedErr } = await supa
+        .from('node_children')
+        .select(
+          `parent_id, child_id, position, is_required, label, notes, child:content_nodes(id, node_type, title, slug, state, owner_id, description, metadata, hero_image, icon, objectives)`
+        )
+        .in('parent_id', childIds)
+        .order('position');
+
+      if (nestedErr) {
+        console.error('❌ course detail nested children error:', nestedErr);
+        return NextResponse.json({ error: nestedErr.message }, { status: 400 });
+      }
+
+      if (nestedRows) {
+        const grouped = new Map<number, NodeChildRow[]>();
+        for (const row of (nestedRows ?? []) as NodeChildRow[]) {
+          if (!row.child) continue;
+          const parentId = row.parent_id as number;
+          if (!grouped.has(parentId)) grouped.set(parentId, []);
+          grouped.get(parentId)!.push(row);
+        }
+        nestedMap = grouped;
+      }
+    }
+
+    const tree = visibleChildren.map((row) => ({
+      ...row,
+      children: nestedMap.get(row.child!.id) ?? [],
+    }));
+
+    return NextResponse.json({ item: { ...course, children: tree } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 course detail GET unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/courses/route.ts
+++ b/src/app/api/courses/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerAnonClient } from '@/lib/supabaseServer';
+
+export async function GET(request: NextRequest) {
+  console.log('🎓 courses GET: start');
+
+  try {
+    const supa = await getServerAnonClient();
+    const { searchParams } = new URL(request.url);
+    const ownerId = searchParams.get('owner_id');
+    const tagId = searchParams.get('tag_id');
+    const limitParam = searchParams.get('limit');
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+
+    let select = 'id, title, slug, description, owner_id, metadata, hero_image, icon, objectives, state, created_at, updated_at';
+    if (tagId) {
+      select += ', content_node_tags!inner(tag_id)';
+    }
+
+    let query = supa
+      .from('content_nodes')
+      .select(select)
+      .eq('node_type', 'course')
+      .eq('state', 'published')
+      .order('created_at', { ascending: false });
+
+    if (ownerId) {
+      query = query.eq('owner_id', ownerId);
+    }
+
+    if (tagId) {
+      query = query.eq('content_node_tags.tag_id', tagId);
+    }
+
+    if (limit && Number.isFinite(limit)) {
+      query = query.limit(limit);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      console.error('❌ courses GET error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.log('✅ courses GET: returning', data?.length ?? 0, 'courses');
+    return NextResponse.json({ items: data ?? [] });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('💥 courses GET unexpected error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add admin course node CRUD endpoints for listing, creating, updating, and archiving content nodes
- expose admin helpers to manage node hierarchy and content blocks for the course builder
- provide public course listing, course detail, and lesson block viewer endpoints backed by Supabase RLS

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ded6b6825c833283dbeb7bc2a1ffa5