### PR TITLE
Add sequential unlock preview support in Course Builder

### DIFF
--- a/src/app/api/admin/course-builder/nodes/[nodeId]/sequential/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/sequential/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+} from '@/lib/courseBuilder';
+
+function parseNodeId(value: string | string[] | undefined) {
+  if (!value || Array.isArray(value)) {
+    throw new CourseBuilderError('Invalid node id', 400);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new CourseBuilderError('Invalid node id', 400);
+  }
+  return parsed;
+}
+
+export async function POST(request: NextRequest, { params }: { params: { nodeId: string } }) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const nodeId = parseNodeId(params.nodeId);
+    const body = (await request.json().catch(() => ({}))) as { on?: unknown };
+
+    if (typeof body.on !== 'boolean') {
+      throw new CourseBuilderError('Body must include boolean "on"', 400);
+    }
+
+    const { error } = await adminClient.rpc('enforce_strict_sequence', {
+      _root_id: nodeId,
+      _on: body.on,
+    });
+
+    if (error) {
+      throw new CourseBuilderError('Failed to update sequential unlock', 500, {
+        details: error.message,
+        nodeId,
+        on: body.on,
+      });
+    }
+
+    const subtree = await fetchNodeSubtree(nodeId);
+    return NextResponse.json({ subtree });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/admin/course-builder/unlock-status/route.ts
+++ b/src/app/api/admin/course-builder/unlock-status/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireAdmin } from '@/lib/requireAdmin';
+import {
+  CourseBuilderError,
+  adminClient,
+  handleCourseBuilderError,
+} from '@/lib/courseBuilder';
+
+function parseParentId(value: string | null) {
+  if (!value) {
+    throw new CourseBuilderError('parentId query parameter is required', 400);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new CourseBuilderError('parentId must be a number', 400);
+  }
+  return parsed;
+}
+
+function parseUserId(value: string | null, fallback: string) {
+  if (!value) {
+    return fallback;
+  }
+  const uuidRegex =
+    /^(\{)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}(\})?$/;
+  if (!uuidRegex.test(value)) {
+    throw new CourseBuilderError('userId must be a valid UUID', 400);
+  }
+  return value;
+}
+
+export async function GET(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const url = new URL(request.url);
+    const parentId = parseParentId(url.searchParams.get('parentId'));
+    const userId = parseUserId(url.searchParams.get('userId'), guard.user.id);
+
+    const { data, error } = await adminClient.rpc('get_child_unlock_status', {
+      _parent_id: parentId,
+      _user_id: userId,
+    });
+
+    if (error) {
+      throw new CourseBuilderError('Failed to load unlock status', 500, {
+        details: error.message,
+        parentId,
+        userId,
+      });
+    }
+
+    return NextResponse.json({ unlockStatus: data ?? [] });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/components/admin/courseEditor/Sidebar/Tree.tsx
+++ b/src/components/admin/courseEditor/Sidebar/Tree.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
   Chip,
+  FormControlLabel,
   IconButton,
   InputAdornment,
   List,
@@ -14,6 +15,7 @@ import {
   ListItemButton,
   Paper,
   Stack,
+  Switch,
   TextField,
   Tooltip,
   Typography,
@@ -30,9 +32,11 @@ import StorageIcon from '@mui/icons-material/Storage';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AddIcon from '@mui/icons-material/Add';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 
-import type { NodeSubtree } from '@/types/course';
+import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
 import { useUndoRedoInput } from '@/hooks/useUndoRedoInput';
+import { fetchUnlockStatus } from '../api/requests';
 
 const NODE_ICONS: Record<string, ReactElement> = {
   course: <MenuBookIcon fontSize="small" />,
@@ -71,6 +75,10 @@ export type TreeProps = {
   canAddChapter: boolean;
   canAddBlock: boolean;
   courseStats: Map<number, { lessons: number; chapters: number }>;
+  previewMode: boolean;
+  unlockStatusRefreshToken: number;
+  onToggleSequential: (courseId: number, on: boolean) => Promise<void> | void;
+  sequentialLoading: boolean;
 };
 
 function matchesQuery(value: string | null | undefined, query: string) {
@@ -477,6 +485,10 @@ type OutlineHeaderProps = {
   canAddLesson: boolean;
   canAddChapter: boolean;
   canAddBlock: boolean;
+  previewMode: boolean;
+  sequentialUnlock: boolean;
+  onSequentialToggle: (on: boolean) => void;
+  sequentialLoading: boolean;
 };
 
 function OutlineHeader({
@@ -485,6 +497,10 @@ function OutlineHeader({
   onBack,
   onExpandAll,
   onCollapseAll,
+  previewMode,
+  sequentialUnlock,
+  onSequentialToggle,
+  sequentialLoading,
 }: OutlineHeaderProps) {
   return (
     <Box sx={{ p: 3, borderBottom: '1px solid', borderColor: 'divider' }}>
@@ -532,6 +548,27 @@ function OutlineHeader({
         <Chip size="small" label={`${stats.lessons} lessons`} sx={{ bgcolor: '#e7f3ff', color: '#0c5ba0', fontWeight: 600 }} />
         <Chip size="small" label={`${stats.chapters} chapters`} sx={{ bgcolor: '#e7f3ff', color: '#0c5ba0', fontWeight: 600 }} />
       </Box>
+
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            checked={sequentialUnlock}
+            onChange={(event) => {
+              void onSequentialToggle(event.target.checked);
+            }}
+            disabled={sequentialLoading}
+          />
+        }
+        label="All nodes require previous nodes"
+        sx={{ mt: 2, '& .MuiFormControlLabel-label': { fontSize: 13 } }}
+      />
+
+      {previewMode ? (
+        <Typography variant="caption" color="text.secondary">
+          Locked icons reflect current completion progress.
+        </Typography>
+      ) : null}
     </Box>
   );
 }
@@ -546,6 +583,9 @@ function ChapterCard({
   onSelect,
   selectedId,
   onContextMenu,
+  previewMode,
+  lockStatus,
+  childLocks,
 }: {
   subtree: NodeSubtree;
   expanded: Set<number>;
@@ -553,10 +593,17 @@ function ChapterCard({
   onSelect: (id: number) => void;
   selectedId: number | null;
   onContextMenu?: (e: React.MouseEvent<HTMLElement>, id: number) => void;
+  previewMode: boolean;
+  lockStatus?: ChildUnlockStatus;
+  childLocks?: Record<number, ChildUnlockStatus>;
 }) {
   const hasChildren = subtree.children.length > 0;
   const isExpanded = expanded.has(subtree.node.id);
   const isSelected = selectedId === subtree.node.id;
+  const isLocked = !!(previewMode && lockStatus?.locked);
+  const lockReason = lockStatus?.reason ?? null;
+
+  const iconColor = isLocked ? 'text.disabled' : 'text.secondary';
 
   return (
     <Box
@@ -604,7 +651,7 @@ function ChapterCard({
               sx={{
                 width: 24,
                 height: 24,
-                color: 'text.secondary',
+                color: iconColor,
                 '&:hover': { bgcolor: 'transparent' },
               }}
             >
@@ -616,15 +663,26 @@ function ChapterCard({
           ) : null}
         </Box>
 
-        <Box sx={{ color: 'text.secondary', display: 'flex', alignItems: 'center' }}>
+        <Box sx={{ color: iconColor, display: 'flex', alignItems: 'center' }}>
           <LayersIcon fontSize="small" />
         </Box>
 
         <TruncateTooltip title={subtree.node.title || 'Untitled'}>
-          <Typography sx={{ fontWeight: 700, fontSize: 15, flex: 1 }} noWrap>
+          <Typography
+            sx={{ fontWeight: 700, fontSize: 15, flex: 1, color: isLocked ? 'text.disabled' : 'text.primary' }}
+            noWrap
+          >
             {subtree.node.title || 'Untitled'}
           </Typography>
         </TruncateTooltip>
+
+        {isLocked ? (
+          <Tooltip title={lockReason ?? 'Locked'}>
+            <Box sx={{ display: 'flex', alignItems: 'center', color: 'text.disabled' }}>
+              <LockOutlinedIcon fontSize="small" sx={{ pointerEvents: 'none' }} />
+            </Box>
+          </Tooltip>
+        ) : null}
 
       </Box>
 
@@ -640,6 +698,8 @@ function ChapterCard({
                 selected={selectedId === child.subtree.node.id}
                 onContextMenu={onContextMenu}
                 divider={idx > 0}
+                previewMode={previewMode}
+                lockStatus={childLocks?.[child.subtree.node.id]}
               />
             ))
           ) : (
@@ -662,13 +722,22 @@ function LessonRow({
   selected,
   onContextMenu,
   divider,
+  previewMode,
+  lockStatus,
 }: {
   subtree: NodeSubtree;
   onSelect: (id: number) => void;
   selected: boolean;
   onContextMenu?: (e: React.MouseEvent<HTMLElement>, id: number) => void;
   divider?: boolean;
+  previewMode: boolean;
+  lockStatus?: ChildUnlockStatus;
 }) {
+  const isLocked = !!(previewMode && lockStatus?.locked);
+  const lockReason = lockStatus?.reason ?? null;
+  const iconColor = isLocked ? 'text.disabled' : 'text.secondary';
+  const textColor = isLocked ? 'text.disabled' : 'text.primary';
+
   return (
     <Box
       onClick={() => onSelect(subtree.node.id)}
@@ -695,12 +764,19 @@ function LessonRow({
         transition: 'background-color .2s',
       }}
     >
-      <ArticleIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+      <ArticleIcon fontSize="small" sx={{ color: iconColor }} />
       <TruncateTooltip title={subtree.node.title || 'Untitled'}>
-        <Typography variant="body2" noWrap sx={{ color: 'text.primary' }}>
+        <Typography variant="body2" noWrap sx={{ color: textColor, flex: 1 }}>
           {subtree.node.title || 'Untitled'}
         </Typography>
       </TruncateTooltip>
+      {isLocked ? (
+        <Tooltip title={lockReason ?? 'Locked'}>
+          <Box sx={{ display: 'flex', alignItems: 'center', color: 'text.disabled' }}>
+            <LockOutlinedIcon fontSize="small" sx={{ pointerEvents: 'none' }} />
+          </Box>
+        </Tooltip>
+      ) : null}
 
     </Box>
   );
@@ -729,6 +805,10 @@ function OutlinePanel({
   canAddChapter,
   canAddBlock,
   stats,
+  previewMode,
+  unlockStatuses,
+  onToggleSequential,
+  sequentialLoading,
 }: {
   course: NodeSubtree;
   expanded: Set<number>;
@@ -749,6 +829,10 @@ function OutlinePanel({
   canAddChapter: boolean;
   canAddBlock: boolean;
   stats: { lessons: number; chapters: number };
+  previewMode: boolean;
+  unlockStatuses: Record<number, Record<number, ChildUnlockStatus>>;
+  onToggleSequential: (courseId: number, on: boolean) => void;
+  sequentialLoading: boolean;
 }) {
   const searchInput = useUndoRedoInput({
     value: search,
@@ -767,6 +851,12 @@ function OutlinePanel({
   );
 
   const hasLessons = course.children.length > 0;
+
+  const courseLockMap = previewMode
+    ? unlockStatuses[course.node.id] ?? {}
+    : ({} as Record<number, ChildUnlockStatus>);
+  const getChildLocks = (parentId: number) =>
+    previewMode ? unlockStatuses[parentId] ?? undefined : undefined;
 
   let contextualMessage: string | null = null;
   if (!search && selectedSubtree) {
@@ -791,6 +881,10 @@ function OutlinePanel({
         canAddLesson={canAddLesson}
         canAddChapter={canAddChapter}
         canAddBlock={canAddBlock}
+        previewMode={previewMode}
+        sequentialUnlock={!!course.node.sequential_unlock}
+        onSequentialToggle={(on) => onToggleSequential(course.node.id, on)}
+        sequentialLoading={sequentialLoading}
       />
 
       {/* Actions bar */}
@@ -864,6 +958,9 @@ function OutlinePanel({
                   onSelect={onSelect}
                   selectedId={selectedNodeId}
                   onContextMenu={onContextMenu}
+                  previewMode={previewMode}
+                  lockStatus={previewMode ? courseLockMap[child.node.id] : undefined}
+                  childLocks={getChildLocks(child.node.id)}
                 />
               ))}
             </Stack>
@@ -912,7 +1009,84 @@ export default function Tree({
   canAddChapter,
   canAddBlock,
   courseStats,
+  previewMode,
+  unlockStatusRefreshToken,
+  onToggleSequential,
+  sequentialLoading,
 }: TreeProps) {
+  const [unlockStatuses, setUnlockStatuses] = useState<Record<number, Record<number, ChildUnlockStatus>>>({});
+
+  useEffect(() => {
+    if (!previewMode || !activeCourse || mode !== 'outline') {
+      setUnlockStatuses({});
+      return;
+    }
+
+    const parentIds = new Set<number>();
+    if (activeCourse.children.length > 0) {
+      parentIds.add(activeCourse.node.id);
+    }
+
+    const collect = (subtree: NodeSubtree) => {
+      if (!expanded.has(subtree.node.id)) {
+        return;
+      }
+      subtree.children.forEach((child) => {
+        const childTree = child.subtree;
+        if (childTree.children.length > 0) {
+          parentIds.add(childTree.node.id);
+        }
+        collect(childTree);
+      });
+    };
+
+    collect(activeCourse);
+
+    if (parentIds.size === 0) {
+      setUnlockStatuses({});
+      return;
+    }
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const entries = await Promise.all(
+          Array.from(parentIds).map(async (parentId) => {
+            const rows = await fetchUnlockStatus(parentId, signal);
+            const map: Record<number, ChildUnlockStatus> = {};
+            rows.forEach((row) => {
+              map[row.child_id] = row;
+            });
+            return [parentId, map] as const;
+          }),
+        );
+
+        if (cancelled) return;
+
+        const next: Record<number, Record<number, ChildUnlockStatus>> = {};
+        entries.forEach(([parentId, map]) => {
+          next[parentId] = map;
+        });
+        setUnlockStatuses(next);
+      } catch (error) {
+        if (cancelled) return;
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        console.error('Failed to fetch unlock statuses', error);
+        setUnlockStatuses({});
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [previewMode, activeCourse, expanded, unlockStatusRefreshToken, mode]);
+
   return (
     <Paper
       elevation={0}
@@ -958,6 +1132,10 @@ export default function Tree({
           canAddChapter={canAddChapter}
           canAddBlock={canAddBlock}
           stats={courseStats.get(activeCourse.node.id) ?? { lessons: 0, chapters: 0 }}
+          previewMode={previewMode}
+          unlockStatuses={unlockStatuses}
+          onToggleSequential={onToggleSequential}
+          sequentialLoading={sequentialLoading}
         />
       ) : (
         <CoursesList

--- a/src/components/admin/courseEditor/Sidebar/Tree.tsx
+++ b/src/components/admin/courseEditor/Sidebar/Tree.tsx
@@ -603,6 +603,31 @@ function ChapterCard({
   const isLocked = !!(previewMode && lockStatus?.locked);
   const lockReason = lockStatus?.reason ?? null;
 
+  const effectiveChildLocks = useMemo<Record<number, ChildUnlockStatus> | undefined>(
+    () => {
+      if (!previewMode || !isLocked) {
+        return childLocks;
+      }
+
+      const merged: Record<number, ChildUnlockStatus> = {};
+      subtree.children.forEach((child) => {
+        const childId = child.subtree.node.id;
+        const existing = childLocks?.[childId];
+
+        merged[childId] = {
+          child_id: childId,
+          child_position: existing?.child_position ?? child.edge.position,
+          is_required: existing?.is_required ?? Boolean(child.edge.is_required),
+          locked: true,
+          reason: existing?.reason ?? lockReason ?? null,
+        };
+      });
+
+      return merged;
+    },
+    [previewMode, isLocked, childLocks, lockReason, subtree],
+  );
+
   const iconColor = isLocked ? 'text.disabled' : 'text.secondary';
 
   return (
@@ -699,7 +724,7 @@ function ChapterCard({
                 onContextMenu={onContextMenu}
                 divider={idx > 0}
                 previewMode={previewMode}
-                lockStatus={childLocks?.[child.subtree.node.id]}
+                lockStatus={effectiveChildLocks?.[child.subtree.node.id]}
               />
             ))
           ) : (

--- a/src/components/admin/courseEditor/api/requests.ts
+++ b/src/components/admin/courseEditor/api/requests.ts
@@ -1,4 +1,11 @@
-import type { ContentBlock, ContentNode, NodeChild, NodeEdgeRule, NodeSubtree } from '@/types/course';
+import type {
+  ChildUnlockStatus,
+  ContentBlock,
+  ContentNode,
+  NodeChild,
+  NodeEdgeRule,
+  NodeSubtree,
+} from '@/types/course';
 
 async function parseJson<T>(res: Response, fallback: string): Promise<T> {
   const json = (await res.json().catch(() => ({}))) as T & { error?: string };
@@ -140,5 +147,22 @@ export async function reorderBlocks(nodeId: number, updates: Array<{ block_id: n
     body: JSON.stringify({ updates }),
   });
   const data = await parseJson<{ subtree: NodeSubtree }>(res, 'Failed to reorder blocks');
+  return data.subtree;
+}
+
+export async function fetchUnlockStatus(parentId: number, signal?: AbortSignal) {
+  const params = new URLSearchParams({ parentId: String(parentId) });
+  const res = await fetch(`/api/admin/course-builder/unlock-status?${params.toString()}`, { signal });
+  const data = await parseJson<{ unlockStatus: ChildUnlockStatus[] }>(res, 'Failed to load unlock status');
+  return data.unlockStatus ?? [];
+}
+
+export async function updateSequentialUnlock(rootId: number, on: boolean) {
+  const res = await fetch(`/api/admin/course-builder/nodes/${rootId}/sequential`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ on }),
+  });
+  const data = await parseJson<{ subtree: NodeSubtree }>(res, 'Failed to update sequential unlock');
   return data.subtree;
 }

--- a/src/components/admin/courseEditor/index.tsx
+++ b/src/components/admin/courseEditor/index.tsx
@@ -36,6 +36,7 @@ import {
   updateBlock,
   updateChild,
   updateNode,
+  updateSequentialUnlock,
 } from './api/requests';
 import { EditorStoreProvider, useEditorStore } from './state/editorStore';
 import type { RenderableResource } from '@/components/course/BlockRenderer';
@@ -303,6 +304,8 @@ function CourseEditorInner() {
   const [courseSearch, setCourseSearch] = useState('');
   const [outlineSearch, setOutlineSearch] = useState('');
   const [lastActiveCourseId, setLastActiveCourseId] = useState<number | null>(null);
+  const [unlockStatusRefreshToken, setUnlockStatusRefreshToken] = useState(0);
+  const [sequentialLoading, setSequentialLoading] = useState(false);
   const [nodeDraft, setNodeDraft] = useState<NodeDraft | null>(null);
   const [metadataError, setMetadataError] = useState<string | null>(null);
   const [resourceCache, setResourceCache] = useState<Record<number, RenderableResource>>({});
@@ -911,6 +914,30 @@ function CourseEditorInner() {
     handleInsertBlock(position, 'text');
   }, [handleInsertBlock, selectedSubtree]);
 
+  const handleSequentialToggle = useCallback(
+    async (courseId: number, on: boolean) => {
+      setSequentialLoading(true);
+      try {
+        await runMutation(
+          async () => {
+            const subtree = await updateSequentialUnlock(courseId, on);
+            return { subtree };
+          },
+          {
+            message: on ? 'Sequential unlock enabled' : 'Sequential unlock disabled',
+            savingMessage: 'Saving…',
+          },
+        );
+        setUnlockStatusRefreshToken((prev) => prev + 1);
+      } catch {
+        // runMutation surfaces the error message
+      } finally {
+        setSequentialLoading(false);
+      }
+    },
+    [runMutation],
+  );
+
   const handleDeleteBlock = useCallback(
     async (blockId: number) => {
       await runMutation(
@@ -1247,6 +1274,10 @@ function CourseEditorInner() {
               canAddChapter={canAddChapter}
               canAddBlock={canAddBlock}
               courseStats={courseStats}
+              previewMode={editorMode === 'preview'}
+              unlockStatusRefreshToken={unlockStatusRefreshToken}
+              onToggleSequential={handleSequentialToggle}
+              sequentialLoading={sequentialLoading}
             />
           </Box>
           <Box

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -12,6 +12,7 @@ export type ContentNode = {
   hero_image: string | null;
   icon: string | null;
   objectives: string | null;
+  sequential_unlock: boolean;
   metadata: Record<string, unknown> | null;
   [key: string]: unknown;
 };
@@ -54,4 +55,12 @@ export type NodeEdgeRule = {
   parent_type: string;
   child_kind: string;
   child_type: string;
+};
+
+export type ChildUnlockStatus = {
+  child_id: number;
+  child_position: number;
+  is_required: boolean;
+  locked: boolean;
+  reason: string | null;
 };


### PR DESCRIPTION
## Summary
- add admin API routes to read unlock status and toggle sequential unlock
- update course editor requests and state to call the new RPCs and re-fetch status
- render lock indicators in the outline preview and expose the sequential toggle switch

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eb7ee90b088332954270de9fe3e064