### PR TITLE
Add edit and preview modes to course builder

### DIFF
--- a/src/components/admin/courseEditor/Canvas/BlockShell.tsx
+++ b/src/components/admin/courseEditor/Canvas/BlockShell.tsx
@@ -2,15 +2,14 @@
 
 import { CSS } from '@dnd-kit/utilities';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
-import { Box, Card, CardContent, Chip, Stack, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { Box, IconButton } from '@mui/material';
 import type { DraggableAttributes } from '@dnd-kit/core';
 import type { ContentBlock } from '@/types/course';
-import type { RenderableResource } from '@/components/course/BlockRenderer';
 import type { ReactNode } from 'react';
 
 export type BlockShellProps = {
   block: ContentBlock;
-  resource: RenderableResource | null;
   isSelected: boolean;
   isEditing: boolean;
   previewMode?: boolean;
@@ -26,7 +25,6 @@ export type BlockShellProps = {
 
 export default function BlockShell({
   block,
-  resource,
   isSelected,
   isEditing,
   previewMode = false,
@@ -44,63 +42,61 @@ export default function BlockShell({
     transition: transition ?? undefined,
   } as const;
 
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (previewMode) return;
+    event.stopPropagation();
+    onSelect(block);
+  };
+
+  const dragHandle = previewMode ? null : (
+    <IconButton
+      className="block-shell__handle"
+      size="small"
+      {...listeners}
+      aria-label="Drag to reorder block"
+      sx={{
+        position: 'absolute',
+        left: -40,
+        top: '50%',
+        transform: 'translateY(-50%)',
+        opacity: isEditing || isDragging ? 0 : 0.4,
+        transition: 'opacity 0.2s ease',
+        cursor: 'grab',
+        color: isSelected ? 'primary.main' : 'text.secondary',
+        '&:hover': { opacity: 1 },
+      }}
+    >
+      <DragIndicatorIcon fontSize="small" />
+    </IconButton>
+  );
+
   return (
-    <Card
+    <Box
       className="block-shell"
       ref={setNodeRef}
       {...attributes}
       sx={{
         position: 'relative',
-        borderColor: isSelected ? 'primary.main' : 'divider',
-        backgroundColor: isEditing ? 'action.hover' : undefined,
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: isSelected ? 'primary.main' : 'transparent',
+        backgroundColor: isEditing
+          ? (theme) => alpha(theme.palette.primary.main, 0.06)
+          : (theme) => alpha(theme.palette.background.paper, previewMode ? 0 : 1),
         cursor: previewMode ? 'default' : 'pointer',
         opacity: isDragging ? 0.6 : 1,
-        transition: 'border-color 0.2s ease, background-color 0.2s ease, opacity 0.2s ease',
+        transition: 'border-color 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease',
+        boxShadow: isSelected ? 2 : 0,
+        p: { xs: 1.5, md: 2 },
         '&:hover .block-shell__handle': {
-          opacity: previewMode || isEditing ? 0 : 1,
+          opacity: previewMode || isEditing ? 0 : 0.8,
         },
       }}
       style={style}
-      variant={isSelected ? 'outlined' : undefined}
-      onClick={() => onSelect(block)}
+      onClick={handleClick}
     >
-      {!previewMode && (
-        <Box
-          className="block-shell__handle"
-          {...listeners}
-          sx={{
-            position: 'absolute',
-            left: -32,
-            top: 0,
-            bottom: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: isSelected ? 'primary.main' : 'text.disabled',
-            cursor: 'grab',
-            opacity: isEditing ? 0 : 0,
-            pointerEvents: isEditing ? 'none' : 'auto',
-            transition: 'opacity 0.2s ease',
-            pr: 1,
-          }}
-        >
-          <DragIndicatorIcon fontSize="small" />
-        </Box>
-      )}
-      <CardContent>
-        <Stack spacing={1.5}>
-          <Stack direction="row" justifyContent="space-between" alignItems="center">
-            <Stack direction="row" spacing={1} alignItems="center">
-              <Typography variant="subtitle2">Block {block.position + 1}</Typography>
-              {resource?.title ? <Chip label={resource.title} size="small" /> : null}
-            </Stack>
-            <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'capitalize' }}>
-              {block.block_type}
-            </Typography>
-          </Stack>
-          <Box>{children}</Box>
-        </Stack>
-      </CardContent>
-    </Card>
+      {dragHandle}
+      <Box>{children}</Box>
+    </Box>
   );
 }

--- a/src/components/admin/courseEditor/Canvas/Canvas.tsx
+++ b/src/components/admin/courseEditor/Canvas/Canvas.tsx
@@ -78,6 +78,7 @@ export default function Canvas({
   }, [blocks, editingBlockId, onInsertBlock, previewMode, selectedBlockId]);
 
   const handleOpenInsertMenu = (element: HTMLElement, position: number) => {
+    if (!canEditBlocks) return;
     setInsertAnchor({ element, position });
   };
 
@@ -154,80 +155,92 @@ export default function Canvas({
     <Box sx={{ p: 3, height: '100%', overflowY: 'auto' }}>
       <Stack spacing={3} sx={{ maxWidth: 900, mx: 'auto' }}>
         <Typography variant="h6">{subtree.node.title ?? 'Untitled node'}</Typography>
-        {blocks.length === 0 ? (
-          <Alert severity="info">Use the “+” buttons to add content blocks to this node.</Alert>
+        {!previewMode && blocks.length === 0 ? (
+          <Alert severity="info" sx={{ textAlign: 'center' }}>
+            This lesson has no content yet. Click the + buttons to add your first block.
+          </Alert>
         ) : null}
-        <BlockDndContext onDragOver={canEditBlocks ? handleDragOver : undefined} onDragEnd={canEditBlocks ? handleDragEnd : undefined}>
-          <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
-            <Stack
-              spacing={2}
-              sx={{
-                position: 'relative',
-                pl: { xs: 0, md: 4 },
-                '&:hover .canvas-insert': {
-                  opacity: canEditBlocks ? 1 : 0,
-                },
-              }}
-            >
-              {renderInsertAffordance(0)}
-              {blocks.map((block, index) => {
-                const isSelected = selectedBlockId === block.id;
-                const isEditing = editingBlockId === block.id;
-                const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
-                return (
-                  <Fragment key={block.id}>
-                    {indicatorIndex === index ? <DropIndicator /> : null}
-                    <CanvasRow>
-                      <SortableBlock
-                        block={block}
-                        disabled={!canEditBlocks}
-                        isSelected={isSelected}
-                        isEditing={isEditing}
-                        resource={resource}
-                        previewMode={previewMode}
-                        onSelect={() => {
-                          onSelectBlock(block);
-                          if (block.block_type === 'text' && canEditBlocks) {
-                            onStartEdit(block.id);
-                          }
-                        }}
-                      >
-                        {block.block_type === 'text' && isEditing && canEditBlocks ? (
-                          <TipTapHtmlEditor
-                            value={block.text_md ?? ''}
-                            onChange={(html) => onChangeText(block.id, html)}
-                            onBlur={() => onExitEdit()}
-                            onEscape={() => onExitEdit()}
-                            autoFocus
-                          />
-                        ) : (
-                          <BlockRenderer block={block} resource={resource} />
-                        )}
-                      </SortableBlock>
-                    </CanvasRow>
-                    {renderInsertAffordance(index + 1)}
-                  </Fragment>
-                );
-              })}
-              {indicatorIndex === blocks.length ? <DropIndicator /> : null}
-            </Stack>
-          </SortableContext>
-        </BlockDndContext>
-        {!canEditBlocks && (
+        {previewMode ? (
+          <Stack spacing={3}>
+            {blocks.map((block) => {
+              const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
+              return <BlockRenderer key={block.id} block={block} resource={resource} />;
+            })}
+          </Stack>
+        ) : (
+          <BlockDndContext onDragOver={canEditBlocks ? handleDragOver : undefined} onDragEnd={canEditBlocks ? handleDragEnd : undefined}>
+            <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
+              <Stack
+                spacing={2}
+                sx={{
+                  position: 'relative',
+                  pl: { xs: 0, md: 4 },
+                  '&:hover .canvas-insert': {
+                    opacity: canEditBlocks ? 1 : 0,
+                  },
+                }}
+              >
+                {renderInsertAffordance(0)}
+                {blocks.map((block, index) => {
+                  const isSelected = selectedBlockId === block.id;
+                  const isEditing = editingBlockId === block.id;
+                  const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
+                  return (
+                    <Fragment key={block.id}>
+                      {indicatorIndex === index ? <DropIndicator /> : null}
+                      <CanvasRow>
+                        <SortableBlock
+                          block={block}
+                          disabled={!canEditBlocks}
+                          isSelected={isSelected}
+                          isEditing={isEditing}
+                          previewMode={previewMode}
+                          onSelect={() => {
+                            onSelectBlock(block);
+                            if (block.block_type === 'text' && canEditBlocks) {
+                              onStartEdit(block.id);
+                            }
+                          }}
+                        >
+                          {block.block_type === 'text' && isEditing && canEditBlocks ? (
+                            <TipTapHtmlEditor
+                              value={block.text_md ?? ''}
+                              onChange={(html) => onChangeText(block.id, html)}
+                              onBlur={() => onExitEdit()}
+                              onEscape={() => onExitEdit()}
+                              autoFocus
+                            />
+                          ) : (
+                            <BlockRenderer block={block} resource={resource} />
+                          )}
+                        </SortableBlock>
+                      </CanvasRow>
+                      {renderInsertAffordance(index + 1)}
+                    </Fragment>
+                  );
+                })}
+                {indicatorIndex === blocks.length ? <DropIndicator /> : null}
+              </Stack>
+            </SortableContext>
+          </BlockDndContext>
+        )}
+        {!canEditBlocks && !previewMode && (
           <Alert severity="info">Blocks are only available on leaf nodes.</Alert>
         )}
       </Stack>
-      <Menu anchorEl={insertAnchor?.element ?? null} open={!!insertAnchor} onClose={handleCloseInsertMenu}>
-        <MenuItem onClick={() => handleChooseInsert('text')}>
-          <TextFieldsIcon fontSize="small" sx={{ mr: 1 }} /> Text
-        </MenuItem>
-        <MenuItem onClick={() => handleChooseInsert('asset')}>
-          <VideoLibraryIcon fontSize="small" sx={{ mr: 1 }} /> Resource
-        </MenuItem>
-        <MenuItem onClick={() => handleChooseInsert('divider')}>
-          <HorizontalRuleIcon fontSize="small" sx={{ mr: 1 }} /> Divider
-        </MenuItem>
-      </Menu>
+      {!previewMode && (
+        <Menu anchorEl={insertAnchor?.element ?? null} open={!!insertAnchor} onClose={handleCloseInsertMenu}>
+          <MenuItem onClick={() => handleChooseInsert('text')}>
+            <TextFieldsIcon fontSize="small" sx={{ mr: 1 }} /> Text
+          </MenuItem>
+          <MenuItem onClick={() => handleChooseInsert('asset')}>
+            <VideoLibraryIcon fontSize="small" sx={{ mr: 1 }} /> Resource
+          </MenuItem>
+          <MenuItem onClick={() => handleChooseInsert('divider')}>
+            <HorizontalRuleIcon fontSize="small" sx={{ mr: 1 }} /> Divider
+          </MenuItem>
+        </Menu>
+      )}
     </Box>
   );
 }
@@ -237,19 +250,17 @@ type SortableBlockProps = {
   disabled: boolean;
   isSelected: boolean;
   isEditing: boolean;
-  resource: RenderableResource | null;
   previewMode: boolean;
   onSelect: () => void;
   children: React.ReactNode;
 };
 
-function SortableBlock({ block, disabled, isSelected, isEditing, resource, previewMode, onSelect, children }: SortableBlockProps) {
+function SortableBlock({ block, disabled, isSelected, isEditing, previewMode, onSelect, children }: SortableBlockProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: block.id, disabled });
 
   return (
     <BlockShell
       block={block}
-      resource={resource}
       isSelected={isSelected}
       isEditing={isEditing}
       previewMode={previewMode}

--- a/src/components/admin/courseEditor/Sidebar/Tree.tsx
+++ b/src/components/admin/courseEditor/Sidebar/Tree.tsx
@@ -39,7 +39,7 @@ export type TreeProps = {
   onSearchChange: (value: string) => void;
   onToggle: (id: number) => void;
   onSelect: (id: number) => void;
-  onContextMenu: (event: React.MouseEvent<HTMLElement>, nodeId: number) => void;
+  onContextMenu?: (event: React.MouseEvent<HTMLElement>, nodeId: number) => void;
 };
 
 function matchesQuery(value: string | null | undefined, query: string) {
@@ -64,7 +64,7 @@ function TreeNode({
   onSelect: (id: number) => void;
   selectedId: number | null;
   search: string;
-  onContextMenu: (event: React.MouseEvent<HTMLElement>, nodeId: number) => void;
+  onContextMenu?: (event: React.MouseEvent<HTMLElement>, nodeId: number) => void;
 }) {
   const hasChildren = subtree.children.length > 0;
   const isExpanded = expanded.has(subtree.node.id) || (!!search && hasChildren);
@@ -89,16 +89,20 @@ function TreeNode({
           <Box sx={{ width: 32 }} />
         )}
         <Tooltip title={subtree.node.title ?? 'Untitled node'} placement="right">
-          <Chip
-            size="small"
-            icon={NODE_ICONS[subtree.node.node_type] ?? <StorageIcon fontSize="small" />}
-            label={subtree.node.title ?? 'Untitled'}
-            color={selectedId === subtree.node.id ? 'primary' : 'default'}
-            onClick={() => onSelect(subtree.node.id)}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              onContextMenu(event, subtree.node.id);
-            }}
+            <Chip
+              size="small"
+              icon={NODE_ICONS[subtree.node.node_type] ?? <StorageIcon fontSize="small" />}
+              label={subtree.node.title ?? 'Untitled'}
+              color={selectedId === subtree.node.id ? 'primary' : 'default'}
+              onClick={() => onSelect(subtree.node.id)}
+              onContextMenu={
+                onContextMenu
+                  ? (event) => {
+                      event.preventDefault();
+                      onContextMenu(event, subtree.node.id);
+                    }
+                  : undefined
+              }
             sx={{
               maxWidth: '100%',
               '& .MuiChip-label': {

--- a/src/components/admin/courseEditor/Toolbar/Toolbar.tsx
+++ b/src/components/admin/courseEditor/Toolbar/Toolbar.tsx
@@ -1,34 +1,20 @@
 'use client';
 
-import {
-  Box,
-  Button,
-  Stack,
-  Switch,
-  ToggleButton,
-  ToggleButtonGroup,
-  Typography,
-} from '@mui/material';
+import { Box, Button, Chip, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import type { NodeState, NodeSubtree } from '@/types/course';
 import type { NodeDraft } from '../Sidebar/Properties';
+import { useEditorStore } from '../state/editorStore';
 
 export type ToolbarProps = {
   subtree: NodeSubtree | null;
   nodeDraft: NodeDraft | null;
-  previewMode: boolean;
-  onPreviewModeChange: (value: boolean) => void;
   onStateChange: (state: NodeState) => void;
   onShowDetails: () => void;
 };
 
-export default function Toolbar({
-  subtree,
-  nodeDraft,
-  previewMode,
-  onPreviewModeChange,
-  onStateChange,
-  onShowDetails,
-}: ToolbarProps) {
+export default function Toolbar({ subtree, nodeDraft, onStateChange, onShowDetails }: ToolbarProps) {
+  const { editorMode, setEditorMode, savingState, savingMessage } = useEditorStore();
+
   if (!subtree || !nodeDraft) {
     return (
       <Box sx={{ p: 3 }}>
@@ -52,6 +38,16 @@ export default function Toolbar({
         </Typography>
       </Stack>
       <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }}>
+        <SaveStatus state={savingState} message={savingMessage} />
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={editorMode}
+          onChange={(_, value) => value && setEditorMode(value)}
+        >
+          <ToggleButton value="edit">Edit</ToggleButton>
+          <ToggleButton value="preview">Preview</ToggleButton>
+        </ToggleButtonGroup>
         <ToggleButtonGroup
           size="small"
           exclusive
@@ -62,14 +58,40 @@ export default function Toolbar({
           <ToggleButton value="published">Published</ToggleButton>
           <ToggleButton value="archived">Archived</ToggleButton>
         </ToggleButtonGroup>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Typography variant="body2">Preview</Typography>
-          <Switch checked={previewMode} onChange={(event) => onPreviewModeChange(event.target.checked)} />
-        </Stack>
         <Button variant="outlined" onClick={onShowDetails}>
           Node details
         </Button>
       </Stack>
     </Stack>
   );
+}
+
+type SaveStatusProps = {
+  state: 'idle' | 'saving' | 'saved' | 'error';
+  message: string;
+};
+
+function SaveStatus({ state, message }: SaveStatusProps) {
+  const color =
+    state === 'saving' ? 'warning.main' : state === 'error' ? 'error.main' : state === 'saved' ? 'success.main' : 'success.main';
+
+  return (
+    <Chip
+      size="small"
+      label={message}
+      sx={{
+        borderRadius: 999,
+        '& .MuiChip-label': {
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        },
+      }}
+      icon={<StatusDot color={color} />}
+    />
+  );
+}
+
+function StatusDot({ color }: { color: string }) {
+  return <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: color }} />;
 }

--- a/src/components/admin/courseEditor/index.tsx
+++ b/src/components/admin/courseEditor/index.tsx
@@ -202,10 +202,12 @@ function CourseEditorInner() {
     editingBlockId,
     savingState,
     savingMessage,
+    editorMode,
     setSelectedNodeId,
     setSelectedBlockId,
     setEditingBlockId,
     setSavingState,
+    setEditorMode,
   } = useEditorStore();
 
   const [trees, setTrees] = useState<NodeSubtree[]>([]);
@@ -216,7 +218,6 @@ function CourseEditorInner() {
   const [search, setSearch] = useState('');
   const [nodeDraft, setNodeDraft] = useState<NodeDraft | null>(null);
   const [metadataError, setMetadataError] = useState<string | null>(null);
-  const [previewMode, setPreviewMode] = useState(false);
   const [resourceCache, setResourceCache] = useState<Record<number, RenderableResource>>({});
   const [snack, setSnack] = useState<{ message: string; severity: 'success' | 'error' } | null>(null);
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
@@ -266,7 +267,7 @@ function CourseEditorInner() {
     } finally {
       setLoading(false);
     }
-  }, [setSelectedNodeId, setSelectedBlockId]);
+  }, [setEditingBlockId, setSelectedBlockId, setSelectedNodeId, setExpanded]);
 
   useEffect(() => {
     void loadData();
@@ -469,6 +470,13 @@ function CourseEditorInner() {
       pendingTextDrafts.current.delete(pending.tempId);
     }
   }, [queueBlockUpdate, setEditingBlockId, setSelectedBlockId, sortedBlocks]);
+
+  useEffect(() => {
+    if (editorMode === 'preview') {
+      setSelectedBlockId(null);
+      setEditingBlockId(null);
+    }
+  }, [editorMode, setEditingBlockId, setSelectedBlockId]);
 
   const flushNodeUpdate = useCallback(
     async (nodeId: number) => {
@@ -929,18 +937,13 @@ function CourseEditorInner() {
         <Toolbar
           subtree={selectedSubtree}
           nodeDraft={nodeDraft}
-          previewMode={previewMode}
-          onPreviewModeChange={(value) => {
-            setPreviewMode(value);
-            if (value) {
-              setSelectedBlockId(null);
-              setEditingBlockId(null);
-            }
-          }}
           onStateChange={(state) => handleStateChange(state)}
           onShowDetails={() => {
             setSelectedBlockId(null);
             setEditingBlockId(null);
+            if (editorMode === 'preview') {
+              setEditorMode('edit');
+            }
           }}
         />
         <Box
@@ -948,7 +951,10 @@ function CourseEditorInner() {
             flex: 1,
             minHeight: 0,
             display: 'grid',
-            gridTemplateColumns: { xs: '1fr', md: '3fr 5fr 4fr' },
+            gridTemplateColumns:
+              editorMode === 'preview'
+                ? { xs: '1fr', md: '320px 1fr' }
+                : { xs: '1fr', md: '320px minmax(0, 1fr) 360px' },
           }}
         >
           <Box sx={{ borderRight: { md: '1px solid' }, borderColor: 'divider', minHeight: 0 }}>
@@ -964,13 +970,23 @@ function CourseEditorInner() {
                 setSelectedBlockId(null);
                 setEditingBlockId(null);
               }}
-              onContextMenu={(event, nodeId) => {
-                setMenuAnchor(event.currentTarget as HTMLElement);
-                setMenuNodeId(nodeId);
-              }}
+              onContextMenu={
+                editorMode === 'edit'
+                  ? (event, nodeId) => {
+                      setMenuAnchor(event.currentTarget as HTMLElement);
+                      setMenuNodeId(nodeId);
+                    }
+                  : undefined
+              }
             />
           </Box>
-          <Box sx={{ borderRight: { md: '1px solid' }, borderColor: 'divider', minHeight: 0 }}>
+          <Box
+            sx={{
+              borderRight: editorMode === 'preview' ? undefined : { md: '1px solid' },
+              borderColor: 'divider',
+              minHeight: 0,
+            }}
+          >
             <Canvas
               subtree={selectedSubtree}
               resources={resourceCache}
@@ -982,80 +998,90 @@ function CourseEditorInner() {
               onInsertBlock={handleInsertBlock}
               onReorderBlocks={handleReorderBlocks}
               onChangeText={handleTextChange}
-              previewMode={previewMode}
+              previewMode={editorMode === 'preview'}
             />
           </Box>
-          <Box sx={{ minHeight: 0 }}>
-            <Properties
-              subtree={selectedSubtree}
-              nodeDraft={nodeDraft}
-              metadataError={metadataError}
-              onNodeFieldChange={handleNodeFieldChange}
-              onRequestAddChild={(mode, options) =>
-                setAddChildDialog({ open: true, parentId: selectedSubtree?.node.id ?? null, mode, type: options?.type })
-              }
-              onReorderChild={(childId, direction) => selectedSubtree && void handleReorderChild(selectedSubtree.node.id, childId, direction)}
-              onUpdateChild={(childId, updates) => selectedSubtree && void handleUpdateChild(selectedSubtree.node.id, childId, updates)}
-              onRemoveChild={(childId) => selectedSubtree && void handleDetachChild(selectedSubtree.node.id, childId)}
-              selectedBlock={selectedBlock}
-              onClearBlockSelection={() => {
-                setSelectedBlockId(null);
-                setEditingBlockId(null);
-              }}
-              onUpdateBlock={(blockId, updates, options) => queueBlockUpdate(blockId, updates, options)}
-              onDeleteBlock={handleDeleteBlock}
-              onOpenResourcePicker={(mode, blockId) => {
-                if (!selectedSubtree) return;
-                setResourceDialogMode({ type: mode, blockId });
-                setResourceDialogOpen(true);
-              }}
-              resources={resourceCache}
-              savingState={savingState}
-              savingMessage={savingMessage}
-              availableChildTypes={getAvailableChildTypes(selectedSubtree?.node.id ?? null)}
-            />
-          </Box>
+          {editorMode === 'edit' ? (
+            <Box sx={{ minHeight: 0 }}>
+              <Properties
+                subtree={selectedSubtree}
+                nodeDraft={nodeDraft}
+                metadataError={metadataError}
+                onNodeFieldChange={handleNodeFieldChange}
+                onRequestAddChild={(mode, options) =>
+                  setAddChildDialog({ open: true, parentId: selectedSubtree?.node.id ?? null, mode, type: options?.type })
+                }
+                onReorderChild={(childId, direction) =>
+                  selectedSubtree && void handleReorderChild(selectedSubtree.node.id, childId, direction)
+                }
+                onUpdateChild={(childId, updates) =>
+                  selectedSubtree && void handleUpdateChild(selectedSubtree.node.id, childId, updates)
+                }
+                onRemoveChild={(childId) =>
+                  selectedSubtree && void handleDetachChild(selectedSubtree.node.id, childId)
+                }
+                selectedBlock={selectedBlock}
+                onClearBlockSelection={() => {
+                  setSelectedBlockId(null);
+                  setEditingBlockId(null);
+                }}
+                onUpdateBlock={(blockId, updates, options) => queueBlockUpdate(blockId, updates, options)}
+                onDeleteBlock={handleDeleteBlock}
+                onOpenResourcePicker={(mode, blockId) => {
+                  if (!selectedSubtree) return;
+                  setResourceDialogMode({ type: mode, blockId });
+                  setResourceDialogOpen(true);
+                }}
+                resources={resourceCache}
+                savingState={savingState}
+                savingMessage={savingMessage}
+                availableChildTypes={getAvailableChildTypes(selectedSubtree?.node.id ?? null)}
+              />
+            </Box>
+          ) : null}
         </Box>
       </Stack>
 
-      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={() => setMenuAnchor(null)}>
-        <MenuItem
-          onClick={() => {
-            if (!menuNodeId) return;
-            setMenuAnchor(null);
-            setAddChildDialog({ open: true, parentId: menuNodeId, mode: 'create' });
-          }}
-        >
-          <AddIcon fontSize="small" sx={{ mr: 1 }} /> Add child
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            if (!menuNodeId) return;
-            setMenuAnchor(null);
-            setAddChildDialog({ open: true, parentId: menuNodeId, mode: 'attach' });
-          }}
-        >
-          <SearchIcon fontSize="small" sx={{ mr: 1 }} /> Attach existing
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            if (!menuNodeId) return;
-            setMenuAnchor(null);
-            setDuplicateDialog({ open: true, nodeId: menuNodeId });
-          }}
-        >
-          <ContentCopyIcon fontSize="small" sx={{ mr: 1 }} /> Duplicate
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            if (!menuNodeId) return;
-            setMenuAnchor(null);
-            setDeleteDialog({ open: true, nodeId: menuNodeId });
-          }}
-        >
-          <DeleteIcon fontSize="small" sx={{ mr: 1 }} /> Delete
-        </MenuItem>
-      </Menu>
+      {editorMode === 'edit' ? (
+        <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={() => setMenuAnchor(null)}>
+          <MenuItem
+            onClick={() => {
+              if (!menuNodeId) return;
+              setMenuAnchor(null);
+              setAddChildDialog({ open: true, parentId: menuNodeId, mode: 'create' });
+            }}
+          >
+            <AddIcon fontSize="small" sx={{ mr: 1 }} /> Add child
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              if (!menuNodeId) return;
+              setMenuAnchor(null);
+              setAddChildDialog({ open: true, parentId: menuNodeId, mode: 'attach' });
+            }}
+          >
+            <SearchIcon fontSize="small" sx={{ mr: 1 }} /> Attach existing
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              if (!menuNodeId) return;
+              setMenuAnchor(null);
+              setDuplicateDialog({ open: true, nodeId: menuNodeId });
+            }}
+          >
+            <ContentCopyIcon fontSize="small" sx={{ mr: 1 }} /> Duplicate
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              if (!menuNodeId) return;
+              setMenuAnchor(null);
+              setDeleteDialog({ open: true, nodeId: menuNodeId });
+            }}
+          >
+            <DeleteIcon fontSize="small" sx={{ mr: 1 }} /> Delete
+          </MenuItem>
+        </Menu>
+      ) : null}
 
       <ResourcePickerDialog
         open={resourceDialogOpen}

