### PR TITLE
Update student view chapter heading styling

### DIFF
--- a/src/components/admin/courseEditor/Canvas/Canvas.tsx
+++ b/src/components/admin/courseEditor/Canvas/Canvas.tsx
@@ -179,7 +179,12 @@ export default function Canvas({
   return (
     <Box sx={{ p: 3, height: '100%', overflowY: 'auto' }}>
       <Stack spacing={3} sx={{ maxWidth: 900, mx: 'auto' }}>
-        <Typography variant="h6">{subtree.node.title ?? 'Untitled node'}</Typography>
+        <Typography
+          variant={previewMode ? 'h4' : 'h6'}
+          component={previewMode ? 'h1' : undefined}
+        >
+          {subtree.node.title ?? 'Untitled node'}
+        </Typography>
         {!previewMode && blocks.length === 0 ? (
           <Alert severity="info" sx={{ textAlign: 'center' }}>
             {getEmptyStateMessage(subtree.node.node_type)}

--- a/src/components/admin/courseEditor/Canvas/Canvas.tsx
+++ b/src/components/admin/courseEditor/Canvas/Canvas.tsx
@@ -182,6 +182,7 @@ export default function Canvas({
         <Typography
           variant={previewMode ? 'h4' : 'h6'}
           component={previewMode ? 'h1' : undefined}
+          sx={previewMode ? { fontWeight: 'bold' } : undefined}
         >
           {subtree.node.title ?? 'Untitled node'}
         </Typography>


### PR DESCRIPTION
## Summary
- update the course builder preview to render chapter titles as a heading-one style

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7fba45fac8332af145deacfd7f1ae