### PR TITLE
feat: add admin course builder API routes

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,6 +11,7 @@ import CoachRosters from '@/components/admin/CoachRosters';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import ResourceLibraryAdmin from '@/components/admin/ResourceLibraryAdmin';
 import AdminActionRequired from '@/components/admin/AdminActionRequired';
+import CourseBuilderAdmin from '@/components/admin/CourseBuilderAdmin';
 
 
 import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js';
@@ -174,6 +175,7 @@ export default function AdminPage() {
             <Tab label="Assign / Change Coach" />
             <Tab label="Coach Rosters" />
             <Tab label="Resource Library" />
+            <Tab label="Course Builder" />
             <Tab label="Action Required" />
           </Tabs>
 
@@ -192,6 +194,9 @@ export default function AdminPage() {
               <ResourceLibraryAdmin />
             </TabPanel>
             <TabPanel value={tab} index={4}>
+              <CourseBuilderAdmin />
+            </TabPanel>
+            <TabPanel value={tab} index={5}>
               <AdminActionRequired />
             </TabPanel>
           </Box>

--- a/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
+++ b/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
@@ -9,10 +9,6 @@ import {
   validateBlockPayload,
 } from '@/lib/courseBuilder';
 
-type RouteContext = {
-  params: { blockId: string };
-};
-
 function parseBlockId(value: string) {
   const id = Number(value);
   if (!Number.isFinite(id) || id <= 0) {
@@ -21,14 +17,17 @@ function parseBlockId(value: string) {
   return id;
 }
 
-export async function PATCH(request: NextRequest, context: RouteContext) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { blockId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const blockId = parseBlockId(context.params.blockId);
+    const blockId = parseBlockId(params.blockId);
     const existing = await fetchBlockById(blockId);
     const body = await request.json();
     const updates = body?.updates ?? body;
@@ -140,14 +139,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   }
 }
 
-export async function DELETE(request: NextRequest, context: RouteContext) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { blockId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const blockId = parseBlockId(context.params.blockId);
+    const blockId = parseBlockId(params.blockId);
     const existing = await fetchBlockById(blockId);
 
     const { error } = await adminClient

--- a/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
+++ b/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchBlockById,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+  validateBlockPayload,
+} from '@/lib/courseBuilder';
+
+type RouteContext = {
+  params: { blockId: string };
+};
+
+function parseBlockId(value: string) {
+  const id = Number(value);
+  if (!Number.isFinite(id) || id <= 0) {
+    throw new CourseBuilderError('Invalid block id', 400, { value });
+  }
+  return id;
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const blockId = parseBlockId(context.params.blockId);
+    const existing = await fetchBlockById(blockId);
+    const body = await request.json();
+    const updates = body?.updates ?? body;
+
+    if (!updates || typeof updates !== 'object') {
+      throw new CourseBuilderError('Missing update payload', 400);
+    }
+
+    const merged = { ...existing, ...updates } as typeof existing;
+
+    if ('position' in merged && merged.position != null) {
+      const positionValue = Number(merged.position);
+      if (!Number.isFinite(positionValue) || positionValue < 0) {
+        throw new CourseBuilderError('position must be a non-negative number', 400, {
+          position: merged.position,
+        });
+      }
+      merged.position = positionValue;
+    }
+
+    if (merged.resource_id != null) {
+      const resourceId = Number(merged.resource_id);
+      if (!Number.isFinite(resourceId)) {
+        throw new CourseBuilderError('resource_id must be a number', 400, {
+          resource_id: merged.resource_id,
+        });
+      }
+      merged.resource_id = resourceId;
+    }
+
+    if (merged.start_ms != null) {
+      const startMs = Number(merged.start_ms);
+      if (!Number.isFinite(startMs) || startMs < 0) {
+        throw new CourseBuilderError('start_ms must be a non-negative number', 400, {
+          start_ms: merged.start_ms,
+        });
+      }
+      merged.start_ms = startMs;
+    }
+
+    if (merged.end_ms != null) {
+      const endMs = Number(merged.end_ms);
+      if (!Number.isFinite(endMs) || endMs < 0) {
+        throw new CourseBuilderError('end_ms must be a non-negative number', 400, {
+          end_ms: merged.end_ms,
+        });
+      }
+      merged.end_ms = endMs;
+    }
+
+    validateBlockPayload(merged);
+
+    const allowedFields = [
+      'block_type',
+      'position',
+      'text_md',
+      'resource_id',
+      'start_ms',
+      'end_ms',
+      'label',
+      'notes',
+      'settings',
+      'data',
+    ];
+
+    const updatePayload: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (field in updates) {
+        let value = updates[field];
+        if (field === 'position' && value != null) {
+          const positionValue = Number(value);
+          if (!Number.isFinite(positionValue) || positionValue < 0) {
+            throw new CourseBuilderError('position must be a non-negative number', 400, { position: value });
+          }
+          value = positionValue;
+        }
+
+        if ((field === 'resource_id' || field === 'start_ms' || field === 'end_ms') && value != null) {
+          const numericValue = Number(value);
+          if (!Number.isFinite(numericValue) || (field !== 'resource_id' && numericValue < 0)) {
+            throw new CourseBuilderError(`${field} must be a valid number`, 400, { [field]: value });
+          }
+          value = numericValue;
+        }
+
+        updatePayload[field] = value;
+      }
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      return NextResponse.json({ subtree: await fetchNodeSubtree(existing.node_id) });
+    }
+
+    updatePayload.updated_at = new Date().toISOString();
+
+    const { error } = await adminClient
+      .from('content_blocks')
+      .update(updatePayload)
+      .eq('id', blockId);
+
+    if (error) {
+      throw new CourseBuilderError('Failed to update content block', 500, { details: error.message });
+    }
+
+    const subtree = await fetchNodeSubtree(existing.node_id);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const blockId = parseBlockId(context.params.blockId);
+    const existing = await fetchBlockById(blockId);
+
+    const { error } = await adminClient
+      .from('content_blocks')
+      .delete()
+      .eq('id', blockId);
+
+    if (error) {
+      throw new CourseBuilderError('Failed to delete content block', 500, { details: error.message });
+    }
+
+    const subtree = await fetchNodeSubtree(existing.node_id);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
+++ b/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
@@ -19,7 +19,7 @@ function parseBlockId(value: string) {
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { blockId: string } },
+  context: { params: Promise<{ blockId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -27,7 +27,8 @@ export async function PATCH(
   }
 
   try {
-    const blockId = parseBlockId(params.blockId);
+    const { blockId: blockIdParam } = await context.params;
+    const blockId = parseBlockId(blockIdParam);
     const existing = await fetchBlockById(blockId);
     const body = await request.json();
     const updates = body?.updates ?? body;
@@ -141,7 +142,7 @@ export async function PATCH(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { blockId: string } },
+  context: { params: Promise<{ blockId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -149,7 +150,8 @@ export async function DELETE(
   }
 
   try {
-    const blockId = parseBlockId(params.blockId);
+    const { blockId: blockIdParam } = await context.params;
+    const blockId = parseBlockId(blockIdParam);
     const existing = await fetchBlockById(blockId);
 
     const { error } = await adminClient

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
@@ -70,26 +70,59 @@ export async function PATCH(
 
     const { data: existing, error: existingError } = await adminClient
       .from('content_blocks')
-      .select('id')
+      .select(
+        'id, node_id, block_type, text_md, resource_id, start_ms, end_ms, label, notes, settings, data',
+      )
       .eq('node_id', nodeIdNumber);
 
     if (existingError) {
       throw new CourseBuilderError('Failed to load current blocks', 500, { details: existingError.message });
     }
 
-    const existingIds = new Set(existing?.map((row) => row.id));
+    const existingMap = new Map<number, NonNullable<typeof existing>[number]>();
+    for (const row of existing ?? []) {
+      existingMap.set(row.id, row);
+    }
 
     for (const blockId of blockIds) {
-      if (!existingIds.has(blockId)) {
+      if (!existingMap.has(blockId)) {
         throw new CourseBuilderError('One or more blocks do not belong to this node', 400, {
           block_id: blockId,
         });
       }
     }
 
+    const mergedPayload = payload.map((row) => {
+      const base = existingMap.get(row.id as number);
+      if (!base) {
+        return row;
+      }
+      const merged = {
+        id: row.id,
+        node_id: row.node_id,
+        block_type: base.block_type,
+        text_md: base.text_md,
+        resource_id: base.resource_id,
+        start_ms: base.start_ms,
+        end_ms: base.end_ms,
+        label: base.label,
+        notes: base.notes,
+        settings: base.settings,
+        data: base.data,
+        position: row.position,
+      } as Record<string, unknown>;
+
+      if ('label' in row) merged.label = row.label;
+      if ('notes' in row) merged.notes = row.notes;
+      if ('settings' in row) merged.settings = row.settings;
+      if ('data' in row) merged.data = row.data;
+
+      return merged;
+    });
+
     const { error: upsertError } = await adminClient
       .from('content_blocks')
-      .upsert(payload, { onConflict: 'id' });
+      .upsert(mergedPayload, { onConflict: 'id' });
 
     if (upsertError) {
       throw new CourseBuilderError('Failed to reorder blocks', 500, { details: upsertError.message });

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
@@ -7,20 +7,19 @@ import {
   handleCourseBuilderError,
 } from '@/lib/courseBuilder';
 
-type RouteContext = {
-  params: { nodeId: string };
-};
-
-export async function PATCH(request: NextRequest, context: RouteContext) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const nodeId = Number(context.params.nodeId);
+    const nodeId = Number(params.nodeId);
     if (!Number.isFinite(nodeId) || nodeId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
     }
 
     const body = await request.json();

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
@@ -9,7 +9,7 @@ import {
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -17,9 +17,10 @@ export async function PATCH(
   }
 
   try {
-    const nodeId = Number(params.nodeId);
-    if (!Number.isFinite(nodeId) || nodeId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
+    const { nodeId } = await context.params;
+    const nodeIdNumber = Number(nodeId);
+    if (!Number.isFinite(nodeIdNumber) || nodeIdNumber <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: nodeId });
     }
 
     const body = await request.json();
@@ -55,7 +56,7 @@ export async function PATCH(
 
       const row: Record<string, unknown> = {
         id: blockId,
-        node_id: nodeId,
+        node_id: nodeIdNumber,
         position,
       };
 
@@ -70,7 +71,7 @@ export async function PATCH(
     const { data: existing, error: existingError } = await adminClient
       .from('content_blocks')
       .select('id')
-      .eq('node_id', nodeId);
+      .eq('node_id', nodeIdNumber);
 
     if (existingError) {
       throw new CourseBuilderError('Failed to load current blocks', 500, { details: existingError.message });
@@ -94,7 +95,7 @@ export async function PATCH(
       throw new CourseBuilderError('Failed to reorder blocks', 500, { details: upsertError.message });
     }
 
-    const subtree = await fetchNodeSubtree(nodeId);
+    const subtree = await fetchNodeSubtree(nodeIdNumber);
     return NextResponse.json({ subtree });
   } catch (error: unknown) {
     return handleCourseBuilderError(error);

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+} from '@/lib/courseBuilder';
+
+type RouteContext = {
+  params: { nodeId: string };
+};
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const nodeId = Number(context.params.nodeId);
+    if (!Number.isFinite(nodeId) || nodeId <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+    }
+
+    const body = await request.json();
+    const updates = Array.isArray(body?.updates) ? body.updates : body;
+
+    if (!Array.isArray(updates) || updates.length === 0) {
+      throw new CourseBuilderError('updates must be a non-empty array', 400);
+    }
+
+    const blockIds = new Set<number>();
+    const payload: Array<Record<string, unknown>> = [];
+
+    for (const item of updates) {
+      const blockId = Number(item?.block_id ?? item?.id);
+      const position = Number(item?.position);
+
+      if (!Number.isFinite(blockId) || blockId <= 0) {
+        throw new CourseBuilderError('Invalid block_id in updates', 400, { block_id: item?.block_id ?? item?.id });
+      }
+
+      if (!Number.isFinite(position)) {
+        throw new CourseBuilderError('Invalid position for block', 400, {
+          block_id: blockId,
+          position: item?.position,
+        });
+      }
+
+      if (blockIds.has(blockId)) {
+        throw new CourseBuilderError('Duplicate block_id detected in updates', 400, { block_id: blockId });
+      }
+
+      blockIds.add(blockId);
+
+      const row: Record<string, unknown> = {
+        id: blockId,
+        node_id: nodeId,
+        position,
+      };
+
+      if ('label' in item) row.label = item.label;
+      if ('notes' in item) row.notes = item.notes;
+      if ('settings' in item) row.settings = item.settings;
+      if ('data' in item) row.data = item.data;
+
+      payload.push(row);
+    }
+
+    const { data: existing, error: existingError } = await adminClient
+      .from('content_blocks')
+      .select('id')
+      .eq('node_id', nodeId);
+
+    if (existingError) {
+      throw new CourseBuilderError('Failed to load current blocks', 500, { details: existingError.message });
+    }
+
+    const existingIds = new Set(existing?.map((row) => row.id));
+
+    for (const blockId of blockIds) {
+      if (!existingIds.has(blockId)) {
+        throw new CourseBuilderError('One or more blocks do not belong to this node', 400, {
+          block_id: blockId,
+        });
+      }
+    }
+
+    const { error: upsertError } = await adminClient
+      .from('content_blocks')
+      .upsert(payload, { onConflict: 'id' });
+
+    if (upsertError) {
+      throw new CourseBuilderError('Failed to reorder blocks', 500, { details: upsertError.message });
+    }
+
+    const subtree = await fetchNodeSubtree(nodeId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
@@ -8,20 +8,19 @@ import {
   validateBlockPayload,
 } from '@/lib/courseBuilder';
 
-type RouteContext = {
-  params: { nodeId: string };
-};
-
-export async function POST(request: NextRequest, context: RouteContext) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const nodeId = Number(context.params.nodeId);
+    const nodeId = Number(params.nodeId);
     if (!Number.isFinite(nodeId) || nodeId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
     }
 
     const body = await request.json();

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+  validateBlockPayload,
+} from '@/lib/courseBuilder';
+
+type RouteContext = {
+  params: { nodeId: string };
+};
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const nodeId = Number(context.params.nodeId);
+    if (!Number.isFinite(nodeId) || nodeId <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+    }
+
+    const body = await request.json();
+    const block = body?.block ?? body;
+
+    if (!block || typeof block !== 'object') {
+      throw new CourseBuilderError('Missing block payload', 400);
+    }
+
+    const positionValue = block.position != null ? Number(block.position) : null;
+    if (positionValue != null && (!Number.isFinite(positionValue) || positionValue < 0)) {
+      throw new CourseBuilderError('position must be a non-negative number', 400, {
+        position: block.position,
+      });
+    }
+
+    const resourceId = block.resource_id != null ? Number(block.resource_id) : null;
+    if (resourceId != null && !Number.isFinite(resourceId)) {
+      throw new CourseBuilderError('resource_id must be a number', 400, {
+        resource_id: block.resource_id,
+      });
+    }
+
+    const startMs = block.start_ms != null ? Number(block.start_ms) : null;
+    if (startMs != null && (!Number.isFinite(startMs) || startMs < 0)) {
+      throw new CourseBuilderError('start_ms must be a non-negative number', 400, {
+        start_ms: block.start_ms,
+      });
+    }
+
+    const endMs = block.end_ms != null ? Number(block.end_ms) : null;
+    if (endMs != null && (!Number.isFinite(endMs) || endMs < 0)) {
+      throw new CourseBuilderError('end_ms must be a non-negative number', 400, {
+        end_ms: block.end_ms,
+      });
+    }
+
+    const sanitizedBlock = {
+      ...block,
+      position: positionValue ?? undefined,
+      resource_id: resourceId ?? undefined,
+      start_ms: startMs ?? undefined,
+      end_ms: endMs ?? undefined,
+    };
+
+    validateBlockPayload(sanitizedBlock);
+
+    let position = positionValue;
+    if (position == null) {
+      const { data: existing, error } = await adminClient
+        .from('content_blocks')
+        .select('position')
+        .eq('node_id', nodeId)
+        .order('position', { ascending: false })
+        .limit(1);
+
+      if (error) {
+        throw new CourseBuilderError('Failed to determine block position', 500, { details: error.message });
+      }
+
+      position = existing?.[0]?.position != null ? existing[0].position + 1 : 0;
+    }
+
+    const insertPayload = {
+      node_id: nodeId,
+      block_type: block.block_type,
+      position,
+      text_md: block.text_md ?? null,
+      resource_id: resourceId,
+      start_ms: startMs,
+      end_ms: endMs,
+      label: block.label ?? null,
+      notes: block.notes ?? null,
+      settings: block.settings ?? null,
+      data: block.data ?? null,
+    };
+
+    const { error: insertError } = await adminClient
+      .from('content_blocks')
+      .insert(insertPayload);
+
+    if (insertError) {
+      throw new CourseBuilderError('Failed to create content block', 500, { details: insertError.message });
+    }
+
+    const subtree = await fetchNodeSubtree(nodeId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
@@ -10,7 +10,7 @@ import {
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -18,9 +18,10 @@ export async function POST(
   }
 
   try {
-    const nodeId = Number(params.nodeId);
-    if (!Number.isFinite(nodeId) || nodeId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
+    const { nodeId } = await context.params;
+    const nodeIdNumber = Number(nodeId);
+    if (!Number.isFinite(nodeIdNumber) || nodeIdNumber <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: nodeId });
     }
 
     const body = await request.json();
@@ -73,7 +74,7 @@ export async function POST(
       const { data: existing, error } = await adminClient
         .from('content_blocks')
         .select('position')
-        .eq('node_id', nodeId)
+        .eq('node_id', nodeIdNumber)
         .order('position', { ascending: false })
         .limit(1);
 
@@ -85,7 +86,7 @@ export async function POST(
     }
 
     const insertPayload = {
-      node_id: nodeId,
+      node_id: nodeIdNumber,
       block_type: block.block_type,
       position,
       text_md: block.text_md ?? null,
@@ -106,7 +107,7 @@ export async function POST(
       throw new CourseBuilderError('Failed to create content block', 500, { details: insertError.message });
     }
 
-    const subtree = await fetchNodeSubtree(nodeId);
+    const subtree = await fetchNodeSubtree(nodeIdNumber);
     return NextResponse.json({ subtree });
   } catch (error: unknown) {
     return handleCourseBuilderError(error);

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/[childId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/[childId]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+} from '@/lib/courseBuilder';
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ nodeId: string; childId: string }> },
+) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const { nodeId, childId } = await context.params;
+    const parentId = Number(nodeId);
+    const childNodeId = Number(childId);
+
+    if (!Number.isFinite(parentId) || parentId <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: nodeId });
+    }
+
+    if (!Number.isFinite(childNodeId) || childNodeId <= 0) {
+      throw new CourseBuilderError('Invalid child id', 400, { value: childId });
+    }
+
+    const { error } = await adminClient
+      .from('node_children')
+      .delete()
+      .eq('parent_id', parentId)
+      .eq('child_id', childNodeId);
+
+    if (error) {
+      throw new CourseBuilderError('Failed to remove child', 500, {
+        details: error.message,
+      });
+    }
+
+    const subtree = await fetchNodeSubtree(parentId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/reorder/route.ts
@@ -7,20 +7,19 @@ import {
   handleCourseBuilderError,
 } from '@/lib/courseBuilder';
 
-type RouteContext = {
-  params: { nodeId: string };
-};
-
-export async function PATCH(request: NextRequest, context: RouteContext) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const parentId = Number(context.params.nodeId);
+    const parentId = Number(params.nodeId);
     if (!Number.isFinite(parentId) || parentId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
     }
 
     const body = await request.json();

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/reorder/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+} from '@/lib/courseBuilder';
+
+type RouteContext = {
+  params: { nodeId: string };
+};
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const parentId = Number(context.params.nodeId);
+    if (!Number.isFinite(parentId) || parentId <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+    }
+
+    const body = await request.json();
+    const updates = Array.isArray(body?.updates) ? body.updates : body;
+
+    if (!Array.isArray(updates) || updates.length === 0) {
+      throw new CourseBuilderError('updates must be a non-empty array', 400);
+    }
+
+    const childIds = new Set<number>();
+    const payload: Array<Record<string, unknown>> = [];
+
+    for (const item of updates) {
+      const childId = Number(item?.child_id);
+      const position = Number(item?.position);
+
+      if (!Number.isFinite(childId) || childId <= 0) {
+        throw new CourseBuilderError('Invalid child_id in updates', 400, { child_id: item?.child_id });
+      }
+
+      if (!Number.isFinite(position)) {
+        throw new CourseBuilderError('Invalid position for child', 400, { child_id: childId, position: item?.position });
+      }
+
+      if (childIds.has(childId)) {
+        throw new CourseBuilderError('Duplicate child_id detected in updates', 400, { child_id: childId });
+      }
+
+      childIds.add(childId);
+
+      const edge: Record<string, unknown> = {
+        parent_id: parentId,
+        child_id: childId,
+        position,
+      };
+
+      if ('is_required' in item) edge.is_required = item.is_required;
+      if ('label' in item) edge.label = item.label;
+      if ('notes' in item) edge.notes = item.notes;
+
+      payload.push(edge);
+    }
+
+    const { data: existing, error: existingError } = await adminClient
+      .from('node_children')
+      .select('child_id')
+      .eq('parent_id', parentId);
+
+    if (existingError) {
+      throw new CourseBuilderError('Failed to load current children', 500, { details: existingError.message });
+    }
+
+    const existingIds = new Set(existing?.map((row) => row.child_id));
+
+    for (const childId of childIds) {
+      if (!existingIds.has(childId)) {
+        throw new CourseBuilderError('One or more children do not belong to this parent', 400, {
+          child_id: childId,
+        });
+      }
+    }
+
+    const { error: upsertError } = await adminClient
+      .from('node_children')
+      .upsert(payload, { onConflict: 'parent_id,child_id' });
+
+    if (upsertError) {
+      throw new CourseBuilderError('Failed to reorder children', 500, { details: upsertError.message });
+    }
+
+    const subtree = await fetchNodeSubtree(parentId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/reorder/route.ts
@@ -9,7 +9,7 @@ import {
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -17,9 +17,10 @@ export async function PATCH(
   }
 
   try {
-    const parentId = Number(params.nodeId);
+    const { nodeId } = await context.params;
+    const parentId = Number(nodeId);
     if (!Number.isFinite(parentId) || parentId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
+      throw new CourseBuilderError('Invalid node id', 400, { value: nodeId });
     }
 
     const body = await request.json();

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
@@ -20,7 +20,7 @@ function parseId(value: unknown, field: string) {
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -28,7 +28,8 @@ export async function POST(
   }
 
   try {
-    const parentId = parseId(params.nodeId, 'parent_id');
+    const { nodeId } = await context.params;
+    const parentId = parseId(nodeId, 'parent_id');
     const body = await request.json();
 
     const childId = parseId(body?.child_id, 'child_id');

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
@@ -10,10 +10,6 @@ import {
   validateNodeRelationship,
 } from '@/lib/courseBuilder';
 
-type RouteContext = {
-  params: { nodeId: string };
-};
-
 function parseId(value: unknown, field: string) {
   const id = Number(value);
   if (!Number.isFinite(id) || id <= 0) {
@@ -22,14 +18,17 @@ function parseId(value: unknown, field: string) {
   return id;
 }
 
-export async function POST(request: NextRequest, context: RouteContext) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const parentId = parseId(context.params.nodeId, 'parent_id');
+    const parentId = parseId(params.nodeId, 'parent_id');
     const body = await request.json();
 
     const childId = parseId(body?.child_id, 'child_id');

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/children/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeById,
+  fetchNodeSubtree,
+  getParentEdge,
+  handleCourseBuilderError,
+  validateNodeRelationship,
+} from '@/lib/courseBuilder';
+
+type RouteContext = {
+  params: { nodeId: string };
+};
+
+function parseId(value: unknown, field: string) {
+  const id = Number(value);
+  if (!Number.isFinite(id) || id <= 0) {
+    throw new CourseBuilderError(`Invalid ${field}`, 400, { value });
+  }
+  return id;
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const parentId = parseId(context.params.nodeId, 'parent_id');
+    const body = await request.json();
+
+    const childId = parseId(body?.child_id, 'child_id');
+
+    if (childId === parentId) {
+      throw new CourseBuilderError('A node cannot be its own child', 400);
+    }
+
+    const childNode = await fetchNodeById(childId);
+    await validateNodeRelationship(parentId, String(childNode.node_type));
+
+    const existingParent = await getParentEdge(childId);
+    if (existingParent && existingParent.parent_id !== parentId) {
+      throw new CourseBuilderError('Child is already attached to a different parent', 409, {
+        currentParentId: existingParent.parent_id,
+      });
+    }
+
+    let position = body?.position;
+    if (position == null) {
+      const { data: siblings, error } = await adminClient
+        .from('node_children')
+        .select('position')
+        .eq('parent_id', parentId)
+        .order('position', { ascending: false })
+        .limit(1);
+
+      if (error) {
+        throw new CourseBuilderError('Failed to determine child position', 500, { details: error.message });
+      }
+
+      position = siblings?.[0]?.position != null ? siblings[0].position + 1 : 0;
+    }
+
+    const edgePayload = {
+      parent_id: parentId,
+      child_id: childId,
+      position,
+      is_required: body?.is_required ?? existingParent?.is_required ?? true,
+      label: body?.label ?? existingParent?.label ?? null,
+      notes: body?.notes ?? existingParent?.notes ?? null,
+    };
+
+    const { error: upsertError } = await adminClient
+      .from('node_children')
+      .upsert(edgePayload, { onConflict: 'parent_id,child_id' });
+
+    if (upsertError) {
+      throw new CourseBuilderError('Failed to attach child node', 500, { details: upsertError.message });
+    }
+
+    const subtree = await fetchNodeSubtree(parentId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/duplicate/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/duplicate/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+  validateNodeRelationship,
+} from '@/lib/courseBuilder';
+
+type CloneOptions = {
+  userId: string;
+  parentId?: number | null;
+  parentEdge?: {
+    position?: number | null;
+    is_required?: boolean | null;
+    label?: string | null;
+    notes?: string | null;
+  } | null;
+  titleOverride?: string | null;
+};
+
+async function cloneSubtree(nodeId: number, options: CloneOptions) {
+  const sourceSubtree = await fetchNodeSubtree(nodeId);
+  const timestamp = new Date().toISOString();
+
+  async function cloneNode(subtree: typeof sourceSubtree, depth = 0): Promise<number> {
+    const original = subtree.node;
+    const payload: Record<string, unknown> = {
+      ...original,
+      id: undefined,
+      slug: null,
+      created_at: timestamp,
+      updated_at: timestamp,
+      created_by: options.userId,
+      updated_by: options.userId,
+    };
+
+    if (depth === 0 && options.titleOverride) {
+      payload.title = options.titleOverride;
+    } else if (depth === 0) {
+      payload.title = `${original.title ?? 'Untitled'} (Copy)`;
+    }
+
+    const { data: inserted, error: insertError } = await adminClient
+      .from('content_nodes')
+      .insert(payload)
+      .select('*')
+      .single();
+
+    if (insertError) {
+      throw new CourseBuilderError('Failed to duplicate node', 500, {
+        details: insertError.message,
+      });
+    }
+
+    const newNodeId = inserted.id as number;
+
+    if (subtree.blocks.length > 0) {
+      const blockPayload = subtree.blocks.map((block) => ({
+        node_id: newNodeId,
+        block_type: block.block_type,
+        position: block.position,
+        text_md: block.text_md ?? null,
+        resource_id: block.resource_id ?? null,
+        start_ms: block.start_ms ?? null,
+        end_ms: block.end_ms ?? null,
+        label: block.label ?? null,
+        notes: block.notes ?? null,
+        settings: block.settings ?? null,
+        data: block.data ?? null,
+      }));
+
+      const { error: blockError } = await adminClient
+        .from('content_blocks')
+        .insert(blockPayload);
+
+      if (blockError) {
+        throw new CourseBuilderError('Failed to duplicate content blocks', 500, {
+          details: blockError.message,
+        });
+      }
+    }
+
+    for (const child of subtree.children) {
+      const clonedChildId = await cloneNode(child.subtree, depth + 1);
+
+      const edgePayload = {
+        parent_id: newNodeId,
+        child_id: clonedChildId,
+        position: child.edge.position,
+        is_required: child.edge.is_required ?? true,
+        label: child.edge.label ?? null,
+        notes: child.edge.notes ?? null,
+      };
+
+      const { error: edgeError } = await adminClient
+        .from('node_children')
+        .insert(edgePayload);
+
+      if (edgeError) {
+        throw new CourseBuilderError('Failed to duplicate child relationship', 500, {
+          details: edgeError.message,
+        });
+      }
+    }
+
+    return newNodeId;
+  }
+
+  const newRootId = await cloneNode(sourceSubtree, 0);
+
+  if (options.parentId) {
+    const newRootSubtree = await fetchNodeSubtree(newRootId);
+    await validateNodeRelationship(options.parentId, String(newRootSubtree.node.node_type));
+
+    let position = options.parentEdge?.position ?? null;
+    if (position == null) {
+      const { data: siblings, error: siblingsError } = await adminClient
+        .from('node_children')
+        .select('position')
+        .eq('parent_id', options.parentId)
+        .order('position', { ascending: false })
+        .limit(1);
+
+      if (siblingsError) {
+        throw new CourseBuilderError('Failed to determine insertion position', 500, {
+          details: siblingsError.message,
+        });
+      }
+
+      position = siblings?.[0]?.position != null ? siblings[0].position + 1 : 0;
+    }
+
+    const edgePayload = {
+      parent_id: options.parentId,
+      child_id: newRootId,
+      position,
+      is_required: options.parentEdge?.is_required ?? true,
+      label: options.parentEdge?.label ?? null,
+      notes: options.parentEdge?.notes ?? null,
+    };
+
+    const { error: attachError } = await adminClient
+      .from('node_children')
+      .insert(edgePayload);
+
+    if (attachError) {
+      throw new CourseBuilderError('Failed to attach duplicated node to parent', 500, {
+        details: attachError.message,
+      });
+    }
+
+    return fetchNodeSubtree(options.parentId);
+  }
+
+  return fetchNodeSubtree(newRootId);
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ nodeId: string }> },
+) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const { nodeId } = await context.params;
+    const id = Number(nodeId);
+    if (!Number.isFinite(id) || id <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: nodeId });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const parentInfo = body?.parent ?? null;
+    const title = typeof body?.title === 'string' ? body.title : null;
+
+    const subtree = await cloneSubtree(id, {
+      userId: guard.user.id,
+      parentId: parentInfo?.parent_id ?? null,
+      parentEdge: parentInfo ?? null,
+      titleOverride: title,
+    });
+
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/relocate/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/relocate/route.ts
@@ -10,20 +10,19 @@ import {
   validateNodeRelationship,
 } from '@/lib/courseBuilder';
 
-type RouteContext = {
-  params: { nodeId: string };
-};
-
-export async function PATCH(request: NextRequest, context: RouteContext) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const nodeId = Number(context.params.nodeId);
+    const nodeId = Number(params.nodeId);
     if (!Number.isFinite(nodeId) || nodeId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
     }
 
     const body = await request.json();

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/relocate/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/relocate/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  flattenSubtreeIds,
+  getParentEdge,
+  handleCourseBuilderError,
+  validateNodeRelationship,
+} from '@/lib/courseBuilder';
+
+type RouteContext = {
+  params: { nodeId: string };
+};
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const nodeId = Number(context.params.nodeId);
+    if (!Number.isFinite(nodeId) || nodeId <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: context.params.nodeId });
+    }
+
+    const body = await request.json();
+    const newParentIdValue = body?.new_parent_id ?? body?.parent_id ?? null;
+    const positionValue = body?.position;
+
+    const currentEdge = await getParentEdge(nodeId);
+
+    if (newParentIdValue == null) {
+      if (!currentEdge) {
+        return NextResponse.json({ subtree: await fetchNodeSubtree(nodeId), previousParentSubtree: null });
+      }
+
+      const { error: deleteEdgeError } = await adminClient
+        .from('node_children')
+        .delete()
+        .eq('parent_id', currentEdge.parent_id)
+        .eq('child_id', nodeId);
+
+      if (deleteEdgeError) {
+        throw new CourseBuilderError('Failed to detach node', 500, { details: deleteEdgeError.message });
+      }
+
+      const nodeSubtree = await fetchNodeSubtree(nodeId);
+      let previousParentSubtree = null;
+      if (currentEdge) {
+        previousParentSubtree = await fetchNodeSubtree(currentEdge.parent_id);
+      }
+
+      return NextResponse.json({ subtree: nodeSubtree, previousParentSubtree });
+    }
+
+    const newParentId = Number(newParentIdValue);
+    if (!Number.isFinite(newParentId) || newParentId <= 0) {
+      throw new CourseBuilderError('Invalid new_parent_id', 400, { value: newParentIdValue });
+    }
+
+    if (newParentId === nodeId) {
+      throw new CourseBuilderError('A node cannot become its own parent', 400);
+    }
+
+    const nodeSubtree = await fetchNodeSubtree(nodeId);
+    const descendantIds = new Set(flattenSubtreeIds(nodeSubtree));
+
+    if (descendantIds.has(newParentId)) {
+      throw new CourseBuilderError('Cannot move node beneath one of its descendants', 400, {
+        newParentId,
+      });
+    }
+
+    const parent = await validateNodeRelationship(newParentId, String(nodeSubtree.node.node_type));
+
+    let position = positionValue;
+    if (position == null) {
+      const { data: siblings, error } = await adminClient
+        .from('node_children')
+        .select('position')
+        .eq('parent_id', newParentId)
+        .order('position', { ascending: false })
+        .limit(1);
+
+      if (error) {
+        throw new CourseBuilderError('Failed to determine new position', 500, { details: error.message });
+      }
+
+      position = siblings?.[0]?.position != null ? siblings[0].position + 1 : 0;
+    }
+
+    const edgePayload = {
+      parent_id: parent.id,
+      child_id: nodeId,
+      position,
+      is_required: body?.is_required ?? currentEdge?.is_required ?? true,
+      label: body?.label ?? currentEdge?.label ?? null,
+      notes: body?.notes ?? currentEdge?.notes ?? null,
+    };
+
+    const { error: upsertError } = await adminClient
+      .from('node_children')
+      .upsert(edgePayload, { onConflict: 'parent_id,child_id' });
+
+    if (upsertError) {
+      throw new CourseBuilderError('Failed to attach node to new parent', 500, { details: upsertError.message });
+    }
+
+    if (currentEdge && currentEdge.parent_id !== parent.id) {
+      const { error: deleteOldEdgeError } = await adminClient
+        .from('node_children')
+        .delete()
+        .eq('parent_id', currentEdge.parent_id)
+        .eq('child_id', nodeId);
+
+      if (deleteOldEdgeError) {
+        throw new CourseBuilderError('Failed to remove node from previous parent', 500, {
+          details: deleteOldEdgeError.message,
+        });
+      }
+    }
+
+    const newParentSubtree = await fetchNodeSubtree(parent.id);
+    let previousParentSubtree = null;
+    if (currentEdge && currentEdge.parent_id !== parent.id) {
+      previousParentSubtree = await fetchNodeSubtree(currentEdge.parent_id);
+    }
+
+    return NextResponse.json({ subtree: newParentSubtree, previousParentSubtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/relocate/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/relocate/route.ts
@@ -12,7 +12,7 @@ import {
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -20,33 +20,34 @@ export async function PATCH(
   }
 
   try {
-    const nodeId = Number(params.nodeId);
-    if (!Number.isFinite(nodeId) || nodeId <= 0) {
-      throw new CourseBuilderError('Invalid node id', 400, { value: params.nodeId });
+    const { nodeId } = await context.params;
+    const nodeIdNumber = Number(nodeId);
+    if (!Number.isFinite(nodeIdNumber) || nodeIdNumber <= 0) {
+      throw new CourseBuilderError('Invalid node id', 400, { value: nodeId });
     }
 
     const body = await request.json();
     const newParentIdValue = body?.new_parent_id ?? body?.parent_id ?? null;
     const positionValue = body?.position;
 
-    const currentEdge = await getParentEdge(nodeId);
+    const currentEdge = await getParentEdge(nodeIdNumber);
 
     if (newParentIdValue == null) {
       if (!currentEdge) {
-        return NextResponse.json({ subtree: await fetchNodeSubtree(nodeId), previousParentSubtree: null });
+        return NextResponse.json({ subtree: await fetchNodeSubtree(nodeIdNumber), previousParentSubtree: null });
       }
 
       const { error: deleteEdgeError } = await adminClient
         .from('node_children')
         .delete()
         .eq('parent_id', currentEdge.parent_id)
-        .eq('child_id', nodeId);
+        .eq('child_id', nodeIdNumber);
 
       if (deleteEdgeError) {
         throw new CourseBuilderError('Failed to detach node', 500, { details: deleteEdgeError.message });
       }
 
-      const nodeSubtree = await fetchNodeSubtree(nodeId);
+      const nodeSubtree = await fetchNodeSubtree(nodeIdNumber);
       let previousParentSubtree = null;
       if (currentEdge) {
         previousParentSubtree = await fetchNodeSubtree(currentEdge.parent_id);
@@ -60,11 +61,11 @@ export async function PATCH(
       throw new CourseBuilderError('Invalid new_parent_id', 400, { value: newParentIdValue });
     }
 
-    if (newParentId === nodeId) {
+    if (newParentId === nodeIdNumber) {
       throw new CourseBuilderError('A node cannot become its own parent', 400);
     }
 
-    const nodeSubtree = await fetchNodeSubtree(nodeId);
+    const nodeSubtree = await fetchNodeSubtree(nodeIdNumber);
     const descendantIds = new Set(flattenSubtreeIds(nodeSubtree));
 
     if (descendantIds.has(newParentId)) {
@@ -93,7 +94,7 @@ export async function PATCH(
 
     const edgePayload = {
       parent_id: parent.id,
-      child_id: nodeId,
+      child_id: nodeIdNumber,
       position,
       is_required: body?.is_required ?? currentEdge?.is_required ?? true,
       label: body?.label ?? currentEdge?.label ?? null,
@@ -113,7 +114,7 @@ export async function PATCH(
         .from('node_children')
         .delete()
         .eq('parent_id', currentEdge.parent_id)
-        .eq('child_id', nodeId);
+        .eq('child_id', nodeIdNumber);
 
       if (deleteOldEdgeError) {
         throw new CourseBuilderError('Failed to remove node from previous parent', 500, {

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
@@ -10,10 +10,6 @@ import {
   handleCourseBuilderError,
 } from '@/lib/courseBuilder';
 
-type RouteContext = {
-  params: { nodeId: string };
-};
-
 function parseNodeId(value: string) {
   const id = Number(value);
   if (!Number.isFinite(id) || id <= 0) {
@@ -22,14 +18,17 @@ function parseNodeId(value: string) {
   return id;
 }
 
-export async function GET(request: NextRequest, context: RouteContext) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const nodeId = parseNodeId(context.params.nodeId);
+    const nodeId = parseNodeId(params.nodeId);
     const subtree = await fetchNodeSubtree(nodeId);
     return NextResponse.json({ subtree });
   } catch (error: unknown) {
@@ -37,14 +36,17 @@ export async function GET(request: NextRequest, context: RouteContext) {
   }
 }
 
-export async function PATCH(request: NextRequest, context: RouteContext) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const nodeId = parseNodeId(context.params.nodeId);
+    const nodeId = parseNodeId(params.nodeId);
     const body = await request.json();
     const updates = body?.updates ?? body;
 
@@ -94,14 +96,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   }
 }
 
-export async function DELETE(request: NextRequest, context: RouteContext) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { nodeId: string } },
+) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
     return guard.res;
   }
 
   try {
-    const nodeId = parseNodeId(context.params.nodeId);
+    const nodeId = parseNodeId(params.nodeId);
 
     const subtree = await fetchNodeSubtree(nodeId);
     const stats = collectSubtreeStats(subtree);

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  collectSubtreeStats,
+  fetchNodeSubtree,
+  flattenSubtreeIds,
+  getParentEdge,
+  handleCourseBuilderError,
+} from '@/lib/courseBuilder';
+
+type RouteContext = {
+  params: { nodeId: string };
+};
+
+function parseNodeId(value: string) {
+  const id = Number(value);
+  if (!Number.isFinite(id) || id <= 0) {
+    throw new CourseBuilderError('Invalid node id', 400, { value });
+  }
+  return id;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const nodeId = parseNodeId(context.params.nodeId);
+    const subtree = await fetchNodeSubtree(nodeId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const nodeId = parseNodeId(context.params.nodeId);
+    const body = await request.json();
+    const updates = body?.updates ?? body;
+
+    if (!updates || typeof updates !== 'object') {
+      throw new CourseBuilderError('Missing update payload', 400);
+    }
+
+    const allowedFields = [
+      'title',
+      'slug',
+      'state',
+      'description',
+      'hero_image',
+      'icon',
+      'objectives',
+      'metadata',
+      'owner_id',
+    ];
+
+    const updatePayload: Record<string, unknown> = {};
+    for (const key of allowedFields) {
+      if (key in updates) {
+        updatePayload[key] = updates[key];
+      }
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      throw new CourseBuilderError('No valid fields provided for update', 400);
+    }
+
+    updatePayload.updated_at = new Date().toISOString();
+    updatePayload.updated_by = guard.user.id;
+
+    const { error } = await adminClient
+      .from('content_nodes')
+      .update(updatePayload)
+      .eq('id', nodeId);
+
+    if (error) {
+      throw new CourseBuilderError('Failed to update node', 500, { details: error.message });
+    }
+
+    const subtree = await fetchNodeSubtree(nodeId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const nodeId = parseNodeId(context.params.nodeId);
+
+    const subtree = await fetchNodeSubtree(nodeId);
+    const stats = collectSubtreeStats(subtree);
+    const nodeIds = flattenSubtreeIds(subtree);
+    const parentEdge = await getParentEdge(nodeId);
+
+    const { error: deleteError } = await adminClient
+      .from('content_nodes')
+      .delete()
+      .in('id', nodeIds);
+
+    if (deleteError) {
+      throw new CourseBuilderError('Failed to delete node subtree', 500, { details: deleteError.message });
+    }
+
+    let parentSubtree = null;
+    if (parentEdge) {
+      parentSubtree = await fetchNodeSubtree(parentEdge.parent_id);
+    }
+
+    const totalNodes = Object.values(stats.nodeCounts).reduce((sum, value) => sum + Number(value), 0);
+    const totalBlocks = Object.values(stats.blockCounts).reduce((sum, value) => sum + Number(value), 0);
+
+    return NextResponse.json({
+      deleted: {
+        nodes: {
+          total: totalNodes,
+          byType: stats.nodeCounts,
+        },
+        blocks: {
+          total: totalBlocks,
+          byType: stats.blockCounts,
+        },
+      },
+      parentSubtree,
+    });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/route.ts
@@ -20,7 +20,7 @@ function parseNodeId(value: string) {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -28,7 +28,8 @@ export async function GET(
   }
 
   try {
-    const nodeId = parseNodeId(params.nodeId);
+    const { nodeId: nodeIdParam } = await context.params;
+    const nodeId = parseNodeId(nodeIdParam);
     const subtree = await fetchNodeSubtree(nodeId);
     return NextResponse.json({ subtree });
   } catch (error: unknown) {
@@ -38,7 +39,7 @@ export async function GET(
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -46,7 +47,8 @@ export async function PATCH(
   }
 
   try {
-    const nodeId = parseNodeId(params.nodeId);
+    const { nodeId: nodeIdParam } = await context.params;
+    const nodeId = parseNodeId(nodeIdParam);
     const body = await request.json();
     const updates = body?.updates ?? body;
 
@@ -98,7 +100,7 @@ export async function PATCH(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { nodeId: string } },
+  context: { params: Promise<{ nodeId: string }> },
 ) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {
@@ -106,7 +108,8 @@ export async function DELETE(
   }
 
   try {
-    const nodeId = parseNodeId(params.nodeId);
+    const { nodeId: nodeIdParam } = await context.params;
+    const nodeId = parseNodeId(nodeIdParam);
 
     const subtree = await fetchNodeSubtree(nodeId);
     const stats = collectSubtreeStats(subtree);

--- a/src/app/api/admin/course-builder/nodes/route.ts
+++ b/src/app/api/admin/course-builder/nodes/route.ts
@@ -8,6 +8,86 @@ import {
   validateNodeRelationship,
 } from '@/lib/courseBuilder';
 
+async function fetchRootNodeIds(nodeType?: string) {
+  let query = adminClient
+    .from('content_nodes')
+    .select('id, node_type, title')
+    .order('title', { ascending: true });
+
+  if (nodeType) {
+    query = query.eq('node_type', nodeType);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new CourseBuilderError('Failed to load content nodes', 500, {
+      details: error.message,
+    });
+  }
+
+  return (data ?? []) as { id: number; node_type: string; title: string }[];
+}
+
+async function searchNodes(term: string | null) {
+  const trimmed = term?.trim();
+  let query = adminClient
+    .from('content_nodes')
+    .select('id,title,node_type,state,slug')
+    .order('updated_at', { ascending: false })
+    .limit(50);
+
+  if (trimmed && trimmed.length > 0) {
+    query = query.ilike('title', `%${trimmed}%`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new CourseBuilderError('Failed to search nodes', 500, {
+      details: error.message,
+    });
+  }
+
+  return (data ?? []) as Array<{
+    id: number;
+    title: string;
+    node_type: string;
+    state: string | null;
+    slug: string | null;
+  }>;
+}
+
+export async function GET(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const url = new URL(request.url);
+    const mode = url.searchParams.get('mode');
+
+    if (mode === 'search') {
+      const nodes = await searchNodes(url.searchParams.get('q'));
+      return NextResponse.json({ nodes });
+    }
+
+    const rootType = url.searchParams.get('rootType') ?? undefined;
+    const ids = await fetchRootNodeIds(rootType);
+
+    const subtrees = [] as Awaited<ReturnType<typeof fetchNodeSubtree>>[];
+    for (const row of ids) {
+      const subtree = await fetchNodeSubtree(row.id);
+      subtrees.push(subtree);
+    }
+
+    return NextResponse.json({ subtrees });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}
+
 export async function POST(request: NextRequest) {
   const guard = await requireAdmin(request);
   if (!guard.ok) {

--- a/src/app/api/admin/course-builder/nodes/route.ts
+++ b/src/app/api/admin/course-builder/nodes/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+  validateNodeRelationship,
+} from '@/lib/courseBuilder';
+
+export async function POST(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const body = await request.json();
+    const { node, parent } = body ?? {};
+
+    if (!node || typeof node !== 'object') {
+      throw new CourseBuilderError('Missing node payload', 400);
+    }
+
+    if (!node.node_type || typeof node.node_type !== 'string') {
+      throw new CourseBuilderError('node.node_type is required', 400);
+    }
+
+    if (!node.title || typeof node.title !== 'string') {
+      throw new CourseBuilderError('node.title is required', 400);
+    }
+
+    const timestamp = new Date().toISOString();
+
+    const insertPayload = {
+      state: 'draft',
+      ...node,
+      created_at: timestamp,
+      updated_at: timestamp,
+      created_by: guard.user.id,
+      updated_by: guard.user.id,
+    };
+
+    const { data: createdNode, error: insertError } = await adminClient
+      .from('content_nodes')
+      .insert(insertPayload)
+      .select('*')
+      .single();
+
+    if (insertError) {
+      throw new CourseBuilderError('Failed to create node', 500, { details: insertError.message });
+    }
+
+    if (parent?.parent_id) {
+      await validateNodeRelationship(parent.parent_id, createdNode.node_type);
+
+      let position = parent.position;
+      if (position == null) {
+        const { data: siblings, error: siblingsError } = await adminClient
+          .from('node_children')
+          .select('position')
+          .eq('parent_id', parent.parent_id)
+          .order('position', { ascending: false })
+          .limit(1);
+
+        if (siblingsError) {
+          throw new CourseBuilderError('Failed to determine child position', 500, {
+            details: siblingsError.message,
+          });
+        }
+
+        position = siblings?.[0]?.position != null ? siblings[0].position + 1 : 0;
+      }
+
+      const edgePayload = {
+        parent_id: parent.parent_id,
+        child_id: createdNode.id,
+        position,
+        is_required: parent.is_required ?? true,
+        label: parent.label ?? null,
+        notes: parent.notes ?? null,
+      };
+
+      const { error: edgeError } = await adminClient.from('node_children').insert(edgePayload);
+
+      if (edgeError) {
+        throw new CourseBuilderError('Failed to attach node to parent', 500, { details: edgeError.message });
+      }
+
+      const subtree = await fetchNodeSubtree(parent.parent_id);
+      return NextResponse.json({ subtree });
+    }
+
+    const subtree = await fetchNodeSubtree(createdNode.id);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/rules/route.ts
+++ b/src/app/api/admin/course-builder/rules/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { CourseBuilderError, adminClient, handleCourseBuilderError } from '@/lib/courseBuilder';
+
+export async function GET(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const { data, error } = await adminClient
+      .from('node_edge_rules')
+      .select('parent_type, child_kind, child_type')
+      .order('parent_type', { ascending: true })
+      .order('child_kind', { ascending: true })
+      .order('child_type', { ascending: true });
+
+    if (error) {
+      throw new CourseBuilderError('Failed to load node edge rules', 500, {
+        details: error.message,
+      });
+    }
+
+    return NextResponse.json({ rules: data ?? [] });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/components/admin/CourseBuilderAdmin.tsx
+++ b/src/components/admin/CourseBuilderAdmin.tsx
@@ -706,6 +706,29 @@ export default function CourseBuilderAdmin() {
     setDeleteDialog((prev) => ({ ...prev, subtree: prev.subtree }));
   }, [deleteDialog.open, deleteDialog.subtree]);
 
+  const ensureResource = useCallback(
+    async (resourceId: number) => {
+      if (resourceCache[resourceId]) {
+        return resourceCache[resourceId];
+      }
+      const { data, error: fetchError } = await supabase
+        .from('resources')
+        .select('id,title,type,state,thumbnail,duration,url')
+        .eq('id', resourceId)
+        .maybeSingle();
+      if (fetchError) {
+        throw new Error(fetchError.message);
+      }
+      if (data) {
+        const row = data as ResourceRow;
+        setResourceCache((prev) => ({ ...prev, [resourceId]: row }));
+        return row;
+      }
+      return null;
+    },
+    [resourceCache],
+  );
+
   useEffect(() => {
     if (!selectedSubtree) return;
     const resourceIds = selectedSubtree.blocks
@@ -884,29 +907,6 @@ export default function CourseBuilderAdmin() {
       }
     },
     [completeSaving, failSaving, startSaving],
-  );
-
-  const ensureResource = useCallback(
-    async (resourceId: number) => {
-      if (resourceCache[resourceId]) {
-        return resourceCache[resourceId];
-      }
-      const { data, error: fetchError } = await supabase
-        .from('resources')
-        .select('id,title,type,state,thumbnail,duration,url')
-        .eq('id', resourceId)
-        .maybeSingle();
-      if (fetchError) {
-        throw new Error(fetchError.message);
-      }
-      if (data) {
-        const row = data as ResourceRow;
-        setResourceCache((prev) => ({ ...prev, [resourceId]: row }));
-        return row;
-      }
-      return null;
-    },
-    [resourceCache],
   );
 
   const flushBlockUpdate = useCallback(

--- a/src/components/admin/CourseBuilderAdmin.tsx
+++ b/src/components/admin/CourseBuilderAdmin.tsx
@@ -122,6 +122,7 @@ type ResourceRow = {
   state: string | null;
   thumbnail: string | null;
   duration: number | null;
+  url: string | null;
 };
 
 const NODE_ICONS: Partial<Record<NodeType, ReactElement>> = {
@@ -402,7 +403,7 @@ function ResourcePickerDialog({ open, onClose, onSelect }: ResourcePickerProps) 
       try {
         let request = supabase
           .from('resources')
-          .select('id,title,type,state,thumbnail,duration')
+          .select('id,title,type,state,thumbnail,duration,url')
           .order('updated_at', { ascending: false })
           .limit(50);
         const trimmed = term.trim();
@@ -451,7 +452,15 @@ function ResourcePickerDialog({ open, onClose, onSelect }: ResourcePickerProps) 
               <ListItem
                 key={row.id}
                 secondaryAction={
-                  <IconButton edge="end" onClick={() => window.open(`/resources/${row.id}`, '_blank')}>
+                  <IconButton
+                    edge="end"
+                    disabled={!row.url}
+                    onClick={() => {
+                      if (row.url) {
+                        window.open(row.url, '_blank', 'noopener,noreferrer');
+                      }
+                    }}
+                  >
                     <OpenInNewIcon fontSize="small" />
                   </IconButton>
                 }
@@ -1212,6 +1221,7 @@ export default function CourseBuilderAdmin() {
                                               state: null,
                                               thumbnail: null,
                                               duration: null,
+                                              url: null,
                                             }
                                           : null,
                                         label: block.label ?? '',

--- a/src/components/admin/CourseBuilderAdmin.tsx
+++ b/src/components/admin/CourseBuilderAdmin.tsx
@@ -1,0 +1,1787 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MouseEvent, ReactElement } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Paper,
+  Select,
+  Snackbar,
+  Stack,
+  Tab,
+  Tabs,
+  TextField,
+  Tooltip,
+  Typography,
+  Checkbox,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import AddIcon from '@mui/icons-material/Add';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import ArticleIcon from '@mui/icons-material/Article';
+import LayersIcon from '@mui/icons-material/Layers';
+import CollectionsBookmarkIcon from '@mui/icons-material/CollectionsBookmark';
+import PlaylistPlayIcon from '@mui/icons-material/PlaylistPlay';
+import TextFieldsIcon from '@mui/icons-material/TextFields';
+import VideoLibraryIcon from '@mui/icons-material/VideoLibrary';
+import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
+import PreviewIcon from '@mui/icons-material/Preview';
+import CloseIcon from '@mui/icons-material/Close';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import StorageIcon from '@mui/icons-material/Storage';
+import { supabase } from '@/lib/supabaseClient';
+
+type NodeType = 'course' | 'lesson' | 'chapter' | 'collection' | 'playlist';
+type NodeState = 'draft' | 'published' | 'archived';
+type BlockType = 'text' | 'asset' | 'divider';
+
+type ContentNode = {
+  id: number;
+  node_type: NodeType;
+  title: string;
+  slug: string | null;
+  state: NodeState;
+  description: string | null;
+  hero_image: string | null;
+  icon: string | null;
+  objectives: string | null;
+  metadata: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+type NodeChild = {
+  parent_id: number;
+  child_id: number;
+  position: number;
+  is_required: boolean | null;
+  label: string | null;
+  notes: string | null;
+};
+
+type ContentBlock = {
+  id: number;
+  node_id: number;
+  block_type: BlockType;
+  position: number;
+  text_md: string | null;
+  resource_id: number | null;
+  start_ms: number | null;
+  end_ms: number | null;
+  label: string | null;
+  notes: string | null;
+  settings: Record<string, unknown> | null;
+  data: Record<string, unknown> | null;
+};
+
+type NodeSubtree = {
+  node: ContentNode;
+  blocks: ContentBlock[];
+  children: Array<{
+    edge: NodeChild;
+    subtree: NodeSubtree;
+  }>;
+};
+
+type NodeEdgeRule = {
+  parent_type: string;
+  child_kind: string;
+  child_type: string;
+};
+
+type ResourceRow = {
+  id: number;
+  title: string;
+  type: string | null;
+  state: string | null;
+  thumbnail: string | null;
+  duration: number | null;
+};
+
+const NODE_ICONS: Partial<Record<NodeType, ReactElement>> = {
+  course: <MenuBookIcon fontSize="small" />,
+  lesson: <ArticleIcon fontSize="small" />,
+  chapter: <LayersIcon fontSize="small" />,
+  collection: <CollectionsBookmarkIcon fontSize="small" />,
+  playlist: <PlaylistPlayIcon fontSize="small" />,
+};
+
+const BLOCK_ICONS: Record<BlockType, ReactElement> = {
+  text: <TextFieldsIcon fontSize="small" />,
+  asset: <VideoLibraryIcon fontSize="small" />,
+  divider: <HorizontalRuleIcon fontSize="small" />,
+};
+
+const STATE_COLORS: Record<NodeState, 'default' | 'success' | 'warning'> = {
+  draft: 'default',
+  published: 'success',
+  archived: 'warning',
+};
+
+function matchesQuery(value: string, query: string) {
+  if (!query) return true;
+  return value.toLowerCase().includes(query.toLowerCase());
+}
+
+function cloneSubtree(subtree: NodeSubtree): NodeSubtree {
+  return {
+    node: { ...subtree.node },
+    blocks: subtree.blocks.map((block) => ({ ...block })),
+    children: subtree.children.map((child) => ({
+      edge: { ...child.edge },
+      subtree: cloneSubtree(child.subtree),
+    })),
+  };
+}
+
+function replaceSubtree(
+  tree: NodeSubtree,
+  updated: NodeSubtree,
+): { next: NodeSubtree; replaced: boolean } {
+  if (tree.node.id === updated.node.id) {
+    return { next: updated, replaced: true };
+  }
+
+  let replaced = false;
+  const children = tree.children.map((child) => {
+    const result = replaceSubtree(child.subtree, updated);
+    if (result.replaced) {
+      replaced = true;
+      return {
+        edge: { ...child.edge },
+        subtree: result.next,
+      };
+    }
+    return child;
+  });
+
+  if (!replaced) {
+    return { next: tree, replaced: false };
+  }
+
+  return {
+    next: {
+      node: { ...tree.node },
+      blocks: tree.blocks.map((block) => ({ ...block })),
+      children,
+    },
+    replaced: true,
+  };
+}
+
+function mergeSubtree(list: NodeSubtree[], updated: NodeSubtree) {
+  let found = false;
+  const next = list.map((tree) => {
+    const result = replaceSubtree(tree, updated);
+    if (result.replaced) {
+      found = true;
+      return result.next;
+    }
+    return tree;
+  });
+
+  if (!found) {
+    next.push(updated);
+  }
+
+  return next;
+}
+
+function pruneTree(tree: NodeSubtree, nodeId: number): { next: NodeSubtree; removed: boolean } {
+  let removed = false;
+  const children = tree.children
+    .map((child) => {
+      if (child.subtree.node.id === nodeId) {
+        removed = true;
+        return null;
+      }
+      const result = pruneTree(child.subtree, nodeId);
+      if (result.removed) {
+        removed = true;
+        return {
+          edge: { ...child.edge },
+          subtree: result.next,
+        };
+      }
+      return child;
+    })
+    .filter(Boolean) as NodeSubtree['children'];
+
+  if (!removed) {
+    return { next: tree, removed: false };
+  }
+
+  return {
+    next: {
+      node: { ...tree.node },
+      blocks: tree.blocks.map((block) => ({ ...block })),
+      children,
+    },
+    removed: true,
+  };
+}
+
+function removeSubtree(list: NodeSubtree[], nodeId: number) {
+  const next: NodeSubtree[] = [];
+  for (const tree of list) {
+    if (tree.node.id === nodeId) {
+      continue;
+    }
+    const result = pruneTree(tree, nodeId);
+    if (result.removed) {
+      next.push(result.next);
+    } else {
+      next.push(tree);
+    }
+  }
+  return next;
+}
+
+function findSubtree(list: NodeSubtree[], nodeId: number): NodeSubtree | null {
+  for (const tree of list) {
+    if (tree.node.id === nodeId) return tree;
+    for (const child of tree.children) {
+      const found = findSubtree([child.subtree], nodeId);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function findParentEdge(list: NodeSubtree[], nodeId: number): NodeChild | null {
+  for (const tree of list) {
+    for (const child of tree.children) {
+      if (child.edge.child_id === nodeId) {
+        return child.edge;
+      }
+      const nested = findParentEdge([child.subtree], nodeId);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+function collectStats(subtree: NodeSubtree) {
+  const nodeCounts = new Map<string, number>();
+  const blockCounts = new Map<string, number>();
+
+  const walk = (node: NodeSubtree) => {
+    const type = node.node.node_type ?? 'unknown';
+    nodeCounts.set(type, (nodeCounts.get(type) ?? 0) + 1);
+    for (const block of node.blocks) {
+      const key = block.block_type ?? 'unknown';
+      blockCounts.set(key, (blockCounts.get(key) ?? 0) + 1);
+    }
+    for (const child of node.children) {
+      walk(child.subtree);
+    }
+  };
+
+  walk(subtree);
+
+  return {
+    nodes: Array.from(nodeCounts.entries()).map(([type, count]) => ({ type, count })),
+    blocks: Array.from(blockCounts.entries()).map(([type, count]) => ({ type, count })),
+  };
+}
+
+type TreeNodeProps = {
+  subtree: NodeSubtree;
+  level: number;
+  expanded: Set<number>;
+  toggle: (id: number) => void;
+  onSelect: (id: number) => void;
+  selectedId: number | null;
+  search: string;
+  onMenu: (event: MouseEvent<HTMLElement>, nodeId: number) => void;
+};
+
+function TreeNode({ subtree, level, expanded, toggle, onSelect, selectedId, search, onMenu }: TreeNodeProps) {
+  const hasChildren = subtree.children.length > 0;
+  const isExpanded = expanded.has(subtree.node.id) || (!!search && hasChildren);
+  const matches = matchesQuery(subtree.node.title ?? '', search);
+  const childMatches = subtree.children.some((child) => matchesQuery(child.subtree.node.title ?? '', search));
+
+  if (search && !matches && !childMatches) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ pl: level * 1.5, py: 0.5 }}>
+        {hasChildren ? (
+          <IconButton size="small" onClick={() => toggle(subtree.node.id)}>
+            {isExpanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+          </IconButton>
+        ) : (
+          <Box sx={{ width: 32 }} />
+        )}
+        <Chip
+          size="small"
+          icon={NODE_ICONS[subtree.node.node_type] ?? <StorageIcon fontSize="small" />}
+          label={subtree.node.title ?? 'Untitled'}
+          color={selectedId === subtree.node.id ? 'primary' : 'default'}
+          onClick={() => onSelect(subtree.node.id)}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            onMenu(event, subtree.node.id);
+          }}
+          sx={{
+            maxWidth: '100%',
+            '& .MuiChip-label': {
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            },
+          }}
+        />
+        <Chip size="small" label={subtree.node.state} color={STATE_COLORS[subtree.node.state]} variant="outlined" />
+      </Stack>
+      {hasChildren && isExpanded && (
+        <Box>
+          {subtree.children.map((child) => (
+            <TreeNode
+              key={child.subtree.node.id}
+              subtree={child.subtree}
+              level={level + 1}
+              expanded={expanded}
+              toggle={toggle}
+              onSelect={onSelect}
+              selectedId={selectedId}
+              search={search}
+              onMenu={onMenu}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+type ResourcePickerProps = {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (resource: ResourceRow) => void;
+};
+
+function ResourcePickerDialog({ open, onClose, onSelect }: ResourcePickerProps) {
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [rows, setRows] = useState<ResourceRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (term: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        let request = supabase
+          .from('resources')
+          .select('id,title,type,state,thumbnail,duration')
+          .order('updated_at', { ascending: false })
+          .limit(50);
+        const trimmed = term.trim();
+        if (trimmed) {
+          request = request.ilike('title', `%${trimmed}%`);
+        }
+        const { data, error: fetchError } = await request;
+        if (fetchError) {
+          throw new Error(fetchError.message);
+        }
+        setRows((data ?? []) as ResourceRow[]);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to load resources';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (open) void load(query);
+  }, [open, query, load]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Select a resource</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <TextField
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search resources"
+            InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
+          />
+          {loading && (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <CircularProgress size={18} />
+              <Typography variant="body2">Loading resources…</Typography>
+            </Stack>
+          )}
+          {error && <Alert severity="error">{error}</Alert>}
+          <List dense>
+            {rows.map((row) => (
+              <ListItem
+                key={row.id}
+                secondaryAction={
+                  <IconButton edge="end" onClick={() => window.open(`/resources/${row.id}`, '_blank')}>
+                    <OpenInNewIcon fontSize="small" />
+                  </IconButton>
+                }
+                onClick={() => {
+                  onSelect(row);
+                  onClose();
+                }}
+              >
+                <ListItemText
+                  primary={row.title}
+                  secondary={[row.type, row.state].filter(Boolean).join(' · ')}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+type BlockEditorState = {
+  mode: 'create' | 'edit';
+  block: ContentBlock | null;
+  type: BlockType;
+  text_md: string;
+  resource: ResourceRow | null;
+  label: string;
+  start_ms: string;
+  end_ms: string;
+  notes: string;
+  preview: boolean;
+};
+
+const EMPTY_BLOCK: BlockEditorState = {
+  mode: 'create',
+  block: null,
+  type: 'text',
+  text_md: '',
+  resource: null,
+  label: '',
+  start_ms: '',
+  end_ms: '',
+  notes: '',
+  preview: false,
+};
+
+type BlockEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  state: BlockEditorState;
+  onChange: (next: BlockEditorState) => void;
+  onSelectResource: () => void;
+  onSubmit: () => void;
+};
+
+function BlockEditorDialog({ open, onClose, state, onChange, onSelectResource, onSubmit }: BlockEditorProps) {
+  const canSave =
+    state.type === 'divider' ||
+    (state.type === 'text' && state.text_md.trim().length > 0) ||
+    (state.type === 'asset' && state.resource);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>{state.mode === 'create' ? 'Add block' : 'Edit block'}</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={3}>
+          <FormControl fullWidth>
+            <InputLabel id="block-type">Block type</InputLabel>
+            <Select
+              labelId="block-type"
+              label="Block type"
+              value={state.type}
+              onChange={(event) =>
+                onChange({ ...state, type: event.target.value as BlockType, resource: null })
+              }
+            >
+              <MenuItem value="text">Text</MenuItem>
+              <MenuItem value="asset">Resource</MenuItem>
+              <MenuItem value="divider">Divider</MenuItem>
+            </Select>
+          </FormControl>
+
+          {state.type === 'text' && (
+            <Stack spacing={1}>
+              <TextField
+                multiline
+                minRows={6}
+                label="Markdown"
+                value={state.text_md}
+                onChange={(event) => onChange({ ...state, text_md: event.target.value })}
+              />
+              <Button startIcon={<PreviewIcon />} onClick={() => onChange({ ...state, preview: !state.preview })}>
+                {state.preview ? 'Hide preview' : 'Show preview'}
+              </Button>
+              {state.preview && (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Typography sx={{ whiteSpace: 'pre-wrap' }}>{state.text_md || 'Nothing to preview yet.'}</Typography>
+                </Paper>
+              )}
+            </Stack>
+          )}
+
+          {state.type === 'asset' && (
+            <Stack spacing={2}>
+              <Button variant="outlined" startIcon={<SearchIcon />} onClick={onSelectResource}>
+                {state.resource ? 'Change resource' : 'Select resource'}
+              </Button>
+              {state.resource && (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Typography variant="subtitle1">{state.resource.title}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {[state.resource.type, state.resource.state].filter(Boolean).join(' · ')}
+                  </Typography>
+                </Paper>
+              )}
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                <TextField
+                  label="Start (ms)"
+                  value={state.start_ms}
+                  onChange={(event) => onChange({ ...state, start_ms: event.target.value })}
+                />
+                <TextField
+                  label="End (ms)"
+                  value={state.end_ms}
+                  onChange={(event) => onChange({ ...state, end_ms: event.target.value })}
+                />
+              </Stack>
+              <TextField
+                label="Label"
+                value={state.label}
+                onChange={(event) => onChange({ ...state, label: event.target.value })}
+              />
+              <TextField
+                label="Notes"
+                value={state.notes}
+                onChange={(event) => onChange({ ...state, notes: event.target.value })}
+              />
+            </Stack>
+          )}
+
+          {state.type === 'divider' && (
+            <Alert severity="info" icon={<HorizontalRuleIcon fontSize="small" />}>
+              Divider blocks do not include additional content.
+            </Alert>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button startIcon={<CloseIcon />} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button startIcon={<SaveIcon />} variant="contained" disabled={!canSave} onClick={onSubmit}>
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+type SnackbarState = { message: string; severity: 'success' | 'error' | 'info' } | null;
+
+type DeleteDialogState = {
+  open: boolean;
+  nodeId: number | null;
+  subtree: NodeSubtree | null;
+};
+
+type AddChildDialogState = {
+  open: boolean;
+  parentId: number | null;
+  mode: 'create' | 'attach';
+};
+
+type DuplicateDialogState = {
+  open: boolean;
+  nodeId: number | null;
+};
+
+export default function CourseBuilderAdmin() {
+  const [trees, setTrees] = useState<NodeSubtree[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [rules, setRules] = useState<NodeEdgeRule[]>([]);
+  const [panelTab, setPanelTab] = useState(0);
+  const [snack, setSnack] = useState<SnackbarState>(null);
+  const [detailsForm, setDetailsForm] = useState({
+    title: '',
+    slug: '',
+    description: '',
+    state: 'draft' as NodeState,
+    hero_image: '',
+    icon: '',
+    objectives: '',
+    metadata: '',
+  });
+  const [blockEditor, setBlockEditor] = useState<BlockEditorState>(EMPTY_BLOCK);
+  const [blockDialogOpen, setBlockDialogOpen] = useState(false);
+  const [resourceDialogOpen, setResourceDialogOpen] = useState(false);
+  const [deleteDialog, setDeleteDialog] = useState<DeleteDialogState>({ open: false, nodeId: null, subtree: null });
+  const [addChildDialog, setAddChildDialog] = useState<AddChildDialogState>({ open: false, parentId: null, mode: 'create' });
+  const [duplicateDialog, setDuplicateDialog] = useState<DuplicateDialogState>({ open: false, nodeId: null });
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuNodeId, setMenuNodeId] = useState<number | null>(null);
+  const optimisticSnapshot = useRef<NodeSubtree[] | null>(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [treeRes, rulesRes] = await Promise.all([
+        fetch('/api/admin/course-builder/nodes?rootType=course'),
+        fetch('/api/admin/course-builder/rules'),
+      ]);
+
+      if (!treeRes.ok) {
+        const body = await treeRes.json().catch(() => ({ error: 'Failed to load course tree' }));
+        throw new Error(body.error ?? 'Failed to load course tree');
+      }
+
+      if (!rulesRes.ok) {
+        const body = await rulesRes.json().catch(() => ({ error: 'Failed to load edge rules' }));
+        throw new Error(body.error ?? 'Failed to load edge rules');
+      }
+
+      const treePayload = (await treeRes.json()) as { subtrees: NodeSubtree[] };
+      const rulesPayload = (await rulesRes.json()) as { rules: NodeEdgeRule[] };
+
+      setTrees(treePayload.subtrees ?? []);
+      setRules(rulesPayload.rules ?? []);
+      const first = treePayload.subtrees?.[0]?.node.id ?? null;
+      setSelectedId(first);
+      setExpanded(new Set(treePayload.subtrees.map((subtree) => subtree.node.id)));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load data';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const selectedSubtree = useMemo(() => {
+    if (selectedId == null) return null;
+    return findSubtree(trees, selectedId);
+  }, [trees, selectedId]);
+
+  useEffect(() => {
+    if (!selectedSubtree) return;
+    setDetailsForm({
+      title: selectedSubtree.node.title ?? '',
+      slug: selectedSubtree.node.slug ?? '',
+      description: selectedSubtree.node.description ?? '',
+      state: (selectedSubtree.node.state ?? 'draft') as NodeState,
+      hero_image: selectedSubtree.node.hero_image ?? '',
+      icon: selectedSubtree.node.icon ?? '',
+      objectives: selectedSubtree.node.objectives ?? '',
+      metadata: selectedSubtree.node.metadata ? JSON.stringify(selectedSubtree.node.metadata, null, 2) : '',
+    });
+    setPanelTab(0);
+  }, [selectedSubtree]);
+
+  const toggleExpand = useCallback((id: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleMenu = useCallback((event: MouseEvent<HTMLElement>, nodeId: number) => {
+    setMenuAnchor(event.currentTarget);
+    setMenuNodeId(nodeId);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setMenuAnchor(null);
+    setMenuNodeId(null);
+  }, []);
+
+  const runMutation = useCallback(
+    async (
+      request: () => Promise<NodeSubtree | { subtree?: NodeSubtree; parentSubtree?: NodeSubtree | null }>,
+      options: { message?: string; optimistic?: (prev: NodeSubtree[]) => NodeSubtree[] } = {},
+    ) => {
+      if (options.optimistic) {
+        setTrees((prev) => {
+          optimisticSnapshot.current = prev.map((tree) => cloneSubtree(tree));
+          return options.optimistic ? options.optimistic(prev) : prev;
+        });
+      }
+
+      try {
+        const payload = await request();
+        setTrees((prev) => {
+          let next = prev;
+          if ('subtree' in payload && payload.subtree) {
+            next = mergeSubtree(next, payload.subtree);
+          } else if ('node' in payload) {
+            next = mergeSubtree(next, payload as NodeSubtree);
+          }
+          if ('parentSubtree' in payload && payload.parentSubtree) {
+            next = mergeSubtree(next, payload.parentSubtree);
+          }
+          return next;
+        });
+        if (options.message) setSnack({ message: options.message, severity: 'success' });
+      } catch (err) {
+        if (optimisticSnapshot.current) {
+          setTrees(optimisticSnapshot.current);
+        }
+        optimisticSnapshot.current = null;
+        const message = err instanceof Error ? err.message : 'Action failed';
+        setSnack({ message, severity: 'error' });
+        throw err;
+      } finally {
+        optimisticSnapshot.current = null;
+      }
+    },
+    [],
+  );
+
+  const [newChildType, setNewChildType] = useState<string>('lesson');
+  const [newChildTitle, setNewChildTitle] = useState('');
+
+  const allowedChildTypes = useMemo(() => {
+    if (!selectedSubtree) return [] as string[];
+    return Array.from(
+      new Set(
+        rules
+          .filter((rule) => rule.parent_type === selectedSubtree.node.node_type && rule.child_kind === 'node')
+          .map((rule) => rule.child_type),
+      ),
+    );
+  }, [rules, selectedSubtree]);
+
+  const availableChildTypes = useMemo(
+    () => (addChildDialog.parentId ? allowedChildTypes : ['course']),
+    [addChildDialog.parentId, allowedChildTypes],
+  );
+
+  const [searchResults, setSearchResults] = useState<{ loading: boolean; rows: ContentNode[] }>({
+    loading: false,
+    rows: [],
+  });
+
+  const fetchSearch = useCallback(async (term: string) => {
+    setSearchResults({ loading: true, rows: [] });
+    try {
+      const res = await fetch(`/api/admin/course-builder/nodes?mode=search&q=${encodeURIComponent(term)}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: 'Failed to search nodes' }));
+        throw new Error(body.error ?? 'Failed to search nodes');
+      }
+      const payload = (await res.json()) as { nodes: ContentNode[] };
+      setSearchResults({ loading: false, rows: payload.nodes ?? [] });
+    } catch (err) {
+      console.error(err);
+      setSearchResults({ loading: false, rows: [] });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (addChildDialog.open && addChildDialog.mode === 'create') {
+      setNewChildType(availableChildTypes[0] ?? 'course');
+      setNewChildTitle('');
+    }
+    if (!addChildDialog.open) {
+      setSearchResults({ loading: false, rows: [] });
+    }
+  }, [addChildDialog, availableChildTypes]);
+
+  const deleteStats = useMemo(() => {
+    return deleteDialog.subtree ? collectStats(deleteDialog.subtree) : null;
+  }, [deleteDialog.subtree]);
+
+  if (loading) {
+    return (
+      <Paper sx={{ p: 4, display: 'grid', placeItems: 'center', minHeight: 320 }}>
+        <Stack spacing={2} alignItems="center">
+          <CircularProgress />
+          <Typography variant="body2">Loading course builder…</Typography>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  if (error) {
+    return (
+      <Paper sx={{ p: 4 }}>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+        <Button startIcon={<RefreshIcon />} onClick={() => void loadData()}>
+          Retry
+        </Button>
+      </Paper>
+    );
+  }
+
+  return (
+    <Stack direction={{ xs: 'column', lg: 'row' }} spacing={3}>
+      <Paper sx={{ flexBasis: 320, flexShrink: 0, p: 2 }} variant="outlined">
+        <Stack spacing={2}>
+          <TextField
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search nodes"
+            InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
+          />
+          <Stack direction="row" spacing={1}>
+            <Button
+              fullWidth
+              startIcon={<AddIcon />}
+              onClick={() => setAddChildDialog({ open: true, parentId: null, mode: 'create' })}
+            >
+              Add Course
+            </Button>
+            <Tooltip title="Refresh">
+              <IconButton onClick={() => void loadData()}>
+                <RefreshIcon />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+          <Divider />
+          <Box sx={{ maxHeight: 600, overflowY: 'auto', pr: 1 }}>
+            {trees.map((tree) => (
+              <TreeNode
+                key={tree.node.id}
+                subtree={tree}
+                level={0}
+                expanded={expanded}
+                toggle={toggleExpand}
+                onSelect={setSelectedId}
+                selectedId={selectedId}
+                search={search}
+                onMenu={handleMenu}
+              />
+            ))}
+          </Box>
+        </Stack>
+      </Paper>
+
+      <Paper sx={{ flex: 1, p: 3 }} variant="outlined">
+        {selectedSubtree ? (
+          <Stack spacing={2}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Typography variant="h6">{selectedSubtree.node.title ?? 'Untitled node'}</Typography>
+              <Tabs value={panelTab} onChange={(_, value) => setPanelTab(value)}>
+                <Tab label="Details" />
+                <Tab label="Children" />
+                <Tab label="Content Blocks" />
+              </Tabs>
+            </Stack>
+
+            {panelTab === 0 && (
+              <Stack spacing={2}>
+                <TextField
+                  label="Title"
+                  value={detailsForm.title}
+                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, title: event.target.value }))}
+                />
+                <TextField
+                  label="Slug"
+                  value={detailsForm.slug}
+                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, slug: event.target.value }))}
+                />
+                <TextField
+                  label="Description"
+                  multiline
+                  minRows={3}
+                  value={detailsForm.description}
+                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, description: event.target.value }))}
+                />
+                <FormControl fullWidth>
+                  <InputLabel id="state-select">State</InputLabel>
+                  <Select
+                    labelId="state-select"
+                    label="State"
+                    value={detailsForm.state}
+                    onChange={(event) =>
+                      setDetailsForm((prev) => ({ ...prev, state: event.target.value as NodeState }))
+                    }
+                  >
+                    <MenuItem value="draft">Draft</MenuItem>
+                    <MenuItem value="published">Published</MenuItem>
+                    <MenuItem value="archived">Archived</MenuItem>
+                  </Select>
+                </FormControl>
+                <TextField
+                  label="Hero image URL"
+                  value={detailsForm.hero_image}
+                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, hero_image: event.target.value }))}
+                />
+                <TextField
+                  label="Icon"
+                  value={detailsForm.icon}
+                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, icon: event.target.value }))}
+                />
+                <TextField
+                  label="Objectives"
+                  multiline
+                  minRows={3}
+                  value={detailsForm.objectives}
+                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, objectives: event.target.value }))}
+                />
+                <TextField
+                  label="Metadata (JSON)"
+                  multiline
+                  minRows={4}
+                  value={detailsForm.metadata}
+                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, metadata: event.target.value }))}
+                />
+                <Button startIcon={<SaveIcon />} variant="contained" onClick={async () => {
+                  if (!selectedSubtree) return;
+                  if (detailsForm.state === 'published') {
+                    const unmet = selectedSubtree.children.filter(
+                      (child) => (child.edge.is_required ?? true) && child.subtree.node.state !== 'published',
+                    );
+                    if (unmet.length > 0) {
+                      setSnack({
+                        message: 'Publish required children before publishing this node.',
+                        severity: 'error',
+                      });
+                      return;
+                    }
+                  }
+
+                  let metadata: Record<string, unknown> | null = null;
+                  if (detailsForm.metadata.trim()) {
+                    try {
+                      metadata = JSON.parse(detailsForm.metadata);
+                    } catch {
+                      setSnack({ message: 'Metadata must be valid JSON', severity: 'error' });
+                      return;
+                    }
+                  }
+
+                  const payload: Record<string, unknown> = {
+                    title: detailsForm.title,
+                    slug: detailsForm.slug || null,
+                    description: detailsForm.description || null,
+                    state: detailsForm.state,
+                    hero_image: detailsForm.hero_image || null,
+                    icon: detailsForm.icon || null,
+                    objectives: detailsForm.objectives || null,
+                    metadata,
+                  };
+
+                  try {
+                    await runMutation(async () => {
+                      const res = await fetch(`/api/admin/course-builder/nodes/${selectedSubtree.node.id}`, {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ updates: payload }),
+                      });
+                      if (!res.ok) {
+                        const body = await res.json().catch(() => ({ error: 'Failed to update node' }));
+                        throw new Error(body.error ?? 'Failed to update node');
+                      }
+                      return (await res.json()) as { subtree: NodeSubtree };
+                    }, { message: 'Node updated' });
+                  } catch (err) {
+                    console.error(err);
+                  }
+                }}>
+                  Save changes
+                </Button>
+              </Stack>
+            )}
+
+            {panelTab === 1 && (
+              <Stack spacing={2}>
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    startIcon={<AddIcon />}
+                    onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'create' })}
+                  >
+                    Create child
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'attach' })}
+                  >
+                    Add existing
+                  </Button>
+                </Stack>
+                <List>
+                  {selectedSubtree.children
+                    .slice()
+                    .sort((a, b) => a.edge.position - b.edge.position)
+                    .map((child, index, arr) => (
+                      <ListItem
+                        key={child.subtree.node.id}
+                        secondaryAction={
+                          <Stack direction="row" spacing={1}>
+                            <Tooltip title="Move up">
+                              <span>
+                                <IconButton
+                                  size="small"
+                                  disabled={index === 0}
+                                  onClick={() =>
+                                    handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'up')
+                                  }
+                                >
+                                  <ArrowUpwardIcon fontSize="small" />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                            <Tooltip title="Move down">
+                              <span>
+                                <IconButton
+                                  size="small"
+                                  disabled={index === arr.length - 1}
+                                  onClick={() =>
+                                    handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'down')
+                                  }
+                                >
+                                  <ArrowDownwardIcon fontSize="small" />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                            <Tooltip title="Remove child">
+                              <IconButton
+                                size="small"
+                                color="error"
+                                onClick={() => handleRemoveChild(selectedSubtree.node.id, child.edge.child_id)}
+                              >
+                                <DeleteIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          </Stack>
+                        }
+                      >
+                        <ListItemIcon>
+                          {NODE_ICONS[child.subtree.node.node_type] ?? <StorageIcon fontSize="small" />}
+                        </ListItemIcon>
+                        <ListItemText
+                          primary={child.subtree.node.title ?? 'Untitled'}
+                          secondary={`${child.subtree.node.node_type} · position ${child.edge.position}`}
+                        />
+                        <Checkbox
+                          checked={child.edge.is_required ?? true}
+                          onChange={(event) =>
+                            handleUpdateChild(selectedSubtree.node.id, child, {
+                              is_required: event.target.checked,
+                            })
+                          }
+                          inputProps={{ 'aria-label': 'Required child toggle' }}
+                        />
+                      </ListItem>
+                    ))}
+                </List>
+              </Stack>
+            )}
+
+            {panelTab === 2 && (
+              <Stack spacing={2}>
+                {selectedSubtree.children.length > 0 ? (
+                  <Alert severity="info">
+                    Content blocks are available only for nodes without child nodes.
+                  </Alert>
+                ) : (
+                  <>
+                    <Stack direction="row" spacing={1}>
+                      <Button
+                        startIcon={<TextFieldsIcon />}
+                        onClick={() => {
+                          setBlockEditor({ ...EMPTY_BLOCK, type: 'text' });
+                          setBlockDialogOpen(true);
+                        }}
+                      >
+                        Add Text
+                      </Button>
+                      <Button
+                        startIcon={<VideoLibraryIcon />}
+                        onClick={() => {
+                          setBlockEditor({ ...EMPTY_BLOCK, type: 'asset' });
+                          setBlockDialogOpen(true);
+                        }}
+                      >
+                        Add Resource
+                      </Button>
+                      <Button
+                        startIcon={<HorizontalRuleIcon />}
+                        onClick={() => {
+                          setBlockEditor({ ...EMPTY_BLOCK, type: 'divider' });
+                          setBlockDialogOpen(true);
+                        }}
+                      >
+                        Add Divider
+                      </Button>
+                    </Stack>
+                    <List>
+                      {selectedSubtree.blocks
+                        .slice()
+                        .sort((a, b) => a.position - b.position)
+                        .map((block, index, arr) => (
+                          <ListItem
+                            key={block.id}
+                            secondaryAction={
+                              <Stack direction="row" spacing={1}>
+                                <Tooltip title="Move up">
+                                  <span>
+                                    <IconButton
+                                      size="small"
+                                      disabled={index === 0}
+                                      onClick={() =>
+                                        handleReorderBlocks(selectedSubtree.node.id, selectedSubtree.blocks, block.id, 'up')
+                                      }
+                                    >
+                                      <ArrowUpwardIcon fontSize="small" />
+                                    </IconButton>
+                                  </span>
+                                </Tooltip>
+                                <Tooltip title="Move down">
+                                  <span>
+                                    <IconButton
+                                      size="small"
+                                      disabled={index === arr.length - 1}
+                                      onClick={() =>
+                                        handleReorderBlocks(
+                                          selectedSubtree.node.id,
+                                          selectedSubtree.blocks,
+                                          block.id,
+                                          'down',
+                                        )
+                                      }
+                                    >
+                                      <ArrowDownwardIcon fontSize="small" />
+                                    </IconButton>
+                                  </span>
+                                </Tooltip>
+                                <Tooltip title="Edit block">
+                                  <IconButton
+                                    size="small"
+                                    onClick={() => {
+                                      setBlockEditor({
+                                        mode: 'edit',
+                                        block,
+                                        type: block.block_type,
+                                        text_md: block.text_md ?? '',
+                                        resource: block.resource_id
+                                          ? {
+                                              id: block.resource_id,
+                                              title: `Resource #${block.resource_id}`,
+                                              type: null,
+                                              state: null,
+                                              thumbnail: null,
+                                              duration: null,
+                                            }
+                                          : null,
+                                        label: block.label ?? '',
+                                        start_ms: block.start_ms != null ? String(block.start_ms) : '',
+                                        end_ms: block.end_ms != null ? String(block.end_ms) : '',
+                                        notes: block.notes ?? '',
+                                        preview: false,
+                                      });
+                                      setBlockDialogOpen(true);
+                                    }}
+                                  >
+                                    <EditIcon fontSize="small" />
+                                  </IconButton>
+                                </Tooltip>
+                                <Tooltip title="Delete block">
+                                  <IconButton size="small" color="error" onClick={() => handleDeleteBlock(block.id)}>
+                                    <DeleteIcon fontSize="small" />
+                                  </IconButton>
+                                </Tooltip>
+                              </Stack>
+                            }
+                          >
+                            <ListItemIcon>{BLOCK_ICONS[block.block_type]}</ListItemIcon>
+                            <ListItemText
+                              primary={`${block.block_type} #${block.position}`}
+                              secondary={
+                                block.block_type === 'text'
+                                  ? (block.text_md ?? '').slice(0, 80)
+                                  : block.block_type === 'asset'
+                                  ? `Resource ${block.resource_id ?? 'unknown'}`
+                                  : 'Divider'
+                              }
+                            />
+                          </ListItem>
+                        ))}
+                    </List>
+                  </>
+                )}
+              </Stack>
+            )}
+          </Stack>
+        ) : (
+          <Typography color="text.secondary">Select a node from the tree to start editing.</Typography>
+        )}
+      </Paper>
+
+      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
+        <MenuItem
+          onClick={() => {
+            if (!menuNodeId) return;
+            const node = findSubtree(trees, menuNodeId);
+            closeMenu();
+            setAddChildDialog({ open: true, parentId: menuNodeId, mode: 'create' });
+            if (node) {
+              setSelectedId(node.node.id);
+            }
+          }}
+        >
+          <AddIcon fontSize="small" sx={{ mr: 1 }} /> Add child
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (!menuNodeId) return;
+            closeMenu();
+            setDuplicateDialog({ open: true, nodeId: menuNodeId });
+          }}
+        >
+          <ContentCopyIcon fontSize="small" sx={{ mr: 1 }} /> Duplicate
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (!menuNodeId) return;
+            closeMenu();
+            const subtree = findSubtree(trees, menuNodeId);
+            setDeleteDialog({ open: true, nodeId: menuNodeId, subtree: subtree ?? null });
+          }}
+        >
+          <DeleteIcon fontSize="small" sx={{ mr: 1 }} /> Delete
+        </MenuItem>
+        <Divider />
+        {(['draft', 'published', 'archived'] as NodeState[]).map((state) => (
+          <MenuItem
+            key={state}
+            onClick={async () => {
+              if (!menuNodeId) return;
+              closeMenu();
+              try {
+                await runMutation(async () => {
+                  const res = await fetch(`/api/admin/course-builder/nodes/${menuNodeId}`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ updates: { state } }),
+                  });
+                  if (!res.ok) {
+                    const body = await res.json().catch(() => ({ error: 'Failed to update state' }));
+                    throw new Error(body.error ?? 'Failed to update state');
+                  }
+                  return (await res.json()) as { subtree: NodeSubtree };
+                }, { message: 'State updated' });
+              } catch (err) {
+                console.error(err);
+              }
+            }}
+          >
+            Set {state}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      <Dialog
+        open={deleteDialog.open && !!deleteDialog.subtree}
+        onClose={() => setDeleteDialog({ open: false, nodeId: null, subtree: null })}
+      >
+        <DialogTitle>Delete node</DialogTitle>
+        <DialogContent dividers>
+          {deleteStats ? (
+            <Stack spacing={2}>
+              <Alert severity="warning">
+                Deleting <strong>{deleteDialog.subtree!.node.title ?? 'this node'}</strong> will also remove the
+                following:
+              </Alert>
+              <Stack spacing={1}>
+                {deleteStats.nodes.map(({ type, count }) => (
+                  <Typography key={type}>{count} × {type}</Typography>
+                ))}
+                {deleteStats.blocks.map(({ type, count }) => (
+                  <Typography key={`block-${type}`}>{count} × {type} blocks</Typography>
+                ))}
+              </Stack>
+              <Alert severity="error">This action cannot be undone.</Alert>
+            </Stack>
+          ) : (
+            <CircularProgress size={20} />
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialog({ open: false, nodeId: null, subtree: null })}>Cancel</Button>
+          <Button
+            color="error"
+            onClick={() => {
+              if (!deleteDialog.nodeId) return;
+              void handleDeleteNode(deleteDialog.nodeId);
+              setDeleteDialog({ open: false, nodeId: null, subtree: null });
+            }}
+          >
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={addChildDialog.open}
+        onClose={() => setAddChildDialog({ open: false, parentId: null, mode: 'create' })}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle>{addChildDialog.mode === 'create' ? 'Create child node' : 'Attach existing node'}</DialogTitle>
+        <DialogContent dividers>
+          {addChildDialog.mode === 'create' ? (
+            <Stack spacing={2}>
+              <FormControl fullWidth disabled={availableChildTypes.length === 0}>
+                <InputLabel id="child-type">Child type</InputLabel>
+                <Select
+                  labelId="child-type"
+                  label="Child type"
+                  value={newChildType}
+                  onChange={(event) => setNewChildType(event.target.value as string)}
+                >
+                  {availableChildTypes.map((type) => (
+                    <MenuItem key={type} value={type}>
+                      {type}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <TextField
+                label="Title"
+                value={newChildTitle}
+                onChange={(event) => setNewChildTitle(event.target.value)}
+              />
+            </Stack>
+          ) : (
+            <Stack spacing={2}>
+              <TextField
+                label="Search by title"
+                onChange={(event) => void fetchSearch(event.target.value)}
+                InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
+              />
+              {searchResults.loading && <CircularProgress size={20} />}
+              <List>
+                {searchResults.rows.map((row) => (
+                  <ListItem
+                    key={row.id}
+                    onClick={() => {
+                      if (!addChildDialog.parentId) return;
+                      void handleAttachExisting(addChildDialog.parentId, row.id);
+                      setAddChildDialog({ open: false, parentId: null, mode: 'create' });
+                    }}
+                  >
+                    <ListItemText primary={row.title} secondary={`${row.node_type} · ${row.state}`} />
+                  </ListItem>
+                ))}
+              </List>
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAddChildDialog({ open: false, parentId: null, mode: 'create' })}>Cancel</Button>
+          {addChildDialog.mode === 'create' && (
+            <Button
+              variant="contained"
+              disabled={!newChildTitle.trim() || availableChildTypes.length === 0}
+              onClick={() => {
+                const parentId = addChildDialog.parentId;
+                if (!newChildTitle.trim()) {
+                  setSnack({ message: 'Provide a title for the new node.', severity: 'error' });
+                  return;
+                }
+                void handleAddChild(parentId, { node_type: newChildType, title: newChildTitle.trim() });
+                setAddChildDialog({ open: false, parentId: null, mode: 'create' });
+              }}
+            >
+              Create
+            </Button>
+          )}
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={duplicateDialog.open}
+        onClose={() => setDuplicateDialog({ open: false, nodeId: null })}
+      >
+        <DialogTitle>Duplicate node</DialogTitle>
+        <DialogContent dividers>
+          <Typography>
+            Duplicate this node and optionally attach it to the same parent. The copy will inherit the entire
+            subtree.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDuplicateDialog({ open: false, nodeId: null })}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              if (!duplicateDialog.nodeId) return;
+              const parentEdge = findParentEdge(trees, duplicateDialog.nodeId);
+              void handleDuplicate(duplicateDialog.nodeId, parentEdge?.parent_id ?? null);
+              setDuplicateDialog({ open: false, nodeId: null });
+            }}
+          >
+            Duplicate
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <ResourcePickerDialog
+        open={resourceDialogOpen}
+        onClose={() => setResourceDialogOpen(false)}
+        onSelect={(resource) =>
+          setBlockEditor((prev) => ({
+            ...prev,
+            resource,
+          }))
+        }
+      />
+
+      <BlockEditorDialog
+        open={blockDialogOpen}
+        onClose={() => setBlockDialogOpen(false)}
+        state={blockEditor}
+        onChange={setBlockEditor}
+        onSelectResource={() => setResourceDialogOpen(true)}
+        onSubmit={() => {
+          if (!selectedSubtree) return;
+          if (blockEditor.mode === 'create') {
+            const base: Partial<ContentBlock> & { block_type: BlockType } = {
+              block_type: blockEditor.type,
+              text_md: blockEditor.type === 'text' ? blockEditor.text_md : undefined,
+              resource_id: blockEditor.type === 'asset' ? blockEditor.resource?.id ?? null : null,
+              label: blockEditor.label || null,
+              start_ms: blockEditor.start_ms ? Number(blockEditor.start_ms) : null,
+              end_ms: blockEditor.end_ms ? Number(blockEditor.end_ms) : null,
+              notes: blockEditor.notes || null,
+            };
+            void handleCreateBlock(selectedSubtree.node.id, base);
+          } else if (blockEditor.block) {
+            const updates: Partial<ContentBlock> = {
+              block_type: blockEditor.type,
+              text_md: blockEditor.type === 'text' ? blockEditor.text_md : null,
+              resource_id: blockEditor.type === 'asset' ? blockEditor.resource?.id ?? null : null,
+              label: blockEditor.label || null,
+              start_ms: blockEditor.start_ms ? Number(blockEditor.start_ms) : null,
+              end_ms: blockEditor.end_ms ? Number(blockEditor.end_ms) : null,
+              notes: blockEditor.notes || null,
+            };
+            void handleUpdateBlock(blockEditor.block.id, updates);
+          }
+          setBlockDialogOpen(false);
+        }}
+      />
+
+      <Snackbar
+        open={!!snack}
+        autoHideDuration={4000}
+        onClose={() => setSnack(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {snack && (
+          <Alert severity={snack.severity} onClose={() => setSnack(null)} sx={{ width: '100%' }}>
+            {snack.message}
+          </Alert>
+        )}
+      </Snackbar>
+    </Stack>
+  );
+
+  async function handleAddChild(parentId: number | null, payload: { node_type: string; title: string }) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch('/api/admin/course-builder/nodes', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ node: payload, parent: parentId ? { parent_id: parentId } : null }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to create node' }));
+          throw new Error(body.error ?? 'Failed to create node');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, { message: 'Node created' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleAttachExisting(parentId: number, childId: number) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ child_id: childId }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to attach child' }));
+          throw new Error(body.error ?? 'Failed to attach child');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, { message: 'Child attached' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleDuplicate(nodeId: number, parentId: number | null) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/duplicate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ parent: parentId ? { parent_id: parentId } : null }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to duplicate node' }));
+          throw new Error(body.error ?? 'Failed to duplicate node');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, { message: 'Node duplicated' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleRemoveChild(parentId: number, childId: number) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/${childId}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to remove child' }));
+          throw new Error(body.error ?? 'Failed to remove child');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, { message: 'Child removed' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleDeleteNode(nodeId: number) {
+    const parentEdge = findParentEdge(trees, nodeId);
+    try {
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}`, { method: 'DELETE' });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to delete node' }));
+            throw new Error(body.error ?? 'Failed to delete node');
+          }
+          const payload = (await res.json()) as { parentSubtree: NodeSubtree | null };
+          if (!payload.parentSubtree) {
+            setTrees((prev) => removeSubtree(prev, nodeId));
+          }
+          return payload;
+        },
+        { message: 'Node deleted', optimistic: (prev) => removeSubtree(prev, nodeId) },
+      );
+      setSelectedId(parentEdge ? parentEdge.parent_id : null);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleReorderChild(parentId: number, childId: number, direction: 'up' | 'down') {
+    const parent = findSubtree(trees, parentId);
+    if (!parent) return;
+    const children = [...parent.children].sort((a, b) => a.edge.position - b.edge.position);
+    const index = children.findIndex((child) => child.edge.child_id === childId);
+    const swapWith = direction === 'up' ? index - 1 : index + 1;
+    if (swapWith < 0 || swapWith >= children.length) return;
+
+    const reordered = [...children];
+    const [moved] = reordered.splice(index, 1);
+    reordered.splice(swapWith, 0, moved);
+
+    const updates = reordered.map((child, idx) => ({ child_id: child.edge.child_id, position: idx }));
+
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/reorder`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ updates }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to reorder children' }));
+          throw new Error(body.error ?? 'Failed to reorder children');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, {
+        optimistic: (prev) => {
+          const snapshot = prev.map((tree) => cloneSubtree(tree));
+          const target = findSubtree(snapshot, parentId);
+          if (target) {
+            target.children = reordered.map((child, idx) => ({
+              edge: { ...child.edge, position: idx },
+              subtree: child.subtree,
+            }));
+          }
+          return snapshot;
+        },
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleUpdateChild(parentId: number, child: NodeSubtree['children'][number], updates: Partial<NodeChild>) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/reorder`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            updates: [
+              {
+                child_id: child.edge.child_id,
+                position: child.edge.position,
+                ...updates,
+              },
+            ],
+          }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to update child' }));
+          throw new Error(body.error ?? 'Failed to update child');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleCreateBlock(nodeId: number, block: Partial<ContentBlock> & { block_type: BlockType }) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/blocks`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ block }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to create block' }));
+          throw new Error(body.error ?? 'Failed to create block');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, { message: 'Block created' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleUpdateBlock(blockId: number, updates: Partial<ContentBlock>) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/blocks/${blockId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ updates }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to update block' }));
+          throw new Error(body.error ?? 'Failed to update block');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, { message: 'Block updated' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleDeleteBlock(blockId: number) {
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/blocks/${blockId}`, { method: 'DELETE' });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to delete block' }));
+          throw new Error(body.error ?? 'Failed to delete block');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      }, { message: 'Block deleted' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleReorderBlocks(
+    nodeId: number,
+    blocks: ContentBlock[],
+    blockId: number,
+    direction: 'up' | 'down',
+  ) {
+    const sorted = [...blocks].sort((a, b) => a.position - b.position);
+    const index = sorted.findIndex((block) => block.id === blockId);
+    const swapWith = direction === 'up' ? index - 1 : index + 1;
+    if (swapWith < 0 || swapWith >= sorted.length) return;
+
+    const reordered = [...sorted];
+    const [moved] = reordered.splice(index, 1);
+    reordered.splice(swapWith, 0, moved);
+
+    const updates = reordered.map((block, idx) => ({ block_id: block.id, position: idx }));
+
+    try {
+      await runMutation(async () => {
+        const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/blocks/reorder`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ updates }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to reorder blocks' }));
+          throw new Error(body.error ?? 'Failed to reorder blocks');
+        }
+        return (await res.json()) as { subtree: NodeSubtree };
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}

--- a/src/components/admin/CourseBuilderAdmin.tsx
+++ b/src/components/admin/CourseBuilderAdmin.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { MouseEvent, ReactElement } from 'react';
+import type { MouseEvent } from 'react';
 import {
   Alert,
   Box,
   Button,
+  Card,
+  Checkbox,
   Chip,
   CircularProgress,
   Dialog,
@@ -16,22 +18,17 @@ import {
   FormControl,
   IconButton,
   InputLabel,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   Menu,
   MenuItem,
   Paper,
   Select,
   Snackbar,
   Stack,
-  Tab,
-  Tabs,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   Typography,
-  Checkbox,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -41,26 +38,31 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
-import EditIcon from '@mui/icons-material/Edit';
-import SaveIcon from '@mui/icons-material/Save';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 import ArticleIcon from '@mui/icons-material/Article';
 import LayersIcon from '@mui/icons-material/Layers';
 import CollectionsBookmarkIcon from '@mui/icons-material/CollectionsBookmark';
 import PlaylistPlayIcon from '@mui/icons-material/PlaylistPlay';
+import StorageIcon from '@mui/icons-material/Storage';
 import TextFieldsIcon from '@mui/icons-material/TextFields';
 import VideoLibraryIcon from '@mui/icons-material/VideoLibrary';
 import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
-import PreviewIcon from '@mui/icons-material/Preview';
+import EditIcon from '@mui/icons-material/Edit';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import CloseIcon from '@mui/icons-material/Close';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import StorageIcon from '@mui/icons-material/Storage';
-import { supabase } from '@/lib/supabaseClient';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 
-type NodeType = 'course' | 'lesson' | 'chapter' | 'collection' | 'playlist';
-type NodeState = 'draft' | 'published' | 'archived';
-type BlockType = 'text' | 'asset' | 'divider';
+import { supabase } from '@/lib/supabaseClient';
+import { BlockRenderer } from '@/components/course/BlockRenderer';
+
+import type { RenderableResource } from '@/components/course/BlockRenderer';
+
+export type NodeType = 'course' | 'lesson' | 'chapter' | 'collection' | 'playlist';
+export type NodeState = 'draft' | 'published' | 'archived';
+export type BlockType = 'text' | 'asset' | 'divider';
 
 type ContentNode = {
   id: number;
@@ -125,7 +127,7 @@ type ResourceRow = {
   url: string | null;
 };
 
-const NODE_ICONS: Partial<Record<NodeType, ReactElement>> = {
+const NODE_ICONS: Partial<Record<NodeType, JSX.Element>> = {
   course: <MenuBookIcon fontSize="small" />,
   lesson: <ArticleIcon fontSize="small" />,
   chapter: <LayersIcon fontSize="small" />,
@@ -133,7 +135,7 @@ const NODE_ICONS: Partial<Record<NodeType, ReactElement>> = {
   playlist: <PlaylistPlayIcon fontSize="small" />,
 };
 
-const BLOCK_ICONS: Record<BlockType, ReactElement> = {
+const BLOCK_ICONS: Record<BlockType, JSX.Element> = {
   text: <TextFieldsIcon fontSize="small" />,
   asset: <VideoLibraryIcon fontSize="small" />,
   divider: <HorizontalRuleIcon fontSize="small" />,
@@ -161,10 +163,7 @@ function cloneSubtree(subtree: NodeSubtree): NodeSubtree {
   };
 }
 
-function replaceSubtree(
-  tree: NodeSubtree,
-  updated: NodeSubtree,
-): { next: NodeSubtree; replaced: boolean } {
+function replaceSubtree(tree: NodeSubtree, updated: NodeSubtree): { next: NodeSubtree; replaced: boolean } {
   if (tree.node.id === updated.node.id) {
     return { next: updated, replaced: true };
   }
@@ -312,6 +311,43 @@ function collectStats(subtree: NodeSubtree) {
   };
 }
 
+function updateBlockDraft(subtree: NodeSubtree, blockId: number, updates: Partial<ContentBlock>): NodeSubtree {
+  const blocks = subtree.blocks.map((block) => (block.id === blockId ? { ...block, ...updates } : block));
+  const children = subtree.children.map((child) => ({
+    edge: { ...child.edge },
+    subtree: updateBlockDraft(child.subtree, blockId, updates),
+  }));
+  return {
+    node: { ...subtree.node },
+    blocks,
+    children,
+  };
+}
+
+function updateBlockAcrossTree(list: NodeSubtree[], blockId: number, updates: Partial<ContentBlock>) {
+  return list.map((tree) => updateBlockDraft(tree, blockId, updates));
+}
+
+function updateNodeDraft(subtree: NodeSubtree, nodeId: number, updates: Partial<ContentNode>): NodeSubtree {
+  const node = subtree.node.id === nodeId ? { ...subtree.node, ...updates } : { ...subtree.node };
+  const children = subtree.children.map((child) => ({
+    edge: { ...child.edge },
+    subtree: updateNodeDraft(child.subtree, nodeId, updates),
+  }));
+  return {
+    node,
+    blocks: subtree.blocks.map((block) => ({ ...block })),
+    children,
+  };
+}
+
+function updateNodeAcrossTree(list: NodeSubtree[], nodeId: number, updates: Partial<ContentNode>) {
+  return list.map((tree) => updateNodeDraft(tree, nodeId, updates));
+}
+
+function sortBlocks(blocks: ContentBlock[]) {
+  return [...blocks].sort((a, b) => a.position - b.position);
+}
 type TreeNodeProps = {
   subtree: NodeSubtree;
   level: number;
@@ -383,7 +419,6 @@ function TreeNode({ subtree, level, expanded, toggle, onSelect, selectedId, sear
     </Box>
   );
 }
-
 type ResourcePickerProps = {
   open: boolean;
   onClose: () => void;
@@ -441,189 +476,71 @@ function ResourcePickerDialog({ open, onClose, onSelect }: ResourcePickerProps) 
             InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
           />
           {loading && (
-            <Stack direction="row" spacing={1} alignItems="center">
-              <CircularProgress size={18} />
-              <Typography variant="body2">Loading resources…</Typography>
+            <Stack alignItems="center" spacing={2} sx={{ py: 4 }}>
+              <CircularProgress size={24} />
+              <Typography variant="body2" color="text.secondary">
+                Loading resources…
+              </Typography>
             </Stack>
           )}
           {error && <Alert severity="error">{error}</Alert>}
-          <List dense>
-            {rows.map((row) => (
-              <ListItem
-                key={row.id}
-                secondaryAction={
-                  <IconButton
-                    edge="end"
-                    disabled={!row.url}
-                    onClick={() => {
-                      if (row.url) {
-                        window.open(row.url, '_blank', 'noopener,noreferrer');
-                      }
-                    }}
-                  >
-                    <OpenInNewIcon fontSize="small" />
-                  </IconButton>
-                }
-                onClick={() => {
-                  onSelect(row);
-                  onClose();
-                }}
-              >
-                <ListItemText
-                  primary={row.title}
-                  secondary={[row.type, row.state].filter(Boolean).join(' · ')}
-                />
-              </ListItem>
-            ))}
-          </List>
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Close</Button>
-      </DialogActions>
-    </Dialog>
-  );
-}
-
-type BlockEditorState = {
-  mode: 'create' | 'edit';
-  block: ContentBlock | null;
-  type: BlockType;
-  text_md: string;
-  resource: ResourceRow | null;
-  label: string;
-  start_ms: string;
-  end_ms: string;
-  notes: string;
-  preview: boolean;
-};
-
-const EMPTY_BLOCK: BlockEditorState = {
-  mode: 'create',
-  block: null,
-  type: 'text',
-  text_md: '',
-  resource: null,
-  label: '',
-  start_ms: '',
-  end_ms: '',
-  notes: '',
-  preview: false,
-};
-
-type BlockEditorProps = {
-  open: boolean;
-  onClose: () => void;
-  state: BlockEditorState;
-  onChange: (next: BlockEditorState) => void;
-  onSelectResource: () => void;
-  onSubmit: () => void;
-};
-
-function BlockEditorDialog({ open, onClose, state, onChange, onSelectResource, onSubmit }: BlockEditorProps) {
-  const canSave =
-    state.type === 'divider' ||
-    (state.type === 'text' && state.text_md.trim().length > 0) ||
-    (state.type === 'asset' && state.resource);
-
-  return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>{state.mode === 'create' ? 'Add block' : 'Edit block'}</DialogTitle>
-      <DialogContent dividers>
-        <Stack spacing={3}>
-          <FormControl fullWidth>
-            <InputLabel id="block-type">Block type</InputLabel>
-            <Select
-              labelId="block-type"
-              label="Block type"
-              value={state.type}
-              onChange={(event) =>
-                onChange({ ...state, type: event.target.value as BlockType, resource: null })
-              }
-            >
-              <MenuItem value="text">Text</MenuItem>
-              <MenuItem value="asset">Resource</MenuItem>
-              <MenuItem value="divider">Divider</MenuItem>
-            </Select>
-          </FormControl>
-
-          {state.type === 'text' && (
-            <Stack spacing={1}>
-              <TextField
-                multiline
-                minRows={6}
-                label="Markdown"
-                value={state.text_md}
-                onChange={(event) => onChange({ ...state, text_md: event.target.value })}
-              />
-              <Button startIcon={<PreviewIcon />} onClick={() => onChange({ ...state, preview: !state.preview })}>
-                {state.preview ? 'Hide preview' : 'Show preview'}
-              </Button>
-              {state.preview && (
-                <Paper variant="outlined" sx={{ p: 2 }}>
-                  <Typography sx={{ whiteSpace: 'pre-wrap' }}>{state.text_md || 'Nothing to preview yet.'}</Typography>
-                </Paper>
-              )}
-            </Stack>
-          )}
-
-          {state.type === 'asset' && (
+          {!loading && !error && (
             <Stack spacing={2}>
-              <Button variant="outlined" startIcon={<SearchIcon />} onClick={onSelectResource}>
-                {state.resource ? 'Change resource' : 'Select resource'}
-              </Button>
-              {state.resource && (
-                <Paper variant="outlined" sx={{ p: 2 }}>
-                  <Typography variant="subtitle1">{state.resource.title}</Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {[state.resource.type, state.resource.state].filter(Boolean).join(' · ')}
-                  </Typography>
-                </Paper>
+              {rows.map((row) => (
+                <Card
+                  key={row.id}
+                  variant="outlined"
+                  sx={{ cursor: 'pointer' }}
+                  onClick={() => {
+                    onSelect(row);
+                    onClose();
+                  }}
+                >
+                  <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ p: 2 }}>
+                    {row.thumbnail && (
+                      <Box
+                        component="img"
+                        src={row.thumbnail}
+                        alt={row.title}
+                        sx={{ width: 120, borderRadius: 1, objectFit: 'cover' }}
+                      />
+                    )}
+                    <Box sx={{ flex: 1 }}>
+                      <Typography variant="subtitle1">{row.title}</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {[row.type, row.state].filter(Boolean).join(' · ')}
+                      </Typography>
+                      {row.url && (
+                        <Button
+                          size="small"
+                          endIcon={<OpenInNewIcon fontSize="small" />}
+                          href={row.url ?? undefined}
+                          target="_blank"
+                          rel="noreferrer"
+                          sx={{ mt: 1 }}
+                        >
+                          Open resource
+                        </Button>
+                      )}
+                    </Box>
+                  </Stack>
+                </Card>
+              ))}
+              {rows.length === 0 && (
+                <Typography variant="body2" color="text.secondary" align="center">
+                  No resources found. Try a different search term.
+                </Typography>
               )}
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
-                <TextField
-                  label="Start (ms)"
-                  value={state.start_ms}
-                  onChange={(event) => onChange({ ...state, start_ms: event.target.value })}
-                />
-                <TextField
-                  label="End (ms)"
-                  value={state.end_ms}
-                  onChange={(event) => onChange({ ...state, end_ms: event.target.value })}
-                />
-              </Stack>
-              <TextField
-                label="Label"
-                value={state.label}
-                onChange={(event) => onChange({ ...state, label: event.target.value })}
-              />
-              <TextField
-                label="Notes"
-                value={state.notes}
-                onChange={(event) => onChange({ ...state, notes: event.target.value })}
-              />
             </Stack>
-          )}
-
-          {state.type === 'divider' && (
-            <Alert severity="info" icon={<HorizontalRuleIcon fontSize="small" />}>
-              Divider blocks do not include additional content.
-            </Alert>
           )}
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button startIcon={<CloseIcon />} onClick={onClose}>
-          Cancel
-        </Button>
-        <Button startIcon={<SaveIcon />} variant="contained" disabled={!canSave} onClick={onSubmit}>
-          Save
-        </Button>
+        <Button onClick={onClose} startIcon={<CloseIcon />}>Close</Button>
       </DialogActions>
     </Dialog>
   );
 }
-
 type SnackbarState = { message: string; severity: 'success' | 'error' | 'info' } | null;
 
 type DeleteDialogState = {
@@ -643,35 +560,67 @@ type DuplicateDialogState = {
   nodeId: number | null;
 };
 
+type SearchResultsState = {
+  loading: boolean;
+  rows: ContentNode[];
+  error?: string | null;
+};
+
+type SavingState = 'idle' | 'saving' | 'saved' | 'error';
+
+type NodeDraft = {
+  title: string;
+  slug: string;
+  description: string;
+  state: NodeState;
+  hero_image: string;
+  icon: string;
+  objectives: string;
+  metadata: string;
+};
 export default function CourseBuilderAdmin() {
   const [trees, setTrees] = useState<NodeSubtree[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [selectedBlockId, setSelectedBlockId] = useState<number | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rules, setRules] = useState<NodeEdgeRule[]>([]);
-  const [panelTab, setPanelTab] = useState(0);
   const [snack, setSnack] = useState<SnackbarState>(null);
-  const [detailsForm, setDetailsForm] = useState({
-    title: '',
-    slug: '',
-    description: '',
-    state: 'draft' as NodeState,
-    hero_image: '',
-    icon: '',
-    objectives: '',
-    metadata: '',
-  });
-  const [blockEditor, setBlockEditor] = useState<BlockEditorState>(EMPTY_BLOCK);
-  const [blockDialogOpen, setBlockDialogOpen] = useState(false);
-  const [resourceDialogOpen, setResourceDialogOpen] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuNodeId, setMenuNodeId] = useState<number | null>(null);
   const [deleteDialog, setDeleteDialog] = useState<DeleteDialogState>({ open: false, nodeId: null, subtree: null });
   const [addChildDialog, setAddChildDialog] = useState<AddChildDialogState>({ open: false, parentId: null, mode: 'create' });
   const [duplicateDialog, setDuplicateDialog] = useState<DuplicateDialogState>({ open: false, nodeId: null });
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [menuNodeId, setMenuNodeId] = useState<number | null>(null);
+  const [searchResults, setSearchResults] = useState<SearchResultsState>({ loading: false, rows: [] });
+  const [newChildType, setNewChildType] = useState<string>('lesson');
+  const [newChildTitle, setNewChildTitle] = useState('');
+  const [attachQuery, setAttachQuery] = useState('');
+  const [panelMode, setPanelMode] = useState<'node' | 'block'>('node');
+  const [propertiesOpen, setPropertiesOpen] = useState(true);
+  const [resourceDialogOpen, setResourceDialogOpen] = useState(false);
+  const [resourceDialogMode, setResourceDialogMode] = useState<
+    { type: 'insert'; nodeId: number; index: number } | { type: 'update'; blockId: number }
+  | null>(null);
+  const [insertMenu, setInsertMenu] = useState<{ anchor: HTMLElement; index: number } | null>(null);
+  const [dragState, setDragState] = useState<{ blockId: number | null; overIndex: number | null }>({
+    blockId: null,
+    overIndex: null,
+  });
+  const [resourceCache, setResourceCache] = useState<Record<number, ResourceRow>>({});
+  const [savingState, setSavingState] = useState<SavingState>('idle');
+  const [savingMessage, setSavingMessage] = useState('All changes saved');
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const blockUpdateQueue = useRef(new Map<number, Partial<ContentBlock>>());
+  const blockDebounceTimers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
+  const nodeUpdateQueue = useRef(new Map<number, Partial<ContentNode>>());
+  const nodeDebounceTimers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
   const optimisticSnapshot = useRef<NodeSubtree[] | null>(null);
+  const [nodeDraft, setNodeDraft] = useState<NodeDraft | null>(null);
+  const [metadataError, setMetadataError] = useState<string | null>(null);
+  const [showMarkdownPreview, setShowMarkdownPreview] = useState(true);
+  const [editingBlockId, setEditingBlockId] = useState<number | null>(null);
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -699,6 +648,7 @@ export default function CourseBuilderAdmin() {
       setRules(rulesPayload.rules ?? []);
       const first = treePayload.subtrees?.[0]?.node.id ?? null;
       setSelectedId(first);
+      setSelectedBlockId(null);
       setExpanded(new Set(treePayload.subtrees.map((subtree) => subtree.node.id)));
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load data';
@@ -717,9 +667,22 @@ export default function CourseBuilderAdmin() {
     return findSubtree(trees, selectedId);
   }, [trees, selectedId]);
 
+  const sortedBlocks = useMemo(() => {
+    if (!selectedSubtree) return [];
+    return sortBlocks(selectedSubtree.blocks);
+  }, [selectedSubtree]);
+
+  const selectedBlock = useMemo(() => {
+    if (selectedBlockId == null || !selectedSubtree) return null;
+    return selectedSubtree.blocks.find((block) => block.id === selectedBlockId) ?? null;
+  }, [selectedBlockId, selectedSubtree]);
+
   useEffect(() => {
-    if (!selectedSubtree) return;
-    setDetailsForm({
+    if (!selectedSubtree) {
+      setNodeDraft(null);
+      return;
+    }
+    setNodeDraft({
       title: selectedSubtree.node.title ?? '',
       slug: selectedSubtree.node.slug ?? '',
       description: selectedSubtree.node.description ?? '',
@@ -729,8 +692,124 @@ export default function CourseBuilderAdmin() {
       objectives: selectedSubtree.node.objectives ?? '',
       metadata: selectedSubtree.node.metadata ? JSON.stringify(selectedSubtree.node.metadata, null, 2) : '',
     });
-    setPanelTab(0);
+    setPanelMode('node');
+    setSelectedBlockId(null);
+    setMetadataError(null);
+    setShowMarkdownPreview(true);
+    setEditingBlockId(null);
   }, [selectedSubtree]);
+
+  useEffect(() => {
+    if (!deleteDialog.open || !deleteDialog.subtree) {
+      return;
+    }
+    setDeleteDialog((prev) => ({ ...prev, subtree: prev.subtree }));
+  }, [deleteDialog.open, deleteDialog.subtree]);
+
+  useEffect(() => {
+    if (!selectedSubtree) return;
+    const resourceIds = selectedSubtree.blocks
+      .filter((block) => block.block_type === 'asset' && block.resource_id)
+      .map((block) => block.resource_id!)
+      .filter((id, index, arr) => arr.indexOf(id) === index);
+
+    for (const id of resourceIds) {
+      if (!resourceCache[id]) {
+        void ensureResource(id);
+      }
+    }
+  }, [selectedSubtree, resourceCache, ensureResource]);
+
+  useEffect(() => {
+    if (addChildDialog.open && addChildDialog.mode === 'attach' && addChildDialog.parentId != null) {
+      setSearchResults((prev) => ({ ...prev, loading: true, error: null }));
+      const controller = new AbortController();
+      const load = async () => {
+        try {
+          const res = await fetch(
+            `/api/admin/course-builder/nodes?search=${encodeURIComponent(attachQuery)}&excludeParent=${addChildDialog.parentId}`,
+            { signal: controller.signal },
+          );
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to search nodes' }));
+            throw new Error(body.error ?? 'Failed to search nodes');
+          }
+          const data = (await res.json()) as { subtrees: NodeSubtree[] };
+          const rows = (data.subtrees ?? []).map((subtree) => subtree.node);
+          setSearchResults({ loading: false, rows });
+        } catch (err) {
+          if (controller.signal.aborted) return;
+          const message = err instanceof Error ? err.message : 'Failed to search nodes';
+          setSearchResults({ loading: false, rows: [], error: message });
+        }
+      };
+      void load();
+      return () => controller.abort();
+    }
+    if (!addChildDialog.open) {
+      setSearchResults({ loading: false, rows: [] });
+    }
+  }, [addChildDialog, attachQuery]);
+
+  const deleteStats = useMemo(() => {
+    return deleteDialog.subtree ? collectStats(deleteDialog.subtree) : null;
+  }, [deleteDialog.subtree]);
+
+  const availableChildTypes = useMemo(() => {
+    if (!selectedSubtree) return [] as string[];
+    return rules
+      .filter((rule) => rule.parent_type === selectedSubtree.node.node_type && rule.child_kind === 'node')
+      .map((rule) => rule.child_type);
+  }, [rules, selectedSubtree]);
+
+  useEffect(() => {
+    if (addChildDialog.open && addChildDialog.mode === 'create') {
+      setNewChildType(availableChildTypes[0] ?? 'lesson');
+      setNewChildTitle('');
+    }
+  }, [addChildDialog.open, addChildDialog.mode, availableChildTypes]);
+
+  const startSaving = useCallback((message?: string) => {
+    setSavingState('saving');
+    setSavingMessage(message ?? 'Saving…');
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+  }, []);
+
+  const completeSaving = useCallback((message?: string) => {
+    setSavingState('saved');
+    setSavingMessage(message ?? 'Changes saved');
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+    }
+    saveTimerRef.current = setTimeout(() => {
+      setSavingState('idle');
+      setSavingMessage('All changes saved');
+    }, 2000);
+  }, []);
+
+  const failSaving = useCallback((message?: string) => {
+    setSavingState('error');
+    setSavingMessage(message ?? 'Failed to save changes');
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    const blockTimers = blockDebounceTimers.current;
+    const nodeTimers = nodeDebounceTimers.current;
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+      }
+      blockTimers.forEach((timer) => clearTimeout(timer));
+      nodeTimers.forEach((timer) => clearTimeout(timer));
+    };
+  }, []);
 
   const toggleExpand = useCallback((id: number) => {
     setExpanded((prev) => {
@@ -754,7 +833,12 @@ export default function CourseBuilderAdmin() {
   const runMutation = useCallback(
     async (
       request: () => Promise<NodeSubtree | { subtree?: NodeSubtree; parentSubtree?: NodeSubtree | null }>,
-      options: { message?: string; optimistic?: (prev: NodeSubtree[]) => NodeSubtree[] } = {},
+      options: {
+        optimistic?: (prev: NodeSubtree[]) => NodeSubtree[];
+        message?: string;
+        savingMessage?: string;
+        silent?: boolean;
+      } = {},
     ) => {
       if (options.optimistic) {
         setTrees((prev) => {
@@ -763,89 +847,536 @@ export default function CourseBuilderAdmin() {
         });
       }
 
+      startSaving(options.savingMessage);
+
       try {
         const payload = await request();
         setTrees((prev) => {
-          let next = prev;
           if ('subtree' in payload && payload.subtree) {
-            next = mergeSubtree(next, payload.subtree);
-          } else if ('node' in payload) {
-            next = mergeSubtree(next, payload as NodeSubtree);
+            return mergeSubtree(prev, payload.subtree);
           }
-          if ('parentSubtree' in payload && payload.parentSubtree) {
-            next = mergeSubtree(next, payload.parentSubtree);
+          if ('parentSubtree' in payload) {
+            const parentSubtree = payload.parentSubtree;
+            if (!parentSubtree) {
+              return removeSubtree(prev, payload.subtree?.node.id ?? -1);
+            }
+            return mergeSubtree(prev.filter((tree) => tree.node.id !== parentSubtree.node.id), parentSubtree);
           }
-          return next;
+          return mergeSubtree(prev, payload as NodeSubtree);
         });
-        if (options.message) setSnack({ message: options.message, severity: 'success' });
+        if (options.message) {
+          setSnack({ message: options.message, severity: 'success' });
+        }
+        completeSaving();
+        optimisticSnapshot.current = null;
+        return payload;
       } catch (err) {
         if (optimisticSnapshot.current) {
           setTrees(optimisticSnapshot.current);
         }
         optimisticSnapshot.current = null;
-        const message = err instanceof Error ? err.message : 'Action failed';
-        setSnack({ message, severity: 'error' });
+        const message = err instanceof Error ? err.message : 'Failed to save changes';
+        failSaving(message);
+        if (!options.silent) {
+          setSnack({ message, severity: 'error' });
+        }
         throw err;
-      } finally {
-        optimisticSnapshot.current = null;
       }
     },
-    [],
+    [completeSaving, failSaving, startSaving],
   );
 
-  const [newChildType, setNewChildType] = useState<string>('lesson');
-  const [newChildTitle, setNewChildTitle] = useState('');
-
-  const allowedChildTypes = useMemo(() => {
-    if (!selectedSubtree) return [] as string[];
-    return Array.from(
-      new Set(
-        rules
-          .filter((rule) => rule.parent_type === selectedSubtree.node.node_type && rule.child_kind === 'node')
-          .map((rule) => rule.child_type),
-      ),
-    );
-  }, [rules, selectedSubtree]);
-
-  const availableChildTypes = useMemo(
-    () => (addChildDialog.parentId ? allowedChildTypes : ['course']),
-    [addChildDialog.parentId, allowedChildTypes],
-  );
-
-  const [searchResults, setSearchResults] = useState<{ loading: boolean; rows: ContentNode[] }>({
-    loading: false,
-    rows: [],
-  });
-
-  const fetchSearch = useCallback(async (term: string) => {
-    setSearchResults({ loading: true, rows: [] });
-    try {
-      const res = await fetch(`/api/admin/course-builder/nodes?mode=search&q=${encodeURIComponent(term)}`);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({ error: 'Failed to search nodes' }));
-        throw new Error(body.error ?? 'Failed to search nodes');
+  const ensureResource = useCallback(
+    async (resourceId: number) => {
+      if (resourceCache[resourceId]) {
+        return resourceCache[resourceId];
       }
-      const payload = (await res.json()) as { nodes: ContentNode[] };
-      setSearchResults({ loading: false, rows: payload.nodes ?? [] });
-    } catch (err) {
-      console.error(err);
-      setSearchResults({ loading: false, rows: [] });
-    }
+      const { data, error: fetchError } = await supabase
+        .from('resources')
+        .select('id,title,type,state,thumbnail,duration,url')
+        .eq('id', resourceId)
+        .maybeSingle();
+      if (fetchError) {
+        throw new Error(fetchError.message);
+      }
+      if (data) {
+        const row = data as ResourceRow;
+        setResourceCache((prev) => ({ ...prev, [resourceId]: row }));
+        return row;
+      }
+      return null;
+    },
+    [resourceCache],
+  );
+
+  const flushBlockUpdate = useCallback(
+    async (blockId: number) => {
+      const pending = blockUpdateQueue.current.get(blockId);
+      if (!pending) return;
+      blockUpdateQueue.current.delete(blockId);
+      const timer = blockDebounceTimers.current.get(blockId);
+      if (timer) {
+        clearTimeout(timer);
+        blockDebounceTimers.current.delete(blockId);
+      }
+
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/blocks/${blockId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ updates: pending }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to update block' }));
+            throw new Error(body.error ?? 'Failed to update block');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { silent: true },
+      );
+    },
+    [runMutation],
+  );
+
+  const queueBlockUpdate = useCallback(
+    (blockId: number, updates: Partial<ContentBlock>, options: { debounce?: boolean } = { debounce: true }) => {
+      setTrees((prev) => {
+        if (!optimisticSnapshot.current) {
+          optimisticSnapshot.current = prev.map((tree) => cloneSubtree(tree));
+        }
+        return updateBlockAcrossTree(prev, blockId, updates);
+      });
+      const current = blockUpdateQueue.current.get(blockId) ?? {};
+      blockUpdateQueue.current.set(blockId, { ...current, ...updates });
+
+      if (options.debounce) {
+        const existing = blockDebounceTimers.current.get(blockId);
+        if (existing) clearTimeout(existing);
+        const timer = setTimeout(() => {
+          void flushBlockUpdate(blockId);
+        }, 800);
+        blockDebounceTimers.current.set(blockId, timer);
+      } else {
+        void flushBlockUpdate(blockId);
+      }
+    },
+    [flushBlockUpdate],
+  );
+
+  const flushNodeUpdate = useCallback(
+    async (nodeId: number) => {
+      const pending = nodeUpdateQueue.current.get(nodeId);
+      if (!pending) return;
+      nodeUpdateQueue.current.delete(nodeId);
+      const timer = nodeDebounceTimers.current.get(nodeId);
+      if (timer) {
+        clearTimeout(timer);
+        nodeDebounceTimers.current.delete(nodeId);
+      }
+
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ updates: pending }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to update node' }));
+            throw new Error(body.error ?? 'Failed to update node');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { silent: true },
+      );
+    },
+    [runMutation],
+  );
+
+  const queueNodeUpdate = useCallback(
+    (nodeId: number, updates: Partial<ContentNode>, options: { debounce?: boolean } = { debounce: true }) => {
+      setTrees((prev) => {
+        if (!optimisticSnapshot.current) {
+          optimisticSnapshot.current = prev.map((tree) => cloneSubtree(tree));
+        }
+        return updateNodeAcrossTree(prev, nodeId, updates);
+      });
+      const current = nodeUpdateQueue.current.get(nodeId) ?? {};
+      nodeUpdateQueue.current.set(nodeId, { ...current, ...updates });
+
+      if (options.debounce) {
+        const existing = nodeDebounceTimers.current.get(nodeId);
+        if (existing) clearTimeout(existing);
+        const timer = setTimeout(() => {
+          void flushNodeUpdate(nodeId);
+        }, 800);
+        nodeDebounceTimers.current.set(nodeId, timer);
+      } else {
+        void flushNodeUpdate(nodeId);
+      }
+    },
+    [flushNodeUpdate],
+  );
+
+  const handleSelectBlock = useCallback((blockId: number) => {
+    setSelectedBlockId(blockId);
+    setPanelMode('block');
+    setPropertiesOpen(true);
+    setEditingBlockId(null);
   }, []);
 
-  useEffect(() => {
-    if (addChildDialog.open && addChildDialog.mode === 'create') {
-      setNewChildType(availableChildTypes[0] ?? 'course');
-      setNewChildTitle('');
-    }
-    if (!addChildDialog.open) {
-      setSearchResults({ loading: false, rows: [] });
-    }
-  }, [addChildDialog, availableChildTypes]);
+  const handleReorderBlocksToIndex = useCallback(
+    async (blockId: number, targetIndex: number) => {
+      if (!selectedSubtree) return;
+      const ordered = sortBlocks(selectedSubtree.blocks);
+      const currentIndex = ordered.findIndex((block) => block.id === blockId);
+      if (currentIndex === -1) return;
 
-  const deleteStats = useMemo(() => {
-    return deleteDialog.subtree ? collectStats(deleteDialog.subtree) : null;
-  }, [deleteDialog.subtree]);
+      const nextOrder = [...ordered];
+      const [moved] = nextOrder.splice(currentIndex, 1);
+      let insertIndex = targetIndex;
+      if (targetIndex > currentIndex) {
+        insertIndex = Math.max(0, targetIndex - 1);
+      }
+      insertIndex = Math.min(Math.max(insertIndex, 0), nextOrder.length);
+      nextOrder.splice(insertIndex, 0, moved);
+
+      const withPositions = nextOrder.map((block, index) => ({ ...block, position: index }));
+      const updates = withPositions.map((block) => ({ block_id: block.id, position: block.position }));
+
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${selectedSubtree.node.id}/blocks/reorder`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ updates }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to reorder blocks' }));
+            throw new Error(body.error ?? 'Failed to reorder blocks');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        {
+          optimistic: (prev) => {
+            const snapshot = prev.map((tree) => cloneSubtree(tree));
+            const target = findSubtree(snapshot, selectedSubtree.node.id);
+            if (target) {
+              target.blocks = withPositions;
+            }
+            return snapshot;
+          },
+          silent: true,
+        },
+      );
+    },
+    [runMutation, selectedSubtree],
+  );
+
+  const handleDeleteBlock = useCallback(
+    async (blockId: number) => {
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/blocks/${blockId}`, { method: 'DELETE' });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to delete block' }));
+            throw new Error(body.error ?? 'Failed to delete block');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { message: 'Block deleted' },
+      );
+      if (selectedBlockId === blockId) {
+        setSelectedBlockId(null);
+        setPanelMode('node');
+      }
+    },
+    [runMutation, selectedBlockId],
+  );
+
+  const handleCreateBlock = useCallback(
+    async (nodeId: number, block: Partial<ContentBlock> & { block_type: BlockType }, position: number) => {
+      const beforeIds = findSubtree(trees, nodeId)?.blocks.map((row) => row.id) ?? [];
+      const payload = await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/blocks`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ block: { ...block, position } }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to create block' }));
+            throw new Error(body.error ?? 'Failed to create block');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { message: 'Block created', savingMessage: 'Creating block…' },
+      );
+
+      const subtree = 'subtree' in payload && payload.subtree ? payload.subtree : (payload as NodeSubtree);
+      const newBlock = subtree.blocks.find((row) => !beforeIds.includes(row.id));
+      if (newBlock) {
+        setSelectedBlockId(newBlock.id);
+        setPanelMode('block');
+        setPropertiesOpen(true);
+        setEditingBlockId(newBlock.id);
+      }
+    },
+    [runMutation, trees],
+  );
+
+  const handleAddBlockAt = useCallback(
+    (index: number, type: BlockType) => {
+      if (!selectedSubtree) return;
+      setInsertMenu(null);
+      if (type === 'asset') {
+        setResourceDialogMode({ type: 'insert', nodeId: selectedSubtree.node.id, index });
+        setResourceDialogOpen(true);
+        return;
+      }
+
+      const baseText = 'Start writing your content…';
+      const payload: Partial<ContentBlock> & { block_type: BlockType } =
+        type === 'text'
+          ? { block_type: 'text', text_md: baseText }
+          : { block_type: 'divider' };
+      void handleCreateBlock(selectedSubtree.node.id, payload, index);
+    },
+    [handleCreateBlock, selectedSubtree],
+  );
+
+  const handleResourceSelected = useCallback(
+    (resource: ResourceRow) => {
+      setResourceCache((prev) => ({ ...prev, [resource.id]: resource }));
+      if (!resourceDialogMode) return;
+      if (resourceDialogMode.type === 'insert') {
+        void handleCreateBlock(
+          resourceDialogMode.nodeId,
+          { block_type: 'asset', resource_id: resource.id },
+          resourceDialogMode.index,
+        );
+      } else if (resourceDialogMode.type === 'update') {
+        queueBlockUpdate(resourceDialogMode.blockId, { resource_id: resource.id }, { debounce: false });
+      }
+      setResourceDialogMode(null);
+      setResourceDialogOpen(false);
+    },
+    [handleCreateBlock, queueBlockUpdate, resourceDialogMode],
+  );
+
+  const handleNodeFieldChange = useCallback(
+    (field: keyof NodeDraft, value: string) => {
+      if (!selectedSubtree) return;
+      setNodeDraft((prev) => (prev ? { ...prev, [field]: value } : prev));
+      const nodeId = selectedSubtree.node.id;
+      if (field === 'metadata') {
+        if (!value.trim()) {
+          setMetadataError(null);
+          queueNodeUpdate(nodeId, { metadata: null });
+          return;
+        }
+        try {
+          const parsed = JSON.parse(value);
+          setMetadataError(null);
+          queueNodeUpdate(nodeId, { metadata: parsed });
+        } catch {
+          setMetadataError('Metadata must be valid JSON');
+        }
+        return;
+      }
+
+      if (field === 'state') {
+        queueNodeUpdate(nodeId, { state: value as NodeState }, { debounce: false });
+        return;
+      }
+
+      const mapped: Partial<ContentNode> = {
+        [field]: value ? value : null,
+      } as Partial<ContentNode>;
+      queueNodeUpdate(nodeId, mapped);
+    },
+    [queueNodeUpdate, selectedSubtree],
+  );
+
+  const handleAddChild = useCallback(
+    async (parentId: number | null, payload: { node_type: string; title: string }) => {
+      await runMutation(
+        async () => {
+          const res = await fetch('/api/admin/course-builder/nodes', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ node: payload, parent: parentId ? { parent_id: parentId } : null }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to create node' }));
+            throw new Error(body.error ?? 'Failed to create node');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { message: 'Node created', savingMessage: 'Creating node…' },
+      );
+    },
+    [runMutation],
+  );
+
+  const handleAttachExisting = useCallback(
+    async (parentId: number, childId: number) => {
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ child_id: childId }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to attach child' }));
+            throw new Error(body.error ?? 'Failed to attach child');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { message: 'Child attached' },
+      );
+    },
+    [runMutation],
+  );
+
+  const handleDuplicate = useCallback(
+    async (nodeId: number, parentId: number | null) => {
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/duplicate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ parent: parentId ? { parent_id: parentId } : null }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to duplicate node' }));
+            throw new Error(body.error ?? 'Failed to duplicate node');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { message: 'Node duplicated', savingMessage: 'Duplicating node…' },
+      );
+    },
+    [runMutation],
+  );
+
+  const handleRemoveChild = useCallback(
+    async (parentId: number, childId: number) => {
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/${childId}`, { method: 'DELETE' });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to remove child' }));
+            throw new Error(body.error ?? 'Failed to remove child');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { message: 'Child removed' },
+      );
+    },
+    [runMutation],
+  );
+
+  const handleDeleteNode = useCallback(
+    async (nodeId: number) => {
+      const parentEdge = findParentEdge(trees, nodeId);
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}`, { method: 'DELETE' });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to delete node' }));
+            throw new Error(body.error ?? 'Failed to delete node');
+          }
+          return (await res.json()) as { parentSubtree: NodeSubtree | null };
+        },
+        {
+          message: 'Node deleted',
+          optimistic: (prev) => removeSubtree(prev, nodeId),
+        },
+      );
+      setSelectedId(parentEdge ? parentEdge.parent_id : null);
+      setSelectedBlockId(null);
+      setPanelMode('node');
+    },
+    [runMutation, trees],
+  );
+
+  const handleReorderChild = useCallback(
+    async (parentId: number, childId: number, direction: 'up' | 'down') => {
+      const parent = findSubtree(trees, parentId);
+      if (!parent) return;
+      const children = [...parent.children].sort((a, b) => a.edge.position - b.edge.position);
+      const index = children.findIndex((child) => child.edge.child_id === childId);
+      const swapWith = direction === 'up' ? index - 1 : index + 1;
+      if (swapWith < 0 || swapWith >= children.length) return;
+
+      const reordered = [...children];
+      const [moved] = reordered.splice(index, 1);
+      reordered.splice(swapWith, 0, moved);
+
+      const updates = reordered.map((child, idx) => ({ child_id: child.edge.child_id, position: idx }));
+
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/reorder`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ updates }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to reorder children' }));
+            throw new Error(body.error ?? 'Failed to reorder children');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        {
+          optimistic: (prev) => {
+            const snapshot = prev.map((tree) => cloneSubtree(tree));
+            const target = findSubtree(snapshot, parentId);
+            if (target) {
+              target.children = reordered.map((child, idx) => ({
+                edge: { ...child.edge, position: idx },
+                subtree: child.subtree,
+              }));
+            }
+            return snapshot;
+          },
+        },
+      );
+    },
+    [runMutation, trees],
+  );
+
+  const handleUpdateChild = useCallback(
+    async (parentId: number, child: NodeSubtree['children'][number], updates: Partial<NodeChild>) => {
+      await runMutation(
+        async () => {
+          const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/reorder`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              updates: [
+                {
+                  child_id: child.edge.child_id,
+                  position: child.edge.position,
+                  ...updates,
+                },
+              ],
+            }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({ error: 'Failed to update child' }));
+            throw new Error(body.error ?? 'Failed to update child');
+          }
+          return (await res.json()) as { subtree: NodeSubtree };
+        },
+        { silent: true },
+      );
+    },
+    [runMutation],
+  );
 
   if (loading) {
     return (
@@ -871,32 +1402,193 @@ export default function CourseBuilderAdmin() {
     );
   }
 
-  return (
-    <Stack direction={{ xs: 'column', lg: 'row' }} spacing={3}>
-      <Paper sx={{ flexBasis: 320, flexShrink: 0, p: 2 }} variant="outlined">
-        <Stack spacing={2}>
-          <TextField
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search nodes"
-            InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
-          />
-          <Stack direction="row" spacing={1}>
-            <Button
-              fullWidth
-              startIcon={<AddIcon />}
-              onClick={() => setAddChildDialog({ open: true, parentId: null, mode: 'create' })}
-            >
-              Add Course
-            </Button>
-            <Tooltip title="Refresh">
-              <IconButton onClick={() => void loadData()}>
-                <RefreshIcon />
+  const canEditBlocks = !!selectedSubtree && selectedSubtree.children.length === 0;
+  const resourceForBlock = (block: ContentBlock): RenderableResource | null => {
+    if (!block.resource_id) return null;
+    return resourceCache[block.resource_id] ?? null;
+  };
+
+  const renderDropZone = (index: number) => (
+    <Box
+      key={`drop-${index}`}
+      onDragOver={(event) => {
+        event.preventDefault();
+        setDragState((prev) => ({ ...prev, overIndex: index }));
+      }}
+      onDragLeave={() => setDragState((prev) => ({ ...prev, overIndex: prev.overIndex === index ? null : prev.overIndex }))}
+      onDrop={(event) => {
+        event.preventDefault();
+        if (dragState.blockId != null) {
+          void handleReorderBlocksToIndex(dragState.blockId, index);
+        }
+        setDragState({ blockId: null, overIndex: null });
+      }}
+      sx={{
+        position: 'relative',
+        my: 1,
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<AddIcon />}
+        onClick={(event) => {
+          setInsertMenu({ anchor: event.currentTarget, index });
+        }}
+      >
+        Add block
+      </Button>
+      {dragState.overIndex === index && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            left: 12,
+            right: 12,
+            height: 2,
+            bgcolor: 'primary.main',
+          }}
+        />
+      )}
+    </Box>
+  );
+
+  const renderBlockCard = (block: ContentBlock, index: number) => {
+    const isSelected = selectedBlockId === block.id;
+    const isText = block.block_type === 'text';
+    const isEditing = editingBlockId === block.id;
+    return (
+      <Box
+        key={block.id}
+        sx={{
+          position: 'relative',
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: isSelected ? 'primary.main' : 'transparent',
+          bgcolor: isSelected ? 'action.hover' : 'background.paper',
+          px: 4,
+          py: 3,
+          transition: 'border-color 0.2s ease, background-color 0.2s ease',
+          '&:hover .block-controls': { opacity: 1 },
+          cursor: 'pointer',
+        }}
+        draggable
+        onDragStart={(event) => {
+          event.dataTransfer.effectAllowed = 'move';
+          setDragState({ blockId: block.id, overIndex: null });
+        }}
+        onDragEnd={() => setDragState({ blockId: null, overIndex: null })}
+        onClick={() => handleSelectBlock(block.id)}
+      >
+        <Box
+          className="block-handle"
+          sx={{
+            position: 'absolute',
+            left: 12,
+            top: 16,
+            opacity: 0.4,
+            display: 'flex',
+            alignItems: 'center',
+            '&:hover': { opacity: 1 },
+          }}
+        >
+          <DragIndicatorIcon fontSize="small" />
+        </Box>
+        <Stack direction="row" spacing={1} className="block-controls" sx={{ position: 'absolute', right: 12, top: 12, opacity: 0 }}>
+          {isText && (
+            <Tooltip title={isEditing ? 'Stop editing' : 'Edit inline'}>
+              <IconButton
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setEditingBlockId(isEditing ? null : block.id);
+                }}
+              >
+                <EditIcon fontSize="small" />
               </IconButton>
             </Tooltip>
-          </Stack>
-          <Divider />
-          <Box sx={{ maxHeight: 600, overflowY: 'auto', pr: 1 }}>
+          )}
+          <Tooltip title="Delete block">
+            <IconButton
+              size="small"
+              color="error"
+              onClick={(event) => {
+                event.stopPropagation();
+                void handleDeleteBlock(block.id);
+              }}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+        <Stack spacing={2}>
+          <Chip
+            size="small"
+            icon={BLOCK_ICONS[block.block_type]}
+            label={`${block.block_type.toUpperCase()} · #${index + 1}`}
+            variant="outlined"
+            sx={{ alignSelf: 'flex-start' }}
+          />
+          {block.label && (
+            <Typography variant="subtitle2" color="text.secondary">
+              {block.label}
+            </Typography>
+          )}
+          {isText && isEditing ? (
+            <TextField
+              multiline
+              minRows={6}
+              value={block.text_md ?? ''}
+              onChange={(event) => queueBlockUpdate(block.id, { text_md: event.target.value })}
+              onBlur={() => setEditingBlockId(null)}
+              autoFocus
+            />
+          ) : (
+            <BlockRenderer block={block} resource={resourceForBlock(block)} />
+          )}
+        </Stack>
+      </Box>
+    );
+  };
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          gridTemplateColumns: {
+            xs: '1fr',
+            lg: propertiesOpen ? '260px minmax(0,1fr) 320px' : '260px minmax(0,1fr)',
+          },
+          alignItems: 'start',
+        }}
+      >
+        <Paper variant="outlined" sx={{ p: 2, maxHeight: 'calc(100vh - 200px)', overflowY: 'auto' }}>
+          <Stack spacing={2}>
+            <TextField
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search nodes"
+              InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
+            />
+            <Stack direction="row" spacing={1}>
+              <Button
+                fullWidth
+                startIcon={<AddIcon />}
+                onClick={() => setAddChildDialog({ open: true, parentId: null, mode: 'create' })}
+              >
+                Add Course
+              </Button>
+              <Tooltip title="Refresh">
+                <IconButton onClick={() => void loadData()}>
+                  <RefreshIcon />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+            <Divider />
             {trees.map((tree) => (
               <TreeNode
                 key={tree.node.id}
@@ -904,383 +1596,400 @@ export default function CourseBuilderAdmin() {
                 level={0}
                 expanded={expanded}
                 toggle={toggleExpand}
-                onSelect={setSelectedId}
+                onSelect={(id) => {
+                  setSelectedId(id);
+                  setPanelMode('node');
+                  setSelectedBlockId(null);
+                }}
                 selectedId={selectedId}
                 search={search}
                 onMenu={handleMenu}
               />
             ))}
-          </Box>
-        </Stack>
-      </Paper>
+          </Stack>
+        </Paper>
 
-      <Paper sx={{ flex: 1, p: 3 }} variant="outlined">
-        {selectedSubtree ? (
-          <Stack spacing={2}>
-            <Stack direction="row" justifyContent="space-between" alignItems="center">
-              <Typography variant="h6">{selectedSubtree.node.title ?? 'Untitled node'}</Typography>
-              <Tabs value={panelTab} onChange={(_, value) => setPanelTab(value)}>
-                <Tab label="Details" />
-                <Tab label="Children" />
-                <Tab label="Content Blocks" />
-              </Tabs>
+        <Stack spacing={2} sx={{ minHeight: 'calc(100vh - 200px)' }}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            {selectedSubtree ? (
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }} justifyContent="space-between">
+                <Stack spacing={0.5}>
+                  <Typography variant="h6">{selectedSubtree.node.title ?? 'Untitled node'}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {selectedSubtree.node.node_type}
+                  </Typography>
+                </Stack>
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} alignItems={{ xs: 'stretch', md: 'center' }}>
+                  <ToggleButtonGroup
+                    size="small"
+                    exclusive
+                    value={nodeDraft?.state ?? selectedSubtree.node.state}
+                    onChange={(_, value) => value && handleNodeFieldChange('state', value)}
+                  >
+                    <ToggleButton value="draft">Draft</ToggleButton>
+                    <ToggleButton value="published">Published</ToggleButton>
+                    <ToggleButton value="archived">Archived</ToggleButton>
+                  </ToggleButtonGroup>
+                  <Button variant="outlined" onClick={() => { setPanelMode('node'); setPropertiesOpen(true); }}>
+                    Node details
+                  </Button>
+                  <Button
+                    variant="contained"
+                    startIcon={<TextFieldsIcon />}
+                    disabled={!canEditBlocks}
+                    onClick={() => {
+                      if (!selectedSubtree) return;
+                      handleAddBlockAt(sortedBlocks.length, 'text');
+                    }}
+                    sx={{ display: { xs: 'none', md: 'inline-flex' } }}
+                  >
+                    Quick text block
+                  </Button>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    {savingState === 'saving' && <CircularProgress size={16} />}
+                    {savingState === 'saved' && <CheckCircleOutlineIcon color="success" fontSize="small" />}
+                    {savingState === 'error' && <ErrorOutlineIcon color="error" fontSize="small" />}
+                    <Typography variant="caption" color="text.secondary">
+                      {savingMessage}
+                    </Typography>
+                  </Stack>
+                </Stack>
+              </Stack>
+            ) : (
+              <Typography color="text.secondary">Select a node to begin editing.</Typography>
+            )}
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 3, flex: 1, overflowY: 'auto' }}>
+            {selectedSubtree ? (
+              <Box sx={{ maxWidth: 820, mx: 'auto' }}>
+                {canEditBlocks ? (
+                  <Stack spacing={2}>
+                    {renderDropZone(0)}
+                    {sortedBlocks.map((block, index) => (
+                      <Stack key={block.id} spacing={2}>
+                        {renderBlockCard(block, index)}
+                        {renderDropZone(index + 1)}
+                      </Stack>
+                    ))}
+                    {sortedBlocks.length === 0 && (
+                      <Alert severity="info" sx={{ mt: 2 }}>
+                        This node has no content blocks yet. Use the add buttons to get started.
+                      </Alert>
+                    )}
+                  </Stack>
+                ) : (
+                  <Alert severity="info">
+                    Content blocks are available only for nodes without child nodes. Select a lesson or chapter leaf node to edit blocks.
+                  </Alert>
+                )}
+              </Box>
+            ) : (
+              <Typography color="text.secondary">Select a node from the tree to preview its content.</Typography>
+            )}
+          </Paper>
+        </Stack>
+
+        {propertiesOpen && (
+          <Paper variant="outlined" sx={{ p: 3, maxHeight: 'calc(100vh - 200px)', overflowY: 'auto' }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+              <Typography variant="subtitle1">
+                {panelMode === 'block' && selectedBlock ? 'Block properties' : 'Node details'}
+              </Typography>
+              <Tooltip title="Collapse panel">
+                <IconButton size="small" onClick={() => setPropertiesOpen(false)}>
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
             </Stack>
 
-            {panelTab === 0 && (
+            {panelMode === 'block' && selectedBlock ? (
               <Stack spacing={2}>
-                <TextField
-                  label="Title"
-                  value={detailsForm.title}
-                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, title: event.target.value }))}
-                />
-                <TextField
-                  label="Slug"
-                  value={detailsForm.slug}
-                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, slug: event.target.value }))}
-                />
-                <TextField
-                  label="Description"
-                  multiline
-                  minRows={3}
-                  value={detailsForm.description}
-                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, description: event.target.value }))}
-                />
-                <FormControl fullWidth>
-                  <InputLabel id="state-select">State</InputLabel>
-                  <Select
-                    labelId="state-select"
-                    label="State"
-                    value={detailsForm.state}
-                    onChange={(event) =>
-                      setDetailsForm((prev) => ({ ...prev, state: event.target.value as NodeState }))
-                    }
-                  >
-                    <MenuItem value="draft">Draft</MenuItem>
-                    <MenuItem value="published">Published</MenuItem>
-                    <MenuItem value="archived">Archived</MenuItem>
-                  </Select>
-                </FormControl>
-                <TextField
-                  label="Hero image URL"
-                  value={detailsForm.hero_image}
-                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, hero_image: event.target.value }))}
-                />
-                <TextField
-                  label="Icon"
-                  value={detailsForm.icon}
-                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, icon: event.target.value }))}
-                />
-                <TextField
-                  label="Objectives"
-                  multiline
-                  minRows={3}
-                  value={detailsForm.objectives}
-                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, objectives: event.target.value }))}
-                />
-                <TextField
-                  label="Metadata (JSON)"
-                  multiline
-                  minRows={4}
-                  value={detailsForm.metadata}
-                  onChange={(event) => setDetailsForm((prev) => ({ ...prev, metadata: event.target.value }))}
-                />
-                <Button startIcon={<SaveIcon />} variant="contained" onClick={async () => {
-                  if (!selectedSubtree) return;
-                  if (detailsForm.state === 'published') {
-                    const unmet = selectedSubtree.children.filter(
-                      (child) => (child.edge.is_required ?? true) && child.subtree.node.state !== 'published',
-                    );
-                    if (unmet.length > 0) {
-                      setSnack({
-                        message: 'Publish required children before publishing this node.',
-                        severity: 'error',
-                      });
-                      return;
-                    }
-                  }
+                <Typography variant="subtitle2">Block #{selectedBlock.position + 1}</Typography>
+                {selectedBlock.block_type === 'text' && (
+                  <Stack spacing={1}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Button
+                        variant={showMarkdownPreview ? 'outlined' : 'contained'}
+                        size="small"
+                        onClick={() => setShowMarkdownPreview((prev) => !prev)}
+                      >
+                        {showMarkdownPreview ? 'Edit raw markdown' : 'Show preview'}
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        onClick={() => {
+                          setEditingBlockId(selectedBlock.id);
+                          setPanelMode('block');
+                        }}
+                      >
+                        Edit inline
+                      </Button>
+                    </Stack>
+                    {!showMarkdownPreview ? (
+                      <TextField
+                        multiline
+                        minRows={8}
+                        value={selectedBlock.text_md ?? ''}
+                        onChange={(event) => queueBlockUpdate(selectedBlock.id, { text_md: event.target.value })}
+                      />
+                    ) : (
+                      <BlockRenderer block={selectedBlock} resource={null} />
+                    )}
+                  </Stack>
+                )}
 
-                  let metadata: Record<string, unknown> | null = null;
-                  if (detailsForm.metadata.trim()) {
-                    try {
-                      metadata = JSON.parse(detailsForm.metadata);
-                    } catch {
-                      setSnack({ message: 'Metadata must be valid JSON', severity: 'error' });
-                      return;
-                    }
-                  }
+                {selectedBlock.block_type === 'asset' && (
+                  <Stack spacing={2}>
+                    <Button
+                      variant="outlined"
+                      startIcon={<SearchIcon />}
+                      onClick={() => {
+                        setResourceDialogMode({ type: 'update', blockId: selectedBlock.id });
+                        setResourceDialogOpen(true);
+                      }}
+                    >
+                      {selectedBlock.resource_id ? 'Change resource' : 'Select resource'}
+                    </Button>
+                    {selectedBlock.resource_id && (
+                      <Card variant="outlined" sx={{ p: 2 }}>
+                        <Typography variant="subtitle1">
+                          {resourceForBlock(selectedBlock)?.title ?? `Resource #${selectedBlock.resource_id}`}
+                        </Typography>
+                        {resourceForBlock(selectedBlock)?.url && (
+                          <Button
+                            size="small"
+                            endIcon={<OpenInNewIcon fontSize="small" />}
+                            href={resourceForBlock(selectedBlock)?.url ?? undefined}
+                            target="_blank"
+                            rel="noreferrer"
+                            sx={{ mt: 1 }}
+                          >
+                            Open resource
+                          </Button>
+                        )}
+                      </Card>
+                    )}
+                    <TextField
+                      label="Caption"
+                      value={selectedBlock.label ?? ''}
+                      onChange={(event) => queueBlockUpdate(selectedBlock.id, { label: event.target.value || null })}
+                    />
+                    <Stack direction="row" spacing={1}>
+                      <TextField
+                        label="Start (ms)"
+                        value={selectedBlock.start_ms != null ? String(selectedBlock.start_ms) : ''}
+                        onChange={(event) => {
+                          const parsed = Number(event.target.value);
+                          if (Number.isNaN(parsed) || parsed < 0) {
+                            queueBlockUpdate(selectedBlock.id, { start_ms: null });
+                          } else {
+                            queueBlockUpdate(selectedBlock.id, { start_ms: parsed });
+                          }
+                        }}
+                      />
+                      <TextField
+                        label="End (ms)"
+                        value={selectedBlock.end_ms != null ? String(selectedBlock.end_ms) : ''}
+                        onChange={(event) => {
+                          const parsed = Number(event.target.value);
+                          if (Number.isNaN(parsed) || parsed < 0) {
+                            queueBlockUpdate(selectedBlock.id, { end_ms: null });
+                          } else {
+                            queueBlockUpdate(selectedBlock.id, { end_ms: parsed });
+                          }
+                        }}
+                      />
+                    </Stack>
+                  </Stack>
+                )}
 
-                  const payload: Record<string, unknown> = {
-                    title: detailsForm.title,
-                    slug: detailsForm.slug || null,
-                    description: detailsForm.description || null,
-                    state: detailsForm.state,
-                    hero_image: detailsForm.hero_image || null,
-                    icon: detailsForm.icon || null,
-                    objectives: detailsForm.objectives || null,
-                    metadata,
-                  };
+                {selectedBlock.block_type === 'divider' && (
+                  <Alert severity="info">Divider blocks have no configurable properties.</Alert>
+                )}
 
-                  try {
-                    await runMutation(async () => {
-                      const res = await fetch(`/api/admin/course-builder/nodes/${selectedSubtree.node.id}`, {
-                        method: 'PATCH',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ updates: payload }),
-                      });
-                      if (!res.ok) {
-                        const body = await res.json().catch(() => ({ error: 'Failed to update node' }));
-                        throw new Error(body.error ?? 'Failed to update node');
-                      }
-                      return (await res.json()) as { subtree: NodeSubtree };
-                    }, { message: 'Node updated' });
-                  } catch (err) {
-                    console.error(err);
-                  }
-                }}>
-                  Save changes
+                <Button
+                  color="error"
+                  startIcon={<DeleteIcon />}
+                  onClick={() => void handleDeleteBlock(selectedBlock.id)}
+                >
+                  Delete block
                 </Button>
               </Stack>
-            )}
-
-            {panelTab === 1 && (
-              <Stack spacing={2}>
-                <Stack direction="row" spacing={1}>
-                  <Button
-                    startIcon={<AddIcon />}
-                    onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'create' })}
-                  >
-                    Create child
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'attach' })}
-                  >
-                    Add existing
-                  </Button>
+            ) : selectedSubtree && nodeDraft ? (
+              <Stack spacing={3}>
+                <Stack spacing={2}>
+                  <TextField
+                    label="Title"
+                    value={nodeDraft.title}
+                    onChange={(event) => handleNodeFieldChange('title', event.target.value)}
+                  />
+                  <TextField
+                    label="Slug"
+                    value={nodeDraft.slug}
+                    onChange={(event) => handleNodeFieldChange('slug', event.target.value)}
+                  />
+                  <TextField
+                    label="Description"
+                    multiline
+                    minRows={3}
+                    value={nodeDraft.description}
+                    onChange={(event) => handleNodeFieldChange('description', event.target.value)}
+                  />
+                  <TextField
+                    label="Hero image URL"
+                    value={nodeDraft.hero_image}
+                    onChange={(event) => handleNodeFieldChange('hero_image', event.target.value)}
+                  />
+                  <TextField
+                    label="Icon"
+                    value={nodeDraft.icon}
+                    onChange={(event) => handleNodeFieldChange('icon', event.target.value)}
+                  />
+                  <TextField
+                    label="Objectives"
+                    multiline
+                    minRows={3}
+                    value={nodeDraft.objectives}
+                    onChange={(event) => handleNodeFieldChange('objectives', event.target.value)}
+                  />
+                  <TextField
+                    label="Metadata (JSON)"
+                    multiline
+                    minRows={4}
+                    value={nodeDraft.metadata}
+                    onChange={(event) => handleNodeFieldChange('metadata', event.target.value)}
+                    error={!!metadataError}
+                    helperText={metadataError ?? 'Provide structured metadata for this node'}
+                  />
                 </Stack>
-                <List>
+
+                <Divider />
+
+                <Stack spacing={1} direction="row" justifyContent="space-between" alignItems="center">
+                  <Typography variant="subtitle2">Children</Typography>
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      size="small"
+                      startIcon={<AddIcon />}
+                      onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'create' })}
+                    >
+                      Add child
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'attach' })}
+                    >
+                      Attach existing
+                    </Button>
+                  </Stack>
+                </Stack>
+
+                <Stack spacing={1.5}>
                   {selectedSubtree.children
                     .slice()
                     .sort((a, b) => a.edge.position - b.edge.position)
                     .map((child, index, arr) => (
-                      <ListItem
-                        key={child.subtree.node.id}
-                        secondaryAction={
-                          <Stack direction="row" spacing={1}>
-                            <Tooltip title="Move up">
-                              <span>
-                                <IconButton
-                                  size="small"
-                                  disabled={index === 0}
-                                  onClick={() =>
-                                    handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'up')
-                                  }
-                                >
-                                  <ArrowUpwardIcon fontSize="small" />
-                                </IconButton>
-                              </span>
-                            </Tooltip>
-                            <Tooltip title="Move down">
-                              <span>
-                                <IconButton
-                                  size="small"
-                                  disabled={index === arr.length - 1}
-                                  onClick={() =>
-                                    handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'down')
-                                  }
-                                >
-                                  <ArrowDownwardIcon fontSize="small" />
-                                </IconButton>
-                              </span>
-                            </Tooltip>
-                            <Tooltip title="Remove child">
-                              <IconButton
-                                size="small"
-                                color="error"
-                                onClick={() => handleRemoveChild(selectedSubtree.node.id, child.edge.child_id)}
-                              >
-                                <DeleteIcon fontSize="small" />
-                              </IconButton>
-                            </Tooltip>
-                          </Stack>
-                        }
-                      >
-                        <ListItemIcon>
-                          {NODE_ICONS[child.subtree.node.node_type] ?? <StorageIcon fontSize="small" />}
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={child.subtree.node.title ?? 'Untitled'}
-                          secondary={`${child.subtree.node.node_type} · position ${child.edge.position}`}
-                        />
-                        <Checkbox
-                          checked={child.edge.is_required ?? true}
-                          onChange={(event) =>
-                            handleUpdateChild(selectedSubtree.node.id, child, {
-                              is_required: event.target.checked,
-                            })
-                          }
-                          inputProps={{ 'aria-label': 'Required child toggle' }}
-                        />
-                      </ListItem>
-                    ))}
-                </List>
-              </Stack>
-            )}
-
-            {panelTab === 2 && (
-              <Stack spacing={2}>
-                {selectedSubtree.children.length > 0 ? (
-                  <Alert severity="info">
-                    Content blocks are available only for nodes without child nodes.
-                  </Alert>
-                ) : (
-                  <>
-                    <Stack direction="row" spacing={1}>
-                      <Button
-                        startIcon={<TextFieldsIcon />}
-                        onClick={() => {
-                          setBlockEditor({ ...EMPTY_BLOCK, type: 'text' });
-                          setBlockDialogOpen(true);
-                        }}
-                      >
-                        Add Text
-                      </Button>
-                      <Button
-                        startIcon={<VideoLibraryIcon />}
-                        onClick={() => {
-                          setBlockEditor({ ...EMPTY_BLOCK, type: 'asset' });
-                          setBlockDialogOpen(true);
-                        }}
-                      >
-                        Add Resource
-                      </Button>
-                      <Button
-                        startIcon={<HorizontalRuleIcon />}
-                        onClick={() => {
-                          setBlockEditor({ ...EMPTY_BLOCK, type: 'divider' });
-                          setBlockDialogOpen(true);
-                        }}
-                      >
-                        Add Divider
-                      </Button>
-                    </Stack>
-                    <List>
-                      {selectedSubtree.blocks
-                        .slice()
-                        .sort((a, b) => a.position - b.position)
-                        .map((block, index, arr) => (
-                          <ListItem
-                            key={block.id}
-                            secondaryAction={
-                              <Stack direction="row" spacing={1}>
-                                <Tooltip title="Move up">
-                                  <span>
-                                    <IconButton
-                                      size="small"
-                                      disabled={index === 0}
-                                      onClick={() =>
-                                        handleReorderBlocks(selectedSubtree.node.id, selectedSubtree.blocks, block.id, 'up')
-                                      }
-                                    >
-                                      <ArrowUpwardIcon fontSize="small" />
-                                    </IconButton>
-                                  </span>
-                                </Tooltip>
-                                <Tooltip title="Move down">
-                                  <span>
-                                    <IconButton
-                                      size="small"
-                                      disabled={index === arr.length - 1}
-                                      onClick={() =>
-                                        handleReorderBlocks(
-                                          selectedSubtree.node.id,
-                                          selectedSubtree.blocks,
-                                          block.id,
-                                          'down',
-                                        )
-                                      }
-                                    >
-                                      <ArrowDownwardIcon fontSize="small" />
-                                    </IconButton>
-                                  </span>
-                                </Tooltip>
-                                <Tooltip title="Edit block">
+                      <Paper key={child.edge.child_id} variant="outlined" sx={{ p: 2 }}>
+                        <Stack spacing={1.5}>
+                          <Stack direction="row" justifyContent="space-between" alignItems="center">
+                            <Stack spacing={0.5}>
+                              <Typography variant="subtitle2">{child.subtree.node.title ?? `Node #${child.subtree.node.id}`}</Typography>
+                              <Typography variant="caption" color="text.secondary">
+                                {child.subtree.node.node_type}
+                              </Typography>
+                            </Stack>
+                            <Stack direction="row" spacing={1} alignItems="center">
+                              <Tooltip title="Move up">
+                                <span>
                                   <IconButton
                                     size="small"
-                                    onClick={() => {
-                                      setBlockEditor({
-                                        mode: 'edit',
-                                        block,
-                                        type: block.block_type,
-                                        text_md: block.text_md ?? '',
-                                        resource: block.resource_id
-                                          ? {
-                                              id: block.resource_id,
-                                              title: `Resource #${block.resource_id}`,
-                                              type: null,
-                                              state: null,
-                                              thumbnail: null,
-                                              duration: null,
-                                              url: null,
-                                            }
-                                          : null,
-                                        label: block.label ?? '',
-                                        start_ms: block.start_ms != null ? String(block.start_ms) : '',
-                                        end_ms: block.end_ms != null ? String(block.end_ms) : '',
-                                        notes: block.notes ?? '',
-                                        preview: false,
-                                      });
-                                      setBlockDialogOpen(true);
-                                    }}
+                                    disabled={index === 0}
+                                    onClick={() => handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'up')}
                                   >
-                                    <EditIcon fontSize="small" />
+                                    <ArrowUpwardIcon fontSize="small" />
                                   </IconButton>
-                                </Tooltip>
-                                <Tooltip title="Delete block">
-                                  <IconButton size="small" color="error" onClick={() => handleDeleteBlock(block.id)}>
-                                    <DeleteIcon fontSize="small" />
+                                </span>
+                              </Tooltip>
+                              <Tooltip title="Move down">
+                                <span>
+                                  <IconButton
+                                    size="small"
+                                    disabled={index === arr.length - 1}
+                                    onClick={() => handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'down')}
+                                  >
+                                    <ArrowDownwardIcon fontSize="small" />
                                   </IconButton>
-                                </Tooltip>
-                              </Stack>
-                            }
-                          >
-                            <ListItemIcon>{BLOCK_ICONS[block.block_type]}</ListItemIcon>
-                            <ListItemText
-                              primary={`${block.block_type} #${block.position}`}
-                              secondary={
-                                block.block_type === 'text'
-                                  ? (block.text_md ?? '').slice(0, 80)
-                                  : block.block_type === 'asset'
-                                  ? `Resource ${block.resource_id ?? 'unknown'}`
-                                  : 'Divider'
+                                </span>
+                              </Tooltip>
+                              <Tooltip title="Remove child">
+                                <IconButton
+                                  size="small"
+                                  color="error"
+                                  onClick={() => void handleRemoveChild(selectedSubtree.node.id, child.edge.child_id)}
+                                >
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            </Stack>
+                          </Stack>
+                          <Stack direction="row" spacing={1} alignItems="center">
+                            <Checkbox
+                              checked={child.edge.is_required ?? true}
+                              onChange={(event) =>
+                                void handleUpdateChild(selectedSubtree.node.id, child, {
+                                  is_required: event.target.checked,
+                                })
                               }
+                              size="small"
                             />
-                          </ListItem>
-                        ))}
-                    </List>
-                  </>
-                )}
+                            <Typography variant="body2">Required for progression</Typography>
+                          </Stack>
+                        </Stack>
+                      </Paper>
+                    ))}
+                  {selectedSubtree.children.length === 0 && (
+                    <Typography variant="body2" color="text.secondary">
+                      This node has no children.
+                    </Typography>
+                  )}
+                </Stack>
               </Stack>
+            ) : (
+              <Typography color="text.secondary">Select a node to edit details.</Typography>
             )}
-          </Stack>
-        ) : (
-          <Typography color="text.secondary">Select a node from the tree to start editing.</Typography>
+          </Paper>
         )}
-      </Paper>
+      </Box>
+
+      {!propertiesOpen && (
+        <Box sx={{ position: 'fixed', bottom: 24, right: 24 }}>
+          <Button variant="contained" onClick={() => setPropertiesOpen(true)}>
+            Open properties
+          </Button>
+        </Box>
+      )}
 
       <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
         <MenuItem
           onClick={() => {
             if (!menuNodeId) return;
-            const node = findSubtree(trees, menuNodeId);
             closeMenu();
             setAddChildDialog({ open: true, parentId: menuNodeId, mode: 'create' });
-            if (node) {
-              setSelectedId(node.node.id);
-            }
           }}
         >
           <AddIcon fontSize="small" sx={{ mr: 1 }} /> Add child
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (!menuNodeId) return;
+            closeMenu();
+            setAddChildDialog({ open: true, parentId: menuNodeId, mode: 'attach' });
+          }}
+        >
+          <SearchIcon fontSize="small" sx={{ mr: 1 }} /> Attach existing
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -1301,47 +2010,38 @@ export default function CourseBuilderAdmin() {
         >
           <DeleteIcon fontSize="small" sx={{ mr: 1 }} /> Delete
         </MenuItem>
-        <Divider />
-        {(['draft', 'published', 'archived'] as NodeState[]).map((state) => (
-          <MenuItem
-            key={state}
-            onClick={async () => {
-              if (!menuNodeId) return;
-              closeMenu();
-              try {
-                await runMutation(async () => {
-                  const res = await fetch(`/api/admin/course-builder/nodes/${menuNodeId}`, {
-                    method: 'PATCH',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ updates: { state } }),
-                  });
-                  if (!res.ok) {
-                    const body = await res.json().catch(() => ({ error: 'Failed to update state' }));
-                    throw new Error(body.error ?? 'Failed to update state');
-                  }
-                  return (await res.json()) as { subtree: NodeSubtree };
-                }, { message: 'State updated' });
-              } catch (err) {
-                console.error(err);
-              }
-            }}
-          >
-            Set {state}
-          </MenuItem>
-        ))}
+      </Menu>
+
+      <Menu
+        anchorEl={insertMenu?.anchor}
+        open={!!insertMenu}
+        onClose={() => setInsertMenu(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <MenuItem onClick={() => insertMenu && handleAddBlockAt(insertMenu.index, 'text')}>
+          <TextFieldsIcon fontSize="small" sx={{ mr: 1 }} /> Text block
+        </MenuItem>
+        <MenuItem onClick={() => insertMenu && handleAddBlockAt(insertMenu.index, 'asset')}>
+          <VideoLibraryIcon fontSize="small" sx={{ mr: 1 }} /> Resource block
+        </MenuItem>
+        <MenuItem onClick={() => insertMenu && handleAddBlockAt(insertMenu.index, 'divider')}>
+          <HorizontalRuleIcon fontSize="small" sx={{ mr: 1 }} /> Divider
+        </MenuItem>
       </Menu>
 
       <Dialog
         open={deleteDialog.open && !!deleteDialog.subtree}
         onClose={() => setDeleteDialog({ open: false, nodeId: null, subtree: null })}
+        fullWidth
+        maxWidth="sm"
       >
         <DialogTitle>Delete node</DialogTitle>
         <DialogContent dividers>
           {deleteStats ? (
             <Stack spacing={2}>
               <Alert severity="warning">
-                Deleting <strong>{deleteDialog.subtree!.node.title ?? 'this node'}</strong> will also remove the
-                following:
+                Deleting <strong>{deleteDialog.subtree!.node.title ?? 'this node'}</strong> will also remove the following:
               </Alert>
               <Stack spacing={1}>
                 {deleteStats.nodes.map(({ type, count }) => (
@@ -1354,7 +2054,7 @@ export default function CourseBuilderAdmin() {
               <Alert severity="error">This action cannot be undone.</Alert>
             </Stack>
           ) : (
-            <CircularProgress size={20} />
+            <CircularProgress size={24} />
           )}
         </DialogContent>
         <DialogActions>
@@ -1406,47 +2106,52 @@ export default function CourseBuilderAdmin() {
           ) : (
             <Stack spacing={2}>
               <TextField
-                label="Search by title"
-                onChange={(event) => void fetchSearch(event.target.value)}
-                InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
+                label="Search nodes"
+                value={attachQuery}
+                onChange={(event) => setAttachQuery(event.target.value)}
               />
               {searchResults.loading && <CircularProgress size={20} />}
-              <List>
-                {searchResults.rows.map((row) => (
-                  <ListItem
-                    key={row.id}
-                    onClick={() => {
-                      if (!addChildDialog.parentId) return;
-                      void handleAttachExisting(addChildDialog.parentId, row.id);
-                      setAddChildDialog({ open: false, parentId: null, mode: 'create' });
-                    }}
-                  >
-                    <ListItemText primary={row.title} secondary={`${row.node_type} · ${row.state}`} />
-                  </ListItem>
-                ))}
-              </List>
+              {searchResults.error && <Alert severity="error">{searchResults.error}</Alert>}
+              {!searchResults.loading && !searchResults.error && (
+                <Stack spacing={1}>
+                  {searchResults.rows.map((row) => (
+                    <Button
+                      key={row.id}
+                      variant="outlined"
+                      onClick={() => {
+                        if (!addChildDialog.parentId) return;
+                        void handleAttachExisting(addChildDialog.parentId, row.id);
+                        setAddChildDialog({ open: false, parentId: null, mode: 'create' });
+                      }}
+                    >
+                      {row.title ?? `Node #${row.id}`} ({row.node_type})
+                    </Button>
+                  ))}
+                  {searchResults.rows.length === 0 && (
+                    <Typography variant="body2" color="text.secondary">
+                      No nodes found.
+                    </Typography>
+                  )}
+                </Stack>
+              )}
             </Stack>
           )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setAddChildDialog({ open: false, parentId: null, mode: 'create' })}>Cancel</Button>
-          {addChildDialog.mode === 'create' && (
+          {addChildDialog.mode === 'create' ? (
             <Button
               variant="contained"
-              disabled={!newChildTitle.trim() || availableChildTypes.length === 0}
+              disabled={!newChildTitle.trim()}
               onClick={() => {
-                const parentId = addChildDialog.parentId;
-                if (!newChildTitle.trim()) {
-                  setSnack({ message: 'Provide a title for the new node.', severity: 'error' });
-                  return;
-                }
-                void handleAddChild(parentId, { node_type: newChildType, title: newChildTitle.trim() });
+                if (addChildDialog.mode !== 'create') return;
+                void handleAddChild(addChildDialog.parentId, { node_type: newChildType, title: newChildTitle });
                 setAddChildDialog({ open: false, parentId: null, mode: 'create' });
               }}
             >
               Create
             </Button>
-          )}
+          ) : null}
         </DialogActions>
       </Dialog>
 
@@ -1457,18 +2162,16 @@ export default function CourseBuilderAdmin() {
         <DialogTitle>Duplicate node</DialogTitle>
         <DialogContent dividers>
           <Typography>
-            Duplicate this node and optionally attach it to the same parent. The copy will inherit the entire
-            subtree.
+            Duplicate this node and attach the copy to the same parent?
           </Typography>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setDuplicateDialog({ open: false, nodeId: null })}>Cancel</Button>
           <Button
-            variant="contained"
             onClick={() => {
               if (!duplicateDialog.nodeId) return;
-              const parentEdge = findParentEdge(trees, duplicateDialog.nodeId);
-              void handleDuplicate(duplicateDialog.nodeId, parentEdge?.parent_id ?? null);
+              const parent = findParentEdge(trees, duplicateDialog.nodeId);
+              void handleDuplicate(duplicateDialog.nodeId, parent ? parent.parent_id : null);
               setDuplicateDialog({ open: false, nodeId: null });
             }}
           >
@@ -1479,48 +2182,11 @@ export default function CourseBuilderAdmin() {
 
       <ResourcePickerDialog
         open={resourceDialogOpen}
-        onClose={() => setResourceDialogOpen(false)}
-        onSelect={(resource) =>
-          setBlockEditor((prev) => ({
-            ...prev,
-            resource,
-          }))
-        }
-      />
-
-      <BlockEditorDialog
-        open={blockDialogOpen}
-        onClose={() => setBlockDialogOpen(false)}
-        state={blockEditor}
-        onChange={setBlockEditor}
-        onSelectResource={() => setResourceDialogOpen(true)}
-        onSubmit={() => {
-          if (!selectedSubtree) return;
-          if (blockEditor.mode === 'create') {
-            const base: Partial<ContentBlock> & { block_type: BlockType } = {
-              block_type: blockEditor.type,
-              text_md: blockEditor.type === 'text' ? blockEditor.text_md : undefined,
-              resource_id: blockEditor.type === 'asset' ? blockEditor.resource?.id ?? null : null,
-              label: blockEditor.label || null,
-              start_ms: blockEditor.start_ms ? Number(blockEditor.start_ms) : null,
-              end_ms: blockEditor.end_ms ? Number(blockEditor.end_ms) : null,
-              notes: blockEditor.notes || null,
-            };
-            void handleCreateBlock(selectedSubtree.node.id, base);
-          } else if (blockEditor.block) {
-            const updates: Partial<ContentBlock> = {
-              block_type: blockEditor.type,
-              text_md: blockEditor.type === 'text' ? blockEditor.text_md : null,
-              resource_id: blockEditor.type === 'asset' ? blockEditor.resource?.id ?? null : null,
-              label: blockEditor.label || null,
-              start_ms: blockEditor.start_ms ? Number(blockEditor.start_ms) : null,
-              end_ms: blockEditor.end_ms ? Number(blockEditor.end_ms) : null,
-              notes: blockEditor.notes || null,
-            };
-            void handleUpdateBlock(blockEditor.block.id, updates);
-          }
-          setBlockDialogOpen(false);
+        onClose={() => {
+          setResourceDialogOpen(false);
+          setResourceDialogMode(null);
         }}
+        onSelect={handleResourceSelected}
       />
 
       <Snackbar
@@ -1535,263 +2201,6 @@ export default function CourseBuilderAdmin() {
           </Alert>
         )}
       </Snackbar>
-    </Stack>
+    </>
   );
-
-  async function handleAddChild(parentId: number | null, payload: { node_type: string; title: string }) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch('/api/admin/course-builder/nodes', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ node: payload, parent: parentId ? { parent_id: parentId } : null }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to create node' }));
-          throw new Error(body.error ?? 'Failed to create node');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, { message: 'Node created' });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleAttachExisting(parentId: number, childId: number) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ child_id: childId }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to attach child' }));
-          throw new Error(body.error ?? 'Failed to attach child');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, { message: 'Child attached' });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleDuplicate(nodeId: number, parentId: number | null) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/duplicate`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ parent: parentId ? { parent_id: parentId } : null }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to duplicate node' }));
-          throw new Error(body.error ?? 'Failed to duplicate node');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, { message: 'Node duplicated' });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleRemoveChild(parentId: number, childId: number) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/${childId}`, {
-          method: 'DELETE',
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to remove child' }));
-          throw new Error(body.error ?? 'Failed to remove child');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, { message: 'Child removed' });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleDeleteNode(nodeId: number) {
-    const parentEdge = findParentEdge(trees, nodeId);
-    try {
-      await runMutation(
-        async () => {
-          const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}`, { method: 'DELETE' });
-          if (!res.ok) {
-            const body = await res.json().catch(() => ({ error: 'Failed to delete node' }));
-            throw new Error(body.error ?? 'Failed to delete node');
-          }
-          const payload = (await res.json()) as { parentSubtree: NodeSubtree | null };
-          if (!payload.parentSubtree) {
-            setTrees((prev) => removeSubtree(prev, nodeId));
-          }
-          return payload;
-        },
-        { message: 'Node deleted', optimistic: (prev) => removeSubtree(prev, nodeId) },
-      );
-      setSelectedId(parentEdge ? parentEdge.parent_id : null);
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleReorderChild(parentId: number, childId: number, direction: 'up' | 'down') {
-    const parent = findSubtree(trees, parentId);
-    if (!parent) return;
-    const children = [...parent.children].sort((a, b) => a.edge.position - b.edge.position);
-    const index = children.findIndex((child) => child.edge.child_id === childId);
-    const swapWith = direction === 'up' ? index - 1 : index + 1;
-    if (swapWith < 0 || swapWith >= children.length) return;
-
-    const reordered = [...children];
-    const [moved] = reordered.splice(index, 1);
-    reordered.splice(swapWith, 0, moved);
-
-    const updates = reordered.map((child, idx) => ({ child_id: child.edge.child_id, position: idx }));
-
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/reorder`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ updates }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to reorder children' }));
-          throw new Error(body.error ?? 'Failed to reorder children');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, {
-        optimistic: (prev) => {
-          const snapshot = prev.map((tree) => cloneSubtree(tree));
-          const target = findSubtree(snapshot, parentId);
-          if (target) {
-            target.children = reordered.map((child, idx) => ({
-              edge: { ...child.edge, position: idx },
-              subtree: child.subtree,
-            }));
-          }
-          return snapshot;
-        },
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleUpdateChild(parentId: number, child: NodeSubtree['children'][number], updates: Partial<NodeChild>) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/nodes/${parentId}/children/reorder`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            updates: [
-              {
-                child_id: child.edge.child_id,
-                position: child.edge.position,
-                ...updates,
-              },
-            ],
-          }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to update child' }));
-          throw new Error(body.error ?? 'Failed to update child');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleCreateBlock(nodeId: number, block: Partial<ContentBlock> & { block_type: BlockType }) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/blocks`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ block }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to create block' }));
-          throw new Error(body.error ?? 'Failed to create block');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, { message: 'Block created' });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleUpdateBlock(blockId: number, updates: Partial<ContentBlock>) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/blocks/${blockId}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ updates }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to update block' }));
-          throw new Error(body.error ?? 'Failed to update block');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, { message: 'Block updated' });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleDeleteBlock(blockId: number) {
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/blocks/${blockId}`, { method: 'DELETE' });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to delete block' }));
-          throw new Error(body.error ?? 'Failed to delete block');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      }, { message: 'Block deleted' });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function handleReorderBlocks(
-    nodeId: number,
-    blocks: ContentBlock[],
-    blockId: number,
-    direction: 'up' | 'down',
-  ) {
-    const sorted = [...blocks].sort((a, b) => a.position - b.position);
-    const index = sorted.findIndex((block) => block.id === blockId);
-    const swapWith = direction === 'up' ? index - 1 : index + 1;
-    if (swapWith < 0 || swapWith >= sorted.length) return;
-
-    const reordered = [...sorted];
-    const [moved] = reordered.splice(index, 1);
-    reordered.splice(swapWith, 0, moved);
-
-    const updates = reordered.map((block, idx) => ({ block_id: block.id, position: idx }));
-
-    try {
-      await runMutation(async () => {
-        const res = await fetch(`/api/admin/course-builder/nodes/${nodeId}/blocks/reorder`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ updates }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: 'Failed to reorder blocks' }));
-          throw new Error(body.error ?? 'Failed to reorder blocks');
-        }
-        return (await res.json()) as { subtree: NodeSubtree };
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  }
 }

--- a/src/components/admin/CourseBuilderAdmin.tsx
+++ b/src/components/admin/CourseBuilderAdmin.tsx
@@ -15,7 +15,9 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  Fade,
   FormControl,
+  FormControlLabel,
   IconButton,
   InputLabel,
   Menu,
@@ -27,8 +29,12 @@ import {
   TextField,
   ToggleButton,
   ToggleButtonGroup,
+  Switch,
   Tooltip,
   Typography,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -133,12 +139,6 @@ const NODE_ICONS: Partial<Record<NodeType, JSX.Element>> = {
   chapter: <LayersIcon fontSize="small" />,
   collection: <CollectionsBookmarkIcon fontSize="small" />,
   playlist: <PlaylistPlayIcon fontSize="small" />,
-};
-
-const BLOCK_ICONS: Record<BlockType, JSX.Element> = {
-  text: <TextFieldsIcon fontSize="small" />,
-  asset: <VideoLibraryIcon fontSize="small" />,
-  divider: <HorizontalRuleIcon fontSize="small" />,
 };
 
 const STATE_COLORS: Record<NodeState, 'default' | 'success' | 'warning'> = {
@@ -608,6 +608,8 @@ export default function CourseBuilderAdmin() {
     blockId: null,
     overIndex: null,
   });
+  const [hoveredBlockId, setHoveredBlockId] = useState<number | null>(null);
+  const [previewMode, setPreviewMode] = useState(false);
   const [resourceCache, setResourceCache] = useState<Record<number, ResourceRow>>({});
   const [savingState, setSavingState] = useState<SavingState>('idle');
   const [savingMessage, setSavingMessage] = useState('All changes saved');
@@ -619,8 +621,7 @@ export default function CourseBuilderAdmin() {
   const optimisticSnapshot = useRef<NodeSubtree[] | null>(null);
   const [nodeDraft, setNodeDraft] = useState<NodeDraft | null>(null);
   const [metadataError, setMetadataError] = useState<string | null>(null);
-  const [showMarkdownPreview, setShowMarkdownPreview] = useState(true);
-  const [editingBlockId, setEditingBlockId] = useState<number | null>(null);
+  const [editingState, setEditingState] = useState<{ blockId: number; mode: 'edit' | 'preview' } | null>(null);
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -695,8 +696,7 @@ export default function CourseBuilderAdmin() {
     setPanelMode('node');
     setSelectedBlockId(null);
     setMetadataError(null);
-    setShowMarkdownPreview(true);
-    setEditingBlockId(null);
+    setEditingState(null);
   }, [selectedSubtree]);
 
   useEffect(() => {
@@ -1019,11 +1019,19 @@ export default function CourseBuilderAdmin() {
     [flushNodeUpdate],
   );
 
-  const handleSelectBlock = useCallback((blockId: number) => {
-    setSelectedBlockId(blockId);
+  const handleSelectBlock = useCallback((block: ContentBlock, options?: { inlineEdit?: boolean }) => {
+    setSelectedBlockId(block.id);
     setPanelMode('block');
     setPropertiesOpen(true);
-    setEditingBlockId(null);
+    setEditingState((prev) => {
+      if (options?.inlineEdit && block.block_type === 'text') {
+        return { blockId: block.id, mode: prev?.blockId === block.id ? prev.mode : 'edit' };
+      }
+      if (prev?.blockId === block.id) {
+        return prev;
+      }
+      return null;
+    });
   }, []);
 
   const handleReorderBlocksToIndex = useCallback(
@@ -1090,6 +1098,7 @@ export default function CourseBuilderAdmin() {
       if (selectedBlockId === blockId) {
         setSelectedBlockId(null);
         setPanelMode('node');
+        setEditingState(null);
       }
     },
     [runMutation, selectedBlockId],
@@ -1120,7 +1129,7 @@ export default function CourseBuilderAdmin() {
         setSelectedBlockId(newBlock.id);
         setPanelMode('block');
         setPropertiesOpen(true);
-        setEditingBlockId(newBlock.id);
+        setEditingState({ blockId: newBlock.id, mode: 'edit' });
       }
     },
     [runMutation, trees],
@@ -1408,145 +1417,314 @@ export default function CourseBuilderAdmin() {
     return resourceCache[block.resource_id] ?? null;
   };
 
-  const renderDropZone = (index: number) => (
-    <Box
-      key={`drop-${index}`}
-      onDragOver={(event) => {
-        event.preventDefault();
-        setDragState((prev) => ({ ...prev, overIndex: index }));
-      }}
-      onDragLeave={() => setDragState((prev) => ({ ...prev, overIndex: prev.overIndex === index ? null : prev.overIndex }))}
-      onDrop={(event) => {
-        event.preventDefault();
-        if (dragState.blockId != null) {
-          void handleReorderBlocksToIndex(dragState.blockId, index);
+  const renderDropZone = (index: number) => {
+    const before = sortedBlocks[index - 1];
+    const after = sortedBlocks[index];
+    const showIndicator = dragState.overIndex === index;
+    const showButton =
+      !previewMode &&
+      (showIndicator || hoveredBlockId === before?.id || hoveredBlockId === after?.id || (sortedBlocks.length === 0 && index === 0));
+
+    return (
+      <Box
+        key={`drop-${index}`}
+        onDragOver={(event) => {
+          if (previewMode) return;
+          event.preventDefault();
+          setDragState((prev) => ({ ...prev, overIndex: index }));
+        }}
+        onDragLeave={() =>
+          setDragState((prev) => ({ ...prev, overIndex: prev.overIndex === index ? null : prev.overIndex }))
         }
-        setDragState({ blockId: null, overIndex: null });
-      }}
-      sx={{
-        position: 'relative',
-        my: 1,
-        display: 'flex',
-        justifyContent: 'center',
-      }}
-    >
-      <Button
-        variant="outlined"
-        size="small"
-        startIcon={<AddIcon />}
-        onClick={(event) => {
-          setInsertMenu({ anchor: event.currentTarget, index });
+        onDrop={(event) => {
+          if (previewMode) return;
+          event.preventDefault();
+          if (dragState.blockId != null) {
+            void handleReorderBlocksToIndex(dragState.blockId, index);
+          }
+          setDragState({ blockId: null, overIndex: null });
+        }}
+        sx={{
+          position: 'relative',
+          height: 32,
+          my: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
         }}
       >
-        Add block
-      </Button>
-      {dragState.overIndex === index && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            left: 12,
-            right: 12,
-            height: 2,
-            bgcolor: 'primary.main',
-          }}
-        />
-      )}
-    </Box>
-  );
+        {!previewMode && (
+          <Fade in={showButton} timeout={120}>
+            <IconButton
+              size="small"
+              color="primary"
+              sx={{
+                bgcolor: 'background.paper',
+                border: '1px solid',
+                borderColor: 'divider',
+                boxShadow: 3,
+                opacity: showButton ? 1 : 0,
+                pointerEvents: showButton ? 'auto' : 'none',
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  bgcolor: 'primary.main',
+                  color: 'primary.contrastText',
+                },
+              }}
+              onClick={(event) => {
+                event.stopPropagation();
+                setInsertMenu({ anchor: event.currentTarget, index });
+              }}
+            >
+              <AddIcon fontSize="small" />
+            </IconButton>
+          </Fade>
+        )}
+        {showIndicator && (
+          <Box
+            sx={{
+              position: 'absolute',
+              left: 32,
+              right: 32,
+              height: 2,
+              bgcolor: 'primary.main',
+              borderRadius: 1,
+            }}
+          />
+        )}
+      </Box>
+    );
+  };
 
-  const renderBlockCard = (block: ContentBlock, index: number) => {
+  const renderBlockCard = (block: ContentBlock) => {
     const isSelected = selectedBlockId === block.id;
-    const isText = block.block_type === 'text';
-    const isEditing = editingBlockId === block.id;
+    const resource = resourceForBlock(block);
+    const isEditing = editingState?.blockId === block.id;
+    const editingMode = editingState?.blockId === block.id ? editingState.mode : 'preview';
+    const showHandle = !previewMode;
+    const showControls = !previewMode;
+
     return (
       <Box
         key={block.id}
         sx={{
           position: 'relative',
-          borderRadius: 2,
+          borderRadius: 3,
           border: '1px solid',
-          borderColor: isSelected ? 'primary.main' : 'transparent',
-          bgcolor: isSelected ? 'action.hover' : 'background.paper',
-          px: 4,
-          py: 3,
-          transition: 'border-color 0.2s ease, background-color 0.2s ease',
-          '&:hover .block-controls': { opacity: 1 },
-          cursor: 'pointer',
+          borderColor: isSelected ? 'primary.main' : hoveredBlockId === block.id ? 'divider' : 'transparent',
+          boxShadow: isSelected
+            ? '0 0 0 3px rgba(25, 118, 210, 0.12)'
+            : hoveredBlockId === block.id
+            ? '0 18px 32px rgba(15, 23, 42, 0.12)'
+            : 'none',
+          backgroundColor: 'background.paper',
+          px: { xs: 2, md: 3 },
+          py: { xs: 2.5, md: 3.5 },
+          cursor: previewMode ? 'default' : block.block_type === 'text' ? 'text' : 'pointer',
+          transition: 'box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease',
+          '&:hover .block-controls': { opacity: previewMode ? 0 : 1 },
+          '&:hover .block-handle': { opacity: previewMode ? 0 : 0.9 },
+          '&:hover .block-overlay': { opacity: previewMode ? 0 : 1 },
         }}
-        draggable
+        draggable={!previewMode}
         onDragStart={(event) => {
+          if (previewMode) return;
           event.dataTransfer.effectAllowed = 'move';
           setDragState({ blockId: block.id, overIndex: null });
         }}
         onDragEnd={() => setDragState({ blockId: null, overIndex: null })}
-        onClick={() => handleSelectBlock(block.id)}
+        onMouseEnter={() => setHoveredBlockId(block.id)}
+        onMouseLeave={() => setHoveredBlockId((prev) => (prev === block.id ? null : prev))}
+        onClick={() => {
+          if (previewMode) return;
+          handleSelectBlock(block, { inlineEdit: block.block_type === 'text' });
+        }}
       >
-        <Box
-          className="block-handle"
-          sx={{
-            position: 'absolute',
-            left: 12,
-            top: 16,
-            opacity: 0.4,
-            display: 'flex',
-            alignItems: 'center',
-            '&:hover': { opacity: 1 },
-          }}
-        >
-          <DragIndicatorIcon fontSize="small" />
-        </Box>
-        <Stack direction="row" spacing={1} className="block-controls" sx={{ position: 'absolute', right: 12, top: 12, opacity: 0 }}>
-          {isText && (
-            <Tooltip title={isEditing ? 'Stop editing' : 'Edit inline'}>
+        {showHandle && (
+          <Box
+            className="block-handle"
+            sx={{
+              position: 'absolute',
+              left: -36,
+              top: 18,
+              opacity: isSelected ? 0.9 : 0,
+              display: 'flex',
+              alignItems: 'center',
+              transition: 'opacity 0.2s ease',
+            }}
+          >
+            <DragIndicatorIcon fontSize="small" color="action" />
+          </Box>
+        )}
+        {showControls && (
+          <Stack
+            direction="row"
+            spacing={1}
+            className="block-controls"
+            sx={{
+              position: 'absolute',
+              right: 12,
+              top: 12,
+              opacity: isSelected ? 1 : 0,
+              transition: 'opacity 0.2s ease',
+            }}
+          >
+            {block.block_type === 'asset' && (
+              <Tooltip title="Change resource">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setResourceDialogMode({ type: 'update', blockId: block.id });
+                      setResourceDialogOpen(true);
+                    }}
+                  >
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            )}
+            <Tooltip title="Delete block">
               <IconButton
                 size="small"
+                color="error"
                 onClick={(event) => {
                   event.stopPropagation();
-                  setEditingBlockId(isEditing ? null : block.id);
+                  void handleDeleteBlock(block.id);
                 }}
               >
-                <EditIcon fontSize="small" />
+                <DeleteIcon fontSize="small" />
               </IconButton>
             </Tooltip>
-          )}
-          <Tooltip title="Delete block">
-            <IconButton
-              size="small"
-              color="error"
-              onClick={(event) => {
-                event.stopPropagation();
-                void handleDeleteBlock(block.id);
-              }}
-            >
-              <DeleteIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        </Stack>
+          </Stack>
+        )}
+
         <Stack spacing={2}>
-          <Chip
-            size="small"
-            icon={BLOCK_ICONS[block.block_type]}
-            label={`${block.block_type.toUpperCase()} · #${index + 1}`}
-            variant="outlined"
-            sx={{ alignSelf: 'flex-start' }}
-          />
-          {block.label && (
-            <Typography variant="subtitle2" color="text.secondary">
-              {block.label}
-            </Typography>
-          )}
-          {isText && isEditing ? (
-            <TextField
-              multiline
-              minRows={6}
-              value={block.text_md ?? ''}
-              onChange={(event) => queueBlockUpdate(block.id, { text_md: event.target.value })}
-              onBlur={() => setEditingBlockId(null)}
-              autoFocus
-            />
+          {block.block_type === 'text' ? (
+            <Stack spacing={1.5}>
+              {isEditing && (
+                <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                  <ToggleButtonGroup
+                    size="small"
+                    exclusive
+                    value={editingMode}
+                    onChange={(_, value) => {
+                      if (!value) return;
+                      setEditingState({ blockId: block.id, mode: value });
+                    }}
+                  >
+                    <ToggleButton value="edit">Write</ToggleButton>
+                    <ToggleButton value="preview">Preview</ToggleButton>
+                  </ToggleButtonGroup>
+                  <Button
+                    size="small"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setEditingState(null);
+                    }}
+                  >
+                    Done
+                  </Button>
+                </Stack>
+              )}
+              {isEditing && editingMode === 'edit' ? (
+                <TextField
+                  multiline
+                  minRows={6}
+                  autoFocus
+                  value={block.text_md ?? ''}
+                  onChange={(event) => queueBlockUpdate(block.id, { text_md: event.target.value })}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleSelectBlock(block, { inlineEdit: true });
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      event.stopPropagation();
+                      setEditingState(null);
+                    }
+                  }}
+                  sx={{
+                    '& .MuiOutlinedInput-root': {
+                      fontSize: '1.05rem',
+                      lineHeight: 1.6,
+                      px: 1.5,
+                      py: 1.5,
+                    },
+                  }}
+                />
+              ) : (
+                <Box
+                  sx={{ position: 'relative' }}
+                  onClick={(event) => {
+                    if (previewMode) return;
+                    event.stopPropagation();
+                    handleSelectBlock(block, { inlineEdit: true });
+                  }}
+                >
+                  <BlockRenderer block={block} resource={resource} />
+                </Box>
+              )}
+            </Stack>
+          ) : block.block_type === 'asset' ? (
+            <Box sx={{ position: 'relative' }}>
+              <BlockRenderer block={block} resource={resource} />
+              {!previewMode && (
+                <Box
+                  className="block-overlay"
+                  sx={{
+                    position: 'absolute',
+                    inset: 0,
+                    display: 'flex',
+                    alignItems: 'flex-end',
+                    justifyContent: 'space-between',
+                    opacity: isSelected || hoveredBlockId === block.id ? 1 : 0,
+                    transition: 'opacity 0.2s ease',
+                    background: 'linear-gradient(180deg, rgba(17, 25, 40, 0) 40%, rgba(17, 25, 40, 0.55) 100%)',
+                    borderRadius: 2,
+                    pointerEvents: 'none',
+                  }}
+                >
+                  <Stack
+                    direction="row"
+                    spacing={1.5}
+                    alignItems="center"
+                    justifyContent="space-between"
+                    sx={{
+                      width: '100%',
+                      px: 2,
+                      py: 1.5,
+                      color: 'common.white',
+                      pointerEvents: 'auto',
+                    }}
+                  >
+                    <Stack spacing={0.5}>
+                      <Typography variant="subtitle2" color="inherit">
+                        {resource?.title ?? 'Unlinked resource'}
+                      </Typography>
+                      <Typography variant="caption" color="rgba(255,255,255,0.75)">
+                        {resource?.type ? resource.type.toUpperCase() : 'Select a resource'}
+                      </Typography>
+                    </Stack>
+                    <Button
+                      size="small"
+                      variant="contained"
+                      color="primary"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setResourceDialogMode({ type: 'update', blockId: block.id });
+                        setResourceDialogOpen(true);
+                      }}
+                    >
+                      {resource ? 'Change' : 'Choose'}
+                    </Button>
+                  </Stack>
+                </Box>
+              )}
+            </Box>
           ) : (
-            <BlockRenderer block={block} resource={resourceForBlock(block)} />
+            <BlockRenderer block={block} resource={resource} />
           )}
         </Stack>
       </Box>
@@ -1612,46 +1790,80 @@ export default function CourseBuilderAdmin() {
         <Stack spacing={2} sx={{ minHeight: 'calc(100vh - 200px)' }}>
           <Paper variant="outlined" sx={{ p: 2 }}>
             {selectedSubtree ? (
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }} justifyContent="space-between">
-                <Stack spacing={0.5}>
-                  <Typography variant="h6">{selectedSubtree.node.title ?? 'Untitled node'}</Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {selectedSubtree.node.node_type}
-                  </Typography>
+              <Stack spacing={2}>
+                <Stack
+                  direction={{ xs: 'column', md: 'row' }}
+                  spacing={2}
+                  alignItems={{ xs: 'flex-start', md: 'center' }}
+                  justifyContent="space-between"
+                >
+                  <Stack spacing={0.5}>
+                    <Typography variant="h6">{selectedSubtree.node.title ?? 'Untitled node'}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {selectedSubtree.node.node_type}
+                    </Typography>
+                  </Stack>
+                  <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems={{ xs: 'flex-start', md: 'center' }}>
+                    <ToggleButtonGroup
+                      size="small"
+                      exclusive
+                      value={nodeDraft?.state ?? selectedSubtree.node.state}
+                      onChange={(_, value) => value && handleNodeFieldChange('state', value)}
+                    >
+                      <ToggleButton value="draft">Draft</ToggleButton>
+                      <ToggleButton value="published">Published</ToggleButton>
+                      <ToggleButton value="archived">Archived</ToggleButton>
+                    </ToggleButtonGroup>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          size="small"
+                          checked={previewMode}
+                          onChange={(event) => {
+                            const checked = event.target.checked;
+                            setPreviewMode(checked);
+                            if (checked) {
+                              setEditingState(null);
+                              setSelectedBlockId(null);
+                              setPanelMode('node');
+                            }
+                          }}
+                        />
+                      }
+                      label="Preview mode"
+                      labelPlacement="start"
+                      sx={{ m: 0 }}
+                    />
+                    <Button variant="outlined" onClick={() => { setPanelMode('node'); setPropertiesOpen(true); }}>
+                      Node details
+                    </Button>
+                  </Stack>
                 </Stack>
-                <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} alignItems={{ xs: 'stretch', md: 'center' }}>
-                  <ToggleButtonGroup
-                    size="small"
-                    exclusive
-                    value={nodeDraft?.state ?? selectedSubtree.node.state}
-                    onChange={(_, value) => value && handleNodeFieldChange('state', value)}
-                  >
-                    <ToggleButton value="draft">Draft</ToggleButton>
-                    <ToggleButton value="published">Published</ToggleButton>
-                    <ToggleButton value="archived">Archived</ToggleButton>
-                  </ToggleButtonGroup>
-                  <Button variant="outlined" onClick={() => { setPanelMode('node'); setPropertiesOpen(true); }}>
-                    Node details
-                  </Button>
-                  <Button
-                    variant="contained"
-                    startIcon={<TextFieldsIcon />}
-                    disabled={!canEditBlocks}
-                    onClick={() => {
-                      if (!selectedSubtree) return;
-                      handleAddBlockAt(sortedBlocks.length, 'text');
-                    }}
-                    sx={{ display: { xs: 'none', md: 'inline-flex' } }}
-                  >
-                    Quick text block
-                  </Button>
+                <Stack
+                  direction={{ xs: 'column', md: 'row' }}
+                  spacing={2}
+                  alignItems={{ xs: 'flex-start', md: 'center' }}
+                  justifyContent="space-between"
+                >
                   <Stack direction="row" spacing={1} alignItems="center">
                     {savingState === 'saving' && <CircularProgress size={16} />}
                     {savingState === 'saved' && <CheckCircleOutlineIcon color="success" fontSize="small" />}
                     {savingState === 'error' && <ErrorOutlineIcon color="error" fontSize="small" />}
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography variant="body2" color="text.secondary">
                       {savingMessage}
                     </Typography>
+                  </Stack>
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      variant="contained"
+                      startIcon={<AddIcon />}
+                      disabled={!canEditBlocks || previewMode}
+                      onClick={(event) => {
+                        setInsertMenu({ anchor: event.currentTarget, index: sortedBlocks.length });
+                      }}
+                    >
+                      Add block
+                    </Button>
                   </Stack>
                 </Stack>
               </Stack>
@@ -1662,20 +1874,39 @@ export default function CourseBuilderAdmin() {
 
           <Paper variant="outlined" sx={{ p: 3, flex: 1, overflowY: 'auto' }}>
             {selectedSubtree ? (
-              <Box sx={{ maxWidth: 820, mx: 'auto' }}>
+              <Box
+                sx={{
+                  maxWidth: 900,
+                  mx: 'auto',
+                  width: '100%',
+                  px: { xs: 1, sm: 2 },
+                  py: { xs: 1, sm: 2 },
+                }}
+              >
                 {canEditBlocks ? (
-                  <Stack spacing={2}>
+                  <Stack spacing={2.5}>
                     {renderDropZone(0)}
                     {sortedBlocks.map((block, index) => (
-                      <Stack key={block.id} spacing={2}>
-                        {renderBlockCard(block, index)}
+                      <Stack key={block.id} spacing={2.5}>
+                        {renderBlockCard(block)}
                         {renderDropZone(index + 1)}
                       </Stack>
                     ))}
                     {sortedBlocks.length === 0 && (
                       <Alert severity="info" sx={{ mt: 2 }}>
-                        This node has no content blocks yet. Use the add buttons to get started.
+                        This node has no content blocks yet. Use the add controls to get started.
                       </Alert>
+                    )}
+                    {!previewMode && (
+                      <Box textAlign="center" pt={sortedBlocks.length ? 1 : 2}>
+                        <Button
+                          variant="outlined"
+                          startIcon={<AddIcon />}
+                          onClick={(event) => setInsertMenu({ anchor: event.currentTarget, index: sortedBlocks.length })}
+                        >
+                          Add block
+                        </Button>
+                      </Box>
                     )}
                   </Stack>
                 ) : (
@@ -1704,46 +1935,27 @@ export default function CourseBuilderAdmin() {
             </Stack>
 
             {panelMode === 'block' && selectedBlock ? (
-              <Stack spacing={2}>
-                <Typography variant="subtitle2">Block #{selectedBlock.position + 1}</Typography>
+              <Stack spacing={3}>
+                <Stack spacing={0.25}>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Block {selectedBlock.position + 1}
+                  </Typography>
+                  <Typography variant="h6" sx={{ textTransform: 'capitalize' }}>
+                    {selectedBlock.block_type} block
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Edit the primary content directly on the canvas. Use this panel for supporting details.
+                  </Typography>
+                </Stack>
+
                 {selectedBlock.block_type === 'text' && (
-                  <Stack spacing={1}>
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <Button
-                        variant={showMarkdownPreview ? 'outlined' : 'contained'}
-                        size="small"
-                        onClick={() => setShowMarkdownPreview((prev) => !prev)}
-                      >
-                        {showMarkdownPreview ? 'Edit raw markdown' : 'Show preview'}
-                      </Button>
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        onClick={() => {
-                          setEditingBlockId(selectedBlock.id);
-                          setPanelMode('block');
-                        }}
-                      >
-                        Edit inline
-                      </Button>
-                    </Stack>
-                    {!showMarkdownPreview ? (
-                      <TextField
-                        multiline
-                        minRows={8}
-                        value={selectedBlock.text_md ?? ''}
-                        onChange={(event) => queueBlockUpdate(selectedBlock.id, { text_md: event.target.value })}
-                      />
-                    ) : (
-                      <BlockRenderer block={selectedBlock} resource={null} />
-                    )}
-                  </Stack>
+                  <Alert severity="info">Click the block in the canvas to edit its markdown inline.</Alert>
                 )}
 
                 {selectedBlock.block_type === 'asset' && (
                   <Stack spacing={2}>
                     <Button
-                      variant="outlined"
+                      variant="contained"
                       startIcon={<SearchIcon />}
                       onClick={() => {
                         setResourceDialogMode({ type: 'update', blockId: selectedBlock.id });
@@ -1752,25 +1964,29 @@ export default function CourseBuilderAdmin() {
                     >
                       {selectedBlock.resource_id ? 'Change resource' : 'Select resource'}
                     </Button>
-                    {selectedBlock.resource_id && (
-                      <Card variant="outlined" sx={{ p: 2 }}>
+                    <Card variant="outlined" sx={{ p: 2 }}>
+                      <Stack spacing={1}>
                         <Typography variant="subtitle1">
-                          {resourceForBlock(selectedBlock)?.title ?? `Resource #${selectedBlock.resource_id}`}
+                          {resourceForBlock(selectedBlock)?.title ?? 'No resource selected'}
                         </Typography>
-                        {resourceForBlock(selectedBlock)?.url && (
+                        {resourceForBlock(selectedBlock)?.url ? (
                           <Button
                             size="small"
                             endIcon={<OpenInNewIcon fontSize="small" />}
                             href={resourceForBlock(selectedBlock)?.url ?? undefined}
                             target="_blank"
                             rel="noreferrer"
-                            sx={{ mt: 1 }}
+                            sx={{ alignSelf: 'flex-start' }}
                           >
                             Open resource
                           </Button>
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">
+                            Pick a published resource to display to learners.
+                          </Typography>
                         )}
-                      </Card>
-                    )}
+                      </Stack>
+                    </Card>
                     <TextField
                       label="Caption"
                       value={selectedBlock.label ?? ''}
@@ -1806,7 +2022,7 @@ export default function CourseBuilderAdmin() {
                 )}
 
                 {selectedBlock.block_type === 'divider' && (
-                  <Alert severity="info">Divider blocks have no configurable properties.</Alert>
+                  <Alert severity="info">Divider blocks create spacing between sections and have no extra settings.</Alert>
                 )}
 
                 <Button
@@ -1818,144 +2034,172 @@ export default function CourseBuilderAdmin() {
                 </Button>
               </Stack>
             ) : selectedSubtree && nodeDraft ? (
-              <Stack spacing={3}>
-                <Stack spacing={2}>
-                  <TextField
-                    label="Title"
-                    value={nodeDraft.title}
-                    onChange={(event) => handleNodeFieldChange('title', event.target.value)}
-                  />
-                  <TextField
-                    label="Slug"
-                    value={nodeDraft.slug}
-                    onChange={(event) => handleNodeFieldChange('slug', event.target.value)}
-                  />
-                  <TextField
-                    label="Description"
-                    multiline
-                    minRows={3}
-                    value={nodeDraft.description}
-                    onChange={(event) => handleNodeFieldChange('description', event.target.value)}
-                  />
-                  <TextField
-                    label="Hero image URL"
-                    value={nodeDraft.hero_image}
-                    onChange={(event) => handleNodeFieldChange('hero_image', event.target.value)}
-                  />
-                  <TextField
-                    label="Icon"
-                    value={nodeDraft.icon}
-                    onChange={(event) => handleNodeFieldChange('icon', event.target.value)}
-                  />
-                  <TextField
-                    label="Objectives"
-                    multiline
-                    minRows={3}
-                    value={nodeDraft.objectives}
-                    onChange={(event) => handleNodeFieldChange('objectives', event.target.value)}
-                  />
-                  <TextField
-                    label="Metadata (JSON)"
-                    multiline
-                    minRows={4}
-                    value={nodeDraft.metadata}
-                    onChange={(event) => handleNodeFieldChange('metadata', event.target.value)}
-                    error={!!metadataError}
-                    helperText={metadataError ?? 'Provide structured metadata for this node'}
-                  />
-                </Stack>
+              <Stack spacing={2}>
+                <Accordion defaultExpanded>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>Basic information</AccordionSummary>
+                  <AccordionDetails>
+                    <Stack spacing={2}>
+                      <TextField
+                        label="Title"
+                        value={nodeDraft.title}
+                        onChange={(event) => handleNodeFieldChange('title', event.target.value)}
+                      />
+                      <TextField
+                        label="Slug"
+                        value={nodeDraft.slug}
+                        onChange={(event) => handleNodeFieldChange('slug', event.target.value)}
+                      />
+                      <TextField
+                        label="Description"
+                        multiline
+                        minRows={3}
+                        value={nodeDraft.description}
+                        onChange={(event) => handleNodeFieldChange('description', event.target.value)}
+                      />
+                    </Stack>
+                  </AccordionDetails>
+                </Accordion>
 
-                <Divider />
+                <Accordion>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>Visuals & objectives</AccordionSummary>
+                  <AccordionDetails>
+                    <Stack spacing={2}>
+                      <TextField
+                        label="Hero image URL"
+                        value={nodeDraft.hero_image}
+                        onChange={(event) => handleNodeFieldChange('hero_image', event.target.value)}
+                      />
+                      <TextField
+                        label="Icon"
+                        value={nodeDraft.icon}
+                        onChange={(event) => handleNodeFieldChange('icon', event.target.value)}
+                      />
+                      <TextField
+                        label="Objectives"
+                        multiline
+                        minRows={3}
+                        value={nodeDraft.objectives}
+                        onChange={(event) => handleNodeFieldChange('objectives', event.target.value)}
+                      />
+                    </Stack>
+                  </AccordionDetails>
+                </Accordion>
 
-                <Stack spacing={1} direction="row" justifyContent="space-between" alignItems="center">
-                  <Typography variant="subtitle2">Children</Typography>
-                  <Stack direction="row" spacing={1}>
-                    <Button
-                      size="small"
-                      startIcon={<AddIcon />}
-                      onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'create' })}
-                    >
-                      Add child
-                    </Button>
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'attach' })}
-                    >
-                      Attach existing
-                    </Button>
-                  </Stack>
-                </Stack>
+                <Accordion>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>Metadata</AccordionSummary>
+                  <AccordionDetails>
+                    <TextField
+                      label="Metadata (JSON)"
+                      multiline
+                      minRows={4}
+                      value={nodeDraft.metadata}
+                      onChange={(event) => handleNodeFieldChange('metadata', event.target.value)}
+                      error={!!metadataError}
+                      helperText={metadataError ?? 'Provide structured metadata for this node'}
+                    />
+                  </AccordionDetails>
+                </Accordion>
 
-                <Stack spacing={1.5}>
-                  {selectedSubtree.children
-                    .slice()
-                    .sort((a, b) => a.edge.position - b.edge.position)
-                    .map((child, index, arr) => (
-                      <Paper key={child.edge.child_id} variant="outlined" sx={{ p: 2 }}>
-                        <Stack spacing={1.5}>
-                          <Stack direction="row" justifyContent="space-between" alignItems="center">
-                            <Stack spacing={0.5}>
-                              <Typography variant="subtitle2">{child.subtree.node.title ?? `Node #${child.subtree.node.id}`}</Typography>
-                              <Typography variant="caption" color="text.secondary">
-                                {child.subtree.node.node_type}
-                              </Typography>
+                <Accordion defaultExpanded>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>Children</AccordionSummary>
+                  <AccordionDetails>
+                    <Stack spacing={1} direction="row" justifyContent="flex-end" sx={{ mb: 2 }}>
+                      <Button
+                        size="small"
+                        startIcon={<AddIcon />}
+                        onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'create' })}
+                      >
+                        Add child
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => setAddChildDialog({ open: true, parentId: selectedSubtree.node.id, mode: 'attach' })}
+                      >
+                        Attach existing
+                      </Button>
+                    </Stack>
+                    <Stack spacing={1.5}>
+                      {selectedSubtree.children
+                        .slice()
+                        .sort((a, b) => a.edge.position - b.edge.position)
+                        .map((child, index, arr) => (
+                          <Paper key={child.edge.child_id} variant="outlined" sx={{ p: 2 }}>
+                            <Stack spacing={1.5}>
+                              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                                <Stack spacing={0.5}>
+                                  <Typography variant="subtitle2">
+                                    {child.subtree.node.title ?? `Node #${child.subtree.node.id}`}
+                                  </Typography>
+                                  <Typography variant="caption" color="text.secondary">
+                                    {child.subtree.node.node_type}
+                                  </Typography>
+                                </Stack>
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                  <Tooltip title="Move up">
+                                    <span>
+                                      <IconButton
+                                        size="small"
+                                        disabled={index === 0}
+                                        onClick={() =>
+                                          void handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'up')
+                                        }
+                                      >
+                                        <ArrowUpwardIcon fontSize="small" />
+                                      </IconButton>
+                                    </span>
+                                  </Tooltip>
+                                  <Tooltip title="Move down">
+                                    <span>
+                                      <IconButton
+                                        size="small"
+                                        disabled={index === arr.length - 1}
+                                        onClick={() =>
+                                          void handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'down')
+                                        }
+                                      >
+                                        <ArrowDownwardIcon fontSize="small" />
+                                      </IconButton>
+                                    </span>
+                                  </Tooltip>
+                                  <FormControlLabel
+                                    control={
+                                      <Checkbox
+                                        size="small"
+                                        checked={!!child.edge.is_required}
+                                        onChange={(event) =>
+                                          void handleUpdateChild(selectedSubtree.node.id, child.edge.child_id, {
+                                            is_required: event.target.checked,
+                                          })
+                                        }
+                                      />
+                                    }
+                                    label="Required"
+                                  />
+                                  <Tooltip title="Detach child">
+                                    <IconButton
+                                      size="small"
+                                      color="error"
+                                      onClick={() =>
+                                        void handleRemoveChild(selectedSubtree.node.id, child.edge.child_id)
+                                      }
+                                    >
+                                      <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                  </Tooltip>
+                                </Stack>
+                              </Stack>
+                              {child.edge.label && (
+                                <Typography variant="body2" color="text.secondary">
+                                  {child.edge.label}
+                                </Typography>
+                              )}
                             </Stack>
-                            <Stack direction="row" spacing={1} alignItems="center">
-                              <Tooltip title="Move up">
-                                <span>
-                                  <IconButton
-                                    size="small"
-                                    disabled={index === 0}
-                                    onClick={() => handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'up')}
-                                  >
-                                    <ArrowUpwardIcon fontSize="small" />
-                                  </IconButton>
-                                </span>
-                              </Tooltip>
-                              <Tooltip title="Move down">
-                                <span>
-                                  <IconButton
-                                    size="small"
-                                    disabled={index === arr.length - 1}
-                                    onClick={() => handleReorderChild(selectedSubtree.node.id, child.edge.child_id, 'down')}
-                                  >
-                                    <ArrowDownwardIcon fontSize="small" />
-                                  </IconButton>
-                                </span>
-                              </Tooltip>
-                              <Tooltip title="Remove child">
-                                <IconButton
-                                  size="small"
-                                  color="error"
-                                  onClick={() => void handleRemoveChild(selectedSubtree.node.id, child.edge.child_id)}
-                                >
-                                  <DeleteIcon fontSize="small" />
-                                </IconButton>
-                              </Tooltip>
-                            </Stack>
-                          </Stack>
-                          <Stack direction="row" spacing={1} alignItems="center">
-                            <Checkbox
-                              checked={child.edge.is_required ?? true}
-                              onChange={(event) =>
-                                void handleUpdateChild(selectedSubtree.node.id, child, {
-                                  is_required: event.target.checked,
-                                })
-                              }
-                              size="small"
-                            />
-                            <Typography variant="body2">Required for progression</Typography>
-                          </Stack>
-                        </Stack>
-                      </Paper>
-                    ))}
-                  {selectedSubtree.children.length === 0 && (
-                    <Typography variant="body2" color="text.secondary">
-                      This node has no children.
-                    </Typography>
-                  )}
-                </Stack>
+                          </Paper>
+                        ))}
+                    </Stack>
+                  </AccordionDetails>
+                </Accordion>
               </Stack>
             ) : (
               <Typography color="text.secondary">Select a node to edit details.</Typography>

--- a/src/components/admin/CourseBuilderAdmin.tsx
+++ b/src/components/admin/CourseBuilderAdmin.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 import {
   Alert,
@@ -69,6 +69,7 @@ import type { RenderableResource } from '@/components/course/BlockRenderer';
 export type NodeType = 'course' | 'lesson' | 'chapter' | 'collection' | 'playlist';
 export type NodeState = 'draft' | 'published' | 'archived';
 export type BlockType = 'text' | 'asset' | 'divider';
+type BlockSpacing = 'compact' | 'normal' | 'spacious';
 
 type ContentNode = {
   id: number;
@@ -107,6 +108,46 @@ type ContentBlock = {
   settings: Record<string, unknown> | null;
   data: Record<string, unknown> | null;
 };
+
+const BLOCK_SPACING_VALUES: Record<BlockSpacing, number> = {
+  compact: 12,
+  normal: 24,
+  spacious: 40,
+};
+
+function readBlockSetting(block: ContentBlock | null | undefined, key: string) {
+  if (!block || !block.settings || typeof block.settings !== 'object') {
+    return undefined;
+  }
+
+  return (block.settings as Record<string, unknown>)[key];
+}
+
+function getBlockSpacingSetting(block: ContentBlock | null | undefined): BlockSpacing {
+  const raw = readBlockSetting(block, 'spacing');
+  if (raw === 'compact' || raw === 'spacious' || raw === 'normal') {
+    return raw;
+  }
+  return 'normal';
+}
+
+function getBlockSpacingPixels(block: ContentBlock | null | undefined): number {
+  return BLOCK_SPACING_VALUES[getBlockSpacingSetting(block)];
+}
+
+function applySpacingSetting(
+  settings: Record<string, unknown> | null,
+  spacing: BlockSpacing,
+): Record<string, unknown> | null {
+  const next = { ...(settings ?? {}) };
+  if (spacing === 'normal') {
+    delete next.spacing;
+  } else {
+    next.spacing = spacing;
+  }
+
+  return Object.keys(next).length > 0 ? next : null;
+}
 
 type NodeSubtree = {
   node: ContentNode;
@@ -619,6 +660,7 @@ export default function CourseBuilderAdmin() {
   const nodeUpdateQueue = useRef(new Map<number, Partial<ContentNode>>());
   const nodeDebounceTimers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
   const optimisticSnapshot = useRef<NodeSubtree[] | null>(null);
+  const lastNodeIdRef = useRef<number | null>(null);
   const [nodeDraft, setNodeDraft] = useState<NodeDraft | null>(null);
   const [metadataError, setMetadataError] = useState<string | null>(null);
   const [editingState, setEditingState] = useState<{ blockId: number; mode: 'edit' | 'preview' } | null>(null);
@@ -681,8 +723,10 @@ export default function CourseBuilderAdmin() {
   useEffect(() => {
     if (!selectedSubtree) {
       setNodeDraft(null);
+      lastNodeIdRef.current = null;
       return;
     }
+
     setNodeDraft({
       title: selectedSubtree.node.title ?? '',
       slug: selectedSubtree.node.slug ?? '',
@@ -693,10 +737,15 @@ export default function CourseBuilderAdmin() {
       objectives: selectedSubtree.node.objectives ?? '',
       metadata: selectedSubtree.node.metadata ? JSON.stringify(selectedSubtree.node.metadata, null, 2) : '',
     });
-    setPanelMode('node');
-    setSelectedBlockId(null);
-    setMetadataError(null);
-    setEditingState(null);
+
+    const nodeId = selectedSubtree.node.id;
+    if (lastNodeIdRef.current !== nodeId) {
+      setPanelMode('node');
+      setSelectedBlockId(null);
+      setMetadataError(null);
+      setEditingState(null);
+      lastNodeIdRef.current = nodeId;
+    }
   }, [selectedSubtree]);
 
   useEffect(() => {
@@ -1104,6 +1153,28 @@ export default function CourseBuilderAdmin() {
     [runMutation, selectedBlockId],
   );
 
+  const dropGapForIndex = useCallback(
+    (index: number) => {
+      const before = sortedBlocks[index - 1] ?? null;
+      const after = sortedBlocks[index] ?? null;
+
+      if (!before && !after) {
+        return getBlockSpacingPixels(null);
+      }
+
+      if (!before) {
+        return getBlockSpacingPixels(after) / 2;
+      }
+
+      if (!after) {
+        return getBlockSpacingPixels(before) / 2;
+      }
+
+      return (getBlockSpacingPixels(before) + getBlockSpacingPixels(after)) / 2;
+    },
+    [sortedBlocks],
+  );
+
   const handleCreateBlock = useCallback(
     async (nodeId: number, block: Partial<ContentBlock> & { block_type: BlockType }, position: number) => {
       const beforeIds = findSubtree(trees, nodeId)?.blocks.map((row) => row.id) ?? [];
@@ -1418,18 +1489,22 @@ export default function CourseBuilderAdmin() {
   };
 
   const renderDropZone = (index: number) => {
+    const gap = dropGapForIndex(index);
+
+    if (previewMode) {
+      return <Box key={`drop-${index}`} sx={{ height: gap, width: '100%' }} />;
+    }
+
     const before = sortedBlocks[index - 1];
     const after = sortedBlocks[index];
     const showIndicator = dragState.overIndex === index;
     const showButton =
-      !previewMode &&
-      (showIndicator || hoveredBlockId === before?.id || hoveredBlockId === after?.id || (sortedBlocks.length === 0 && index === 0));
+      showIndicator || hoveredBlockId === before?.id || hoveredBlockId === after?.id || (sortedBlocks.length === 0 && index === 0);
 
     return (
       <Box
         key={`drop-${index}`}
         onDragOver={(event) => {
-          if (previewMode) return;
           event.preventDefault();
           setDragState((prev) => ({ ...prev, overIndex: index }));
         }}
@@ -1437,7 +1512,6 @@ export default function CourseBuilderAdmin() {
           setDragState((prev) => ({ ...prev, overIndex: prev.overIndex === index ? null : prev.overIndex }))
         }
         onDrop={(event) => {
-          if (previewMode) return;
           event.preventDefault();
           if (dragState.blockId != null) {
             void handleReorderBlocksToIndex(dragState.blockId, index);
@@ -1446,40 +1520,39 @@ export default function CourseBuilderAdmin() {
         }}
         sx={{
           position: 'relative',
-          height: 32,
-          my: 1,
+          height: Math.max(16, gap),
+          my: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          width: '100%',
         }}
       >
-        {!previewMode && (
-          <Fade in={showButton} timeout={120}>
-            <IconButton
-              size="small"
-              color="primary"
-              sx={{
-                bgcolor: 'background.paper',
-                border: '1px solid',
-                borderColor: 'divider',
-                boxShadow: 3,
-                opacity: showButton ? 1 : 0,
-                pointerEvents: showButton ? 'auto' : 'none',
-                transition: 'all 0.2s ease',
-                '&:hover': {
-                  bgcolor: 'primary.main',
-                  color: 'primary.contrastText',
-                },
-              }}
-              onClick={(event) => {
-                event.stopPropagation();
-                setInsertMenu({ anchor: event.currentTarget, index });
-              }}
-            >
-              <AddIcon fontSize="small" />
-            </IconButton>
-          </Fade>
-        )}
+        <Fade in={showButton} timeout={120} unmountOnExit>
+          <IconButton
+            size="small"
+            color="primary"
+            sx={{
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              boxShadow: 3,
+              opacity: showButton ? 1 : 0,
+              pointerEvents: showButton ? 'auto' : 'none',
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
+              },
+            }}
+            onClick={(event) => {
+              event.stopPropagation();
+              setInsertMenu({ anchor: event.currentTarget, index });
+            }}
+          >
+            <AddIcon fontSize="small" />
+          </IconButton>
+        </Fade>
         {showIndicator && (
           <Box
             sx={{
@@ -1503,6 +1576,13 @@ export default function CourseBuilderAdmin() {
     const editingMode = editingState?.blockId === block.id ? editingState.mode : 'preview';
     const showHandle = !previewMode;
     const showControls = !previewMode;
+    const spacingSetting = getBlockSpacingSetting(block);
+    const paddingY =
+      spacingSetting === 'compact'
+        ? { xs: 1.5, md: 2 }
+        : spacingSetting === 'spacious'
+        ? { xs: 3, md: 3.5 }
+        : { xs: 2, md: 2.75 };
 
     return (
       <Box
@@ -1511,15 +1591,18 @@ export default function CourseBuilderAdmin() {
           position: 'relative',
           borderRadius: 3,
           border: '1px solid',
-          borderColor: isSelected ? 'primary.main' : hoveredBlockId === block.id ? 'divider' : 'transparent',
-          boxShadow: isSelected
-            ? '0 0 0 3px rgba(25, 118, 210, 0.12)'
-            : hoveredBlockId === block.id
-            ? '0 18px 32px rgba(15, 23, 42, 0.12)'
-            : 'none',
+          borderColor: isSelected ? 'primary.main' : previewMode ? 'transparent' : hoveredBlockId === block.id ? 'divider' : 'transparent',
+          boxShadow:
+            previewMode && !isSelected
+              ? 'none'
+              : isSelected
+              ? '0 0 0 3px rgba(25, 118, 210, 0.12)'
+              : hoveredBlockId === block.id
+              ? '0 12px 24px rgba(15, 23, 42, 0.12)'
+              : 'none',
           backgroundColor: 'background.paper',
           px: { xs: 2, md: 3 },
-          py: { xs: 2.5, md: 3.5 },
+          py: paddingY,
           cursor: previewMode ? 'default' : block.block_type === 'text' ? 'text' : 'pointer',
           transition: 'box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease',
           '&:hover .block-controls': { opacity: previewMode ? 0 : 1 },
@@ -1799,9 +1882,6 @@ export default function CourseBuilderAdmin() {
                 >
                   <Stack spacing={0.5}>
                     <Typography variant="h6">{selectedSubtree.node.title ?? 'Untitled node'}</Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {selectedSubtree.node.node_type}
-                    </Typography>
                   </Stack>
                   <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems={{ xs: 'flex-start', md: 'center' }}>
                     <ToggleButtonGroup
@@ -1853,18 +1933,20 @@ export default function CourseBuilderAdmin() {
                       {savingMessage}
                     </Typography>
                   </Stack>
-                  <Stack direction="row" spacing={1}>
-                    <Button
-                      variant="contained"
-                      startIcon={<AddIcon />}
-                      disabled={!canEditBlocks || previewMode}
-                      onClick={(event) => {
-                        setInsertMenu({ anchor: event.currentTarget, index: sortedBlocks.length });
-                      }}
-                    >
-                      Add block
-                    </Button>
-                  </Stack>
+                  {!previewMode && (
+                    <Stack direction="row" spacing={1}>
+                      <Button
+                        variant="contained"
+                        startIcon={<AddIcon />}
+                        disabled={!canEditBlocks}
+                        onClick={(event) => {
+                          setInsertMenu({ anchor: event.currentTarget, index: sortedBlocks.length });
+                        }}
+                      >
+                        Add block
+                      </Button>
+                    </Stack>
+                  )}
                 </Stack>
               </Stack>
             ) : (
@@ -1884,13 +1966,13 @@ export default function CourseBuilderAdmin() {
                 }}
               >
                 {canEditBlocks ? (
-                  <Stack spacing={2.5}>
+                  <Stack spacing={0}>
                     {renderDropZone(0)}
                     {sortedBlocks.map((block, index) => (
-                      <Stack key={block.id} spacing={2.5}>
+                      <Fragment key={block.id}>
                         {renderBlockCard(block)}
                         {renderDropZone(index + 1)}
-                      </Stack>
+                      </Fragment>
                     ))}
                     {sortedBlocks.length === 0 && (
                       <Alert severity="info" sx={{ mt: 2 }}>
@@ -2024,6 +2106,31 @@ export default function CourseBuilderAdmin() {
                 {selectedBlock.block_type === 'divider' && (
                   <Alert severity="info">Divider blocks create spacing between sections and have no extra settings.</Alert>
                 )}
+
+                <Divider />
+
+                <Stack spacing={1}>
+                  <Typography variant="subtitle2">Spacing</Typography>
+                  <ToggleButtonGroup
+                    size="small"
+                    exclusive
+                    value={getBlockSpacingSetting(selectedBlock)}
+                    onChange={(_, value) => {
+                      if (!value) return;
+                      const nextSettings = applySpacingSetting(selectedBlock.settings, value as BlockSpacing);
+                      queueBlockUpdate(selectedBlock.id, { settings: nextSettings });
+                    }}
+                  >
+                    <ToggleButton value="compact">Compact</ToggleButton>
+                    <ToggleButton value="normal">Normal</ToggleButton>
+                    <ToggleButton value="spacious">Spacious</ToggleButton>
+                  </ToggleButtonGroup>
+                  <Typography variant="caption" color="text.secondary">
+                    Adjust the breathing room above and below this block.
+                  </Typography>
+                </Stack>
+
+                <Divider />
 
                 <Button
                   color="error"

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -1,0 +1,429 @@
+'use client';
+
+import React from 'react';
+import { Box, Button, Card, CardContent, CardMedia, Divider, Stack, Typography } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import HeadphonesIcon from '@mui/icons-material/Headphones';
+import InsertLinkIcon from '@mui/icons-material/InsertLink';
+import ImageIcon from '@mui/icons-material/Image';
+import TextSnippetIcon from '@mui/icons-material/TextSnippet';
+
+export type RenderableBlock = {
+  id: number;
+  block_type: 'text' | 'asset' | 'divider';
+  position: number;
+  text_md: string | null;
+  resource_id: number | null;
+  start_ms: number | null;
+  end_ms: number | null;
+  label: string | null;
+};
+
+export type RenderableResource = {
+  id: number;
+  title: string;
+  type: string | null;
+  url: string | null;
+  thumbnail: string | null;
+  duration: number | null;
+};
+
+export type BlockRendererProps = {
+  block: RenderableBlock;
+  resource: RenderableResource | null;
+};
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function applyInlineFormatting(value: string) {
+  return escapeHtml(value)
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
+function renderMarkdownToElements(markdown: string) {
+  const lines = markdown.split(/\r?\n/);
+  const elements: React.ReactNode[] = [];
+  let paragraph: string[] = [];
+  let bullet: string[] = [];
+  let ordered: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    const text = paragraph.join(' ');
+    elements.push(
+      <Typography
+        key={`p-${elements.length}`}
+        component="p"
+        sx={{ mb: 2, '&:last-of-type': { mb: 0 } }}
+        dangerouslySetInnerHTML={{ __html: applyInlineFormatting(text) }}
+      />,
+    );
+    paragraph = [];
+  };
+
+  const flushBullet = () => {
+    if (bullet.length === 0) return;
+    elements.push(
+      <Box component="ul" key={`ul-${elements.length}`} sx={{ pl: 3, mb: 2 }}>
+        {bullet.map((item, idx) => (
+          <Box
+            component="li"
+            key={`ul-item-${elements.length}-${idx}`}
+            dangerouslySetInnerHTML={{ __html: applyInlineFormatting(item) }}
+          />
+        ))}
+      </Box>,
+    );
+    bullet = [];
+  };
+
+  const flushOrdered = () => {
+    if (ordered.length === 0) return;
+    elements.push(
+      <Box component="ol" key={`ol-${elements.length}`} sx={{ pl: 3, mb: 2 }}>
+        {ordered.map((item, idx) => (
+          <Box
+            component="li"
+            key={`ol-item-${elements.length}-${idx}`}
+            dangerouslySetInnerHTML={{ __html: applyInlineFormatting(item) }}
+          />
+        ))}
+      </Box>,
+    );
+    ordered = [];
+    orderedIndex = 0;
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      flushParagraph();
+      flushBullet();
+      flushOrdered();
+      continue;
+    }
+
+    const headingMatch = trimmed.match(/^(#{1,3})\s+(.*)$/);
+    if (headingMatch) {
+      flushParagraph();
+      flushBullet();
+      flushOrdered();
+      const level = headingMatch[1].length;
+      const content = headingMatch[2];
+      const variant = level === 1 ? 'h4' : level === 2 ? 'h5' : 'h6';
+      elements.push(
+        <Typography
+          key={`heading-${elements.length}`}
+          variant={variant as 'h4' | 'h5' | 'h6'}
+          sx={{ mt: elements.length === 0 ? 0 : 3, mb: 1.5 }}
+          dangerouslySetInnerHTML={{ __html: applyInlineFormatting(content) }}
+        />,
+      );
+      continue;
+    }
+
+    if (/^[-*]\s+/.test(trimmed)) {
+      flushParagraph();
+      flushOrdered();
+      bullet.push(trimmed.replace(/^[-*]\s+/, ''));
+      continue;
+    }
+
+    const orderedMatch = trimmed.match(/^(\d+)\.\s+(.*)$/);
+    if (orderedMatch) {
+      flushParagraph();
+      flushBullet();
+      ordered.push(orderedMatch[2]);
+      continue;
+    }
+
+    paragraph.push(trimmed);
+  }
+
+  flushParagraph();
+  flushBullet();
+  flushOrdered();
+
+  if (elements.length === 0) {
+    return [
+      <Typography
+        key="empty"
+        component="p"
+        sx={{ mb: 0 }}
+        dangerouslySetInnerHTML={{ __html: applyInlineFormatting(markdown) }}
+      />,
+    ];
+  }
+
+  return elements;
+}
+
+function formatDuration(seconds: number | null) {
+  if (!seconds || Number.isNaN(seconds)) return null;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+function VideoPreview({ resource }: { resource: RenderableResource }) {
+  if (!resource.url) {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={1} alignItems="flex-start">
+            <Stack direction="row" spacing={1} alignItems="center">
+              <PlayArrowIcon fontSize="small" />
+              <Typography variant="subtitle1">{resource.title}</Typography>
+            </Stack>
+            <Typography variant="body2" color="text.secondary">
+              Video resource missing URL.
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const lower = resource.url.toLowerCase();
+  const isYoutube = lower.includes('youtube.com') || lower.includes('youtu.be');
+  const isVimeo = lower.includes('vimeo.com');
+
+  if (isYoutube) {
+    const url = new URL(resource.url);
+    let videoId = url.searchParams.get('v');
+    if (!videoId && lower.includes('youtu.be')) {
+      videoId = resource.url.split('/').pop() ?? '';
+    }
+    if (videoId) {
+      return (
+        <Box sx={{ position: 'relative', pb: '56.25%', height: 0, borderRadius: 2, overflow: 'hidden' }}>
+          <iframe
+            title={resource.title}
+            src={`https://www.youtube.com/embed/${videoId}`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }}
+          />
+        </Box>
+      );
+    }
+  }
+
+  if (isVimeo) {
+    const segments = resource.url.split('/');
+    const id = segments[segments.length - 1];
+    if (id) {
+      return (
+        <Box sx={{ position: 'relative', pb: '56.25%', height: 0, borderRadius: 2, overflow: 'hidden' }}>
+          <iframe
+            title={resource.title}
+            src={`https://player.vimeo.com/video/${id}`}
+            allow="autoplay; fullscreen; picture-in-picture"
+            allowFullScreen
+            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }}
+          />
+        </Box>
+      );
+    }
+  }
+
+  return (
+    <Card variant="outlined">
+      {resource.thumbnail && (
+        <CardMedia component="img" image={resource.thumbnail} alt={resource.title} sx={{ maxHeight: 360 }} />
+      )}
+      <CardContent>
+        <Stack spacing={1}>
+          <Typography variant="subtitle1">{resource.title}</Typography>
+          <Button
+            variant="outlined"
+            size="small"
+            endIcon={<OpenInNewIcon fontSize="small" />}
+            href={resource.url ?? undefined}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open video
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AudioPreview({ resource }: { resource: RenderableResource }) {
+  if (!resource.url) {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={1} alignItems="flex-start">
+            <Stack direction="row" spacing={1} alignItems="center">
+              <HeadphonesIcon fontSize="small" />
+              <Typography variant="subtitle1">{resource.title}</Typography>
+            </Stack>
+            <Typography variant="body2" color="text.secondary">
+              Audio resource missing URL.
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack spacing={2}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <HeadphonesIcon fontSize="small" />
+            <Typography variant="subtitle1">{resource.title}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {formatDuration(resource.duration) ?? ''}
+            </Typography>
+          </Stack>
+          <audio controls src={resource.url} style={{ width: '100%' }}>
+            <track kind="captions" />
+          </audio>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PdfPreview({ resource }: { resource: RenderableResource }) {
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack spacing={1} alignItems="flex-start">
+          <Stack direction="row" spacing={1} alignItems="center">
+            <PictureAsPdfIcon fontSize="small" />
+            <Typography variant="subtitle1">{resource.title}</Typography>
+          </Stack>
+          <Button
+            variant="outlined"
+            size="small"
+            endIcon={<OpenInNewIcon fontSize="small" />}
+            href={resource.url ?? undefined}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open PDF
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ImagePreview({ resource }: { resource: RenderableResource }) {
+  return (
+    <Card variant="outlined">
+      {resource.url ? (
+        <CardMedia component="img" image={resource.url} alt={resource.title} sx={{ maxHeight: 480 }} />
+      ) : (
+        <CardContent>
+          <Stack spacing={1} alignItems="flex-start">
+            <Stack direction="row" spacing={1} alignItems="center">
+              <ImageIcon fontSize="small" />
+              <Typography variant="subtitle1">{resource.title}</Typography>
+            </Stack>
+            <Typography variant="body2" color="text.secondary">
+              Image resource missing URL.
+            </Typography>
+          </Stack>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+function LinkPreview({ resource }: { resource: RenderableResource }) {
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack spacing={1} alignItems="flex-start">
+          <Stack direction="row" spacing={1} alignItems="center">
+            <InsertLinkIcon fontSize="small" />
+            <Typography variant="subtitle1">{resource.title}</Typography>
+          </Stack>
+          <Button
+            variant="outlined"
+            size="small"
+            endIcon={<OpenInNewIcon fontSize="small" />}
+            href={resource.url ?? undefined}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open link
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function BlockRenderer({ block, resource }: BlockRendererProps) {
+  if (block.block_type === 'divider') {
+    return <Divider sx={{ my: 3 }} />;
+  }
+
+  if (block.block_type === 'text') {
+    const markdown = block.text_md ?? '';
+    if (!markdown.trim()) {
+      return (
+        <Card variant="outlined">
+          <CardContent>
+            <Stack spacing={1} alignItems="center" justifyContent="center" sx={{ py: 4 }}>
+              <TextSnippetIcon color="disabled" />
+              <Typography variant="body2" color="text.secondary">
+                Empty text block. Click to edit.
+              </Typography>
+            </Stack>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    return <Stack spacing={1.5}>{renderMarkdownToElements(markdown)}</Stack>;
+  }
+
+  if (!resource) {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={1}>
+            <Typography variant="subtitle1">Missing resource</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Select a published resource to display here.
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  switch (resource.type) {
+    case 'video':
+      return <VideoPreview resource={resource} />;
+    case 'podcast':
+    case 'audio':
+      return <AudioPreview resource={resource} />;
+    case 'pdf':
+    case 'document':
+      return <PdfPreview resource={resource} />;
+    case 'image':
+      return <ImagePreview resource={resource} />;
+    case 'link':
+    default:
+      return <LinkPreview resource={resource} />;
+  }
+}

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -197,24 +197,51 @@ function VideoPreview({ resource }: { resource: RenderableResource }) {
   const isYoutube = lower.includes('youtube.com') || lower.includes('youtu.be');
   const isVimeo = lower.includes('vimeo.com');
 
+  const frameWrapper = (
+    src: string,
+    allow: string,
+    title: string,
+  ) => (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        maxWidth: 860,
+        mx: 'auto',
+        borderRadius: 2,
+        overflow: 'hidden',
+        bgcolor: 'common.black',
+        pb: '56.25%',
+        height: 0,
+      }}
+    >
+      <Box
+        component="iframe"
+        title={title}
+        src={src}
+        allow={allow}
+        allowFullScreen
+        sx={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
+      />
+    </Box>
+  );
+
   if (isYoutube) {
-    const url = new URL(resource.url);
-    let videoId = url.searchParams.get('v');
-    if (!videoId && lower.includes('youtu.be')) {
-      videoId = resource.url.split('/').pop() ?? '';
-    }
-    if (videoId) {
-      return (
-        <Box sx={{ position: 'relative', pb: '56.25%', height: 0, borderRadius: 2, overflow: 'hidden' }}>
-          <iframe
-            title={resource.title}
-            src={`https://www.youtube.com/embed/${videoId}`}
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }}
-          />
-        </Box>
-      );
+    try {
+      const url = new URL(resource.url);
+      let videoId = url.searchParams.get('v');
+      if (!videoId && lower.includes('youtu.be')) {
+        videoId = resource.url.split('/').pop() ?? '';
+      }
+      if (videoId) {
+        return frameWrapper(
+          `https://www.youtube.com/embed/${videoId}`,
+          'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
+          resource.title,
+        );
+      }
+    } catch {
+      // fall back to card preview below
     }
   }
 
@@ -222,16 +249,10 @@ function VideoPreview({ resource }: { resource: RenderableResource }) {
     const segments = resource.url.split('/');
     const id = segments[segments.length - 1];
     if (id) {
-      return (
-        <Box sx={{ position: 'relative', pb: '56.25%', height: 0, borderRadius: 2, overflow: 'hidden' }}>
-          <iframe
-            title={resource.title}
-            src={`https://player.vimeo.com/video/${id}`}
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
-            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }}
-          />
-        </Box>
+      return frameWrapper(
+        `https://player.vimeo.com/video/${id}`,
+        'autoplay; fullscreen; picture-in-picture',
+        resource.title,
       );
     }
   }
@@ -239,7 +260,12 @@ function VideoPreview({ resource }: { resource: RenderableResource }) {
   return (
     <Card variant="outlined">
       {resource.thumbnail && (
-        <CardMedia component="img" image={resource.thumbnail} alt={resource.title} sx={{ maxHeight: 360 }} />
+        <CardMedia
+          component="img"
+          image={resource.thumbnail}
+          alt={resource.title}
+          sx={{ maxHeight: 320, objectFit: 'cover' }}
+        />
       )}
       <CardContent>
         <Stack spacing={1}>

--- a/src/lib/courseBuilder.ts
+++ b/src/lib/courseBuilder.ts
@@ -1,0 +1,301 @@
+import { NextResponse } from 'next/server';
+import { getAdminClient } from './supabaseAdmin';
+
+export class CourseBuilderError extends Error {
+  status: number;
+  details?: Record<string, unknown>;
+
+  constructor(message: string, status = 400, details?: Record<string, unknown>) {
+    super(message);
+    this.name = 'CourseBuilderError';
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export const adminClient = getAdminClient();
+
+export type ContentNodeRow = {
+  id: number;
+  node_type: string;
+  [key: string]: unknown;
+};
+
+export type NodeChildRow = {
+  parent_id: number;
+  child_id: number;
+  position: number;
+  is_required: boolean | null;
+  label: string | null;
+  notes: string | null;
+};
+
+export type ContentBlockRow = {
+  id: number;
+  node_id: number;
+  block_type: 'text' | 'asset' | 'divider';
+  position: number;
+  text_md: string | null;
+  resource_id: number | null;
+  start_ms: number | null;
+  end_ms: number | null;
+  label: string | null;
+  notes: string | null;
+  settings: Record<string, unknown> | null;
+  data: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+export type NodeSubtree = {
+  node: ContentNodeRow;
+  blocks: ContentBlockRow[];
+  children: Array<{
+    edge: NodeChildRow;
+    subtree: NodeSubtree;
+  }>;
+};
+
+export async function fetchNodeById(nodeId: number) {
+  const { data, error } = await adminClient
+    .from('content_nodes')
+    .select('*')
+    .eq('id', nodeId)
+    .maybeSingle();
+
+  if (error) {
+    throw new CourseBuilderError('Failed to load node', 500, { details: error.message, nodeId });
+  }
+
+  if (!data) {
+    throw new CourseBuilderError('Node not found', 404, { nodeId });
+  }
+
+  return data as ContentNodeRow;
+}
+
+async function fetchNodeChildren(parentId: number) {
+  const { data, error } = await adminClient
+    .from('node_children')
+    .select('*')
+    .eq('parent_id', parentId)
+    .order('position', { ascending: true });
+
+  if (error) {
+    throw new CourseBuilderError('Failed to load node children', 500, { details: error.message, parentId });
+  }
+
+  return (data ?? []) as NodeChildRow[];
+}
+
+async function fetchNodeBlocks(nodeId: number) {
+  const { data, error } = await adminClient
+    .from('content_blocks')
+    .select('*')
+    .eq('node_id', nodeId)
+    .order('position', { ascending: true });
+
+  if (error) {
+    throw new CourseBuilderError('Failed to load content blocks', 500, { details: error.message, nodeId });
+  }
+
+  return (data ?? []) as ContentBlockRow[];
+}
+
+export async function fetchBlockById(blockId: number) {
+  const { data, error } = await adminClient
+    .from('content_blocks')
+    .select('*')
+    .eq('id', blockId)
+    .maybeSingle();
+
+  if (error) {
+    throw new CourseBuilderError('Failed to load content block', 500, { details: error.message, blockId });
+  }
+
+  if (!data) {
+    throw new CourseBuilderError('Content block not found', 404, { blockId });
+  }
+
+  return data as ContentBlockRow;
+}
+
+export async function fetchNodeSubtree(nodeId: number, visited = new Set<number>()): Promise<NodeSubtree> {
+  if (visited.has(nodeId)) {
+    throw new CourseBuilderError('Cycle detected in node hierarchy', 500, { nodeId });
+  }
+
+  visited.add(nodeId);
+
+  const node = await fetchNodeById(nodeId);
+  const blocks = await fetchNodeBlocks(nodeId);
+  const children = await fetchNodeChildren(nodeId);
+
+  const childSubtrees = [] as NodeSubtree['children'];
+  for (const child of children) {
+    const subtree = await fetchNodeSubtree(child.child_id, visited);
+    childSubtrees.push({ edge: child, subtree });
+  }
+
+  visited.delete(nodeId);
+
+  return {
+    node,
+    blocks,
+    children: childSubtrees,
+  };
+}
+
+export async function validateNodeRelationship(parentId: number, childNodeType: string) {
+  const parent = await fetchNodeById(parentId);
+
+  const { data, error } = await adminClient
+    .from('node_edge_rules')
+    .select('parent_type, child_kind, child_type')
+    .eq('parent_type', parent.node_type)
+    .eq('child_kind', 'node')
+    .eq('child_type', childNodeType)
+    .maybeSingle();
+
+  if (error) {
+    throw new CourseBuilderError('Failed to validate node relationship', 500, {
+      details: error.message,
+      parentId,
+      childNodeType,
+    });
+  }
+
+  if (!data) {
+    throw new CourseBuilderError('Invalid parent-child relationship', 400, {
+      parentType: parent.node_type,
+      attemptedChildType: childNodeType,
+    });
+  }
+
+  return parent;
+}
+
+export function validateBlockPayload(block: Partial<ContentBlockRow>) {
+  const blockType = block.block_type;
+
+  if (!blockType) {
+    throw new CourseBuilderError('Block type is required', 400);
+  }
+
+  if (!['text', 'asset', 'divider'].includes(blockType)) {
+    throw new CourseBuilderError('Invalid block type', 400, { blockType });
+  }
+
+  if (blockType === 'text') {
+    if (!block.text_md || block.text_md.trim().length === 0) {
+      throw new CourseBuilderError('text blocks require non-empty text_md', 400);
+    }
+
+    if (block.resource_id != null) {
+      throw new CourseBuilderError('text blocks cannot reference resources', 400);
+    }
+
+    if (block.start_ms != null || block.end_ms != null) {
+      throw new CourseBuilderError('text blocks cannot include media trim settings', 400);
+    }
+  }
+
+  if (blockType === 'asset') {
+    if (!block.resource_id) {
+      throw new CourseBuilderError('asset blocks require resource_id', 400);
+    }
+
+    if (block.text_md != null && block.text_md.trim().length > 0) {
+      throw new CourseBuilderError('asset blocks cannot include text_md', 400);
+    }
+  }
+
+  if (blockType === 'divider') {
+    const hasContent =
+      (block.text_md != null && block.text_md.trim().length > 0) ||
+      block.resource_id != null ||
+      block.start_ms != null ||
+      block.end_ms != null;
+
+    if (hasContent) {
+      throw new CourseBuilderError('divider blocks cannot include content fields', 400);
+    }
+  }
+}
+
+export function collectSubtreeStats(subtree: NodeSubtree) {
+  const nodeCounts = new Map<string, number>();
+  const blockCounts = new Map<string, number>();
+
+  const walk = (node: NodeSubtree) => {
+    const nodeType = node.node.node_type ?? 'unknown';
+    nodeCounts.set(nodeType, (nodeCounts.get(nodeType) ?? 0) + 1);
+
+    for (const block of node.blocks) {
+      const blockType = block.block_type ?? 'unknown';
+      blockCounts.set(blockType, (blockCounts.get(blockType) ?? 0) + 1);
+    }
+
+    for (const child of node.children) {
+      walk(child.subtree);
+    }
+  };
+
+  walk(subtree);
+
+  return {
+    nodeCounts: Object.fromEntries(nodeCounts),
+    blockCounts: Object.fromEntries(blockCounts),
+  };
+}
+
+export function flattenSubtreeIds(subtree: NodeSubtree) {
+  const ids = new Set<number>();
+
+  const walk = (node: NodeSubtree) => {
+    ids.add(node.node.id);
+    for (const child of node.children) {
+      walk(child.subtree);
+    }
+  };
+
+  walk(subtree);
+
+  return Array.from(ids);
+}
+
+export async function getParentEdge(childId: number) {
+  const { data, error } = await adminClient
+    .from('node_children')
+    .select('*')
+    .eq('child_id', childId)
+    .maybeSingle();
+
+  if (error) {
+    throw new CourseBuilderError('Failed to lookup parent edge', 500, { details: error.message, childId });
+  }
+
+  return (data ?? null) as NodeChildRow | null;
+}
+
+export function handleCourseBuilderError(error: unknown) {
+  if (error instanceof CourseBuilderError) {
+    return NextResponse.json(
+      {
+        error: error.message,
+        details: error.details ?? null,
+      },
+      { status: error.status }
+    );
+  }
+
+  console.error('Unexpected course builder error:', error);
+  const message = error instanceof Error ? error.message : 'Unknown error';
+
+  return NextResponse.json(
+    {
+      error: 'Server error',
+      details: message,
+    },
+    { status: 500 }
+  );
+}


### PR DESCRIPTION
## Summary
- add course builder helpers for building subtrees, validating relationships, and standardizing error handling for admin clients
- implement admin course builder node routes for CRUD, child management, reordering, relocation, and cascade-aware deletes
- add content block admin routes with strict payload validation and ordering utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df023d7a04833285ff519d9ed44700