--- a/src/components/admin/courseEditor/state/editorStore.tsx
+++ b/src/components/admin/courseEditor/state/editorStore.tsx
@@ -4,16 +4,20 @@ import { createContext, useContext, useMemo, useState, type ReactNode } from 're
 
 export type SavingState = 'idle' | 'saving' | 'saved' | 'error';
 
+export type EditorMode = 'edit' | 'preview';
+
 export type EditorStoreValue = {
   selectedNodeId: number | null;
   selectedBlockId: number | null;
   editingBlockId: number | null;
   savingState: SavingState;
   savingMessage: string;
+  editorMode: EditorMode;
   setSelectedNodeId: (nodeId: number | null) => void;
   setSelectedBlockId: (blockId: number | null) => void;
   setEditingBlockId: (blockId: number | null) => void;
   setSavingState: (state: SavingState, message?: string) => void;
+  setEditorMode: (mode: EditorMode) => void;
 };
 
 const EditorStoreContext = createContext<EditorStoreValue | undefined>(undefined);
@@ -24,6 +28,7 @@ export function EditorStoreProvider({ children }: { children: ReactNode }) {
   const [editingBlockId, setEditingBlockId] = useState<number | null>(null);
   const [savingState, setSavingStateValue] = useState<SavingState>('idle');
   const [savingMessage, setSavingMessage] = useState('All changes saved');
+  const [editorMode, setEditorMode] = useState<EditorMode>('edit');
 
   const setSavingState = (state: SavingState, message?: string) => {
     setSavingStateValue(state);
@@ -41,12 +46,21 @@ export function EditorStoreProvider({ children }: { children: ReactNode }) {
       editingBlockId,
       savingState,
       savingMessage,
+      editorMode,
       setSelectedNodeId,
       setSelectedBlockId,
       setEditingBlockId,
       setSavingState,
+      setEditorMode,
     }),
-    [selectedNodeId, selectedBlockId, editingBlockId, savingState, savingMessage],
+    [
+      selectedNodeId,
+      selectedBlockId,
+      editingBlockId,
+      savingState,
+      savingMessage,
+      editorMode,
+    ],
   );
 
   return <EditorStoreContext.Provider value={value}>{children}</EditorStoreContext.Provider>;


### PR DESCRIPTION
## Summary
- add a global edit/preview mode toggle with persistent save status messaging
- adjust the canvas and block shell to render WYSIWYG content in edit mode and student view in preview mode
- hide editing affordances when previewing, including the properties panel and sidebar context menu actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e05bbe59b8833294c69f2a62a007c5