### PR TITLE
Add smart doc support to course builder

### DIFF
--- a/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
+++ b/src/app/api/admin/course-builder/blocks/[blockId]/route.ts
@@ -79,6 +79,16 @@ export async function PATCH(
       merged.end_ms = endMs;
     }
 
+    if (merged.smart_doc_id != null) {
+      const smartDocId = Number(merged.smart_doc_id);
+      if (!Number.isFinite(smartDocId) || smartDocId <= 0) {
+        throw new CourseBuilderError('smart_doc_id must be a valid number', 400, {
+          smart_doc_id: merged.smart_doc_id,
+        });
+      }
+      merged.smart_doc_id = smartDocId;
+    }
+
     validateBlockPayload(merged);
 
     const allowedFields = [
@@ -86,6 +96,7 @@ export async function PATCH(
       'position',
       'text_md',
       'resource_id',
+      'smart_doc_id',
       'start_ms',
       'end_ms',
       'label',
@@ -106,9 +117,15 @@ export async function PATCH(
           value = positionValue;
         }
 
-        if ((field === 'resource_id' || field === 'start_ms' || field === 'end_ms') && value != null) {
+        if (
+          (field === 'resource_id' || field === 'start_ms' || field === 'end_ms' || field === 'smart_doc_id') &&
+          value != null
+        ) {
           const numericValue = Number(value);
-          if (!Number.isFinite(numericValue) || (field !== 'resource_id' && numericValue < 0)) {
+          if (!Number.isFinite(numericValue) || (field !== 'resource_id' && field !== 'smart_doc_id' && numericValue < 0)) {
+            throw new CourseBuilderError(`${field} must be a valid number`, 400, { [field]: value });
+          }
+          if (field === 'smart_doc_id' && numericValue <= 0) {
             throw new CourseBuilderError(`${field} must be a valid number`, 400, { [field]: value });
           }
           value = numericValue;

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/reorder/route.ts
@@ -71,7 +71,7 @@ export async function PATCH(
     const { data: existing, error: existingError } = await adminClient
       .from('content_blocks')
       .select(
-        'id, node_id, block_type, text_md, resource_id, start_ms, end_ms, label, notes, settings, data',
+        'id, node_id, block_type, text_md, resource_id, smart_doc_id, start_ms, end_ms, label, notes, settings, data',
       )
       .eq('node_id', nodeIdNumber);
 
@@ -103,6 +103,7 @@ export async function PATCH(
         block_type: base.block_type,
         text_md: base.text_md,
         resource_id: base.resource_id,
+        smart_doc_id: base.smart_doc_id,
         start_ms: base.start_ms,
         end_ms: base.end_ms,
         label: base.label,
@@ -116,6 +117,7 @@ export async function PATCH(
       if ('notes' in row) merged.notes = row.notes;
       if ('settings' in row) merged.settings = row.settings;
       if ('data' in row) merged.data = row.data;
+      if ('smart_doc_id' in row) merged.smart_doc_id = row.smart_doc_id;
 
       return merged;
     });

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/blocks/route.ts
@@ -59,10 +59,18 @@ export async function POST(
       });
     }
 
+    const smartDocId = block.smart_doc_id != null ? Number(block.smart_doc_id) : null;
+    if (smartDocId != null && (!Number.isFinite(smartDocId) || smartDocId <= 0)) {
+      throw new CourseBuilderError('smart_doc_id must be a number', 400, {
+        smart_doc_id: block.smart_doc_id,
+      });
+    }
+
     const sanitizedBlock = {
       ...block,
       position: positionValue ?? undefined,
       resource_id: resourceId ?? undefined,
+      smart_doc_id: smartDocId ?? undefined,
       start_ms: startMs ?? undefined,
       end_ms: endMs ?? undefined,
     };
@@ -91,6 +99,7 @@ export async function POST(
       position,
       text_md: block.text_md ?? null,
       resource_id: resourceId,
+      smart_doc_id: smartDocId,
       start_ms: startMs,
       end_ms: endMs,
       label: block.label ?? null,

--- a/src/app/api/admin/course-builder/nodes/[nodeId]/duplicate/route.ts
+++ b/src/app/api/admin/course-builder/nodes/[nodeId]/duplicate/route.ts
@@ -63,6 +63,7 @@ async function cloneSubtree(nodeId: number, options: CloneOptions) {
         position: block.position,
         text_md: block.text_md ?? null,
         resource_id: block.resource_id ?? null,
+        smart_doc_id: block.smart_doc_id ?? null,
         start_ms: block.start_ms ?? null,
         end_ms: block.end_ms ?? null,
         label: block.label ?? null,

--- a/src/components/admin/courseEditor/Canvas/Canvas.tsx
+++ b/src/components/admin/courseEditor/Canvas/Canvas.tsx
@@ -6,6 +6,7 @@ import AddIcon from '@mui/icons-material/Add';
 import TextFieldsIcon from '@mui/icons-material/TextFields';
 import VideoLibraryIcon from '@mui/icons-material/VideoLibrary';
 import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
+import DescriptionIcon from '@mui/icons-material/Description';
 import { arrayMove, SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import type { UniqueIdentifier } from '@dnd-kit/core';
 
@@ -302,6 +303,9 @@ export default function Canvas({
           </MenuItem>
           <MenuItem onClick={() => handleChooseInsert('asset')}>
             <VideoLibraryIcon fontSize="small" sx={{ mr: 1 }} /> Resource
+          </MenuItem>
+          <MenuItem onClick={() => handleChooseInsert('smart_doc')}>
+            <DescriptionIcon fontSize="small" sx={{ mr: 1 }} /> Smart Doc
           </MenuItem>
           <MenuItem onClick={() => handleChooseInsert('divider')}>
             <HorizontalRuleIcon fontSize="small" sx={{ mr: 1 }} /> Divider

--- a/src/components/admin/courseEditor/Canvas/Canvas.tsx
+++ b/src/components/admin/courseEditor/Canvas/Canvas.tsx
@@ -196,7 +196,9 @@ export default function Canvas({
           <Stack spacing={3}>
             {blocks.map((block) => {
               const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
-              return <BlockRenderer key={block.id} block={block} resource={resource} />;
+              return (
+                <BlockRenderer key={block.id} block={block} resource={resource} previewMode />
+              );
             })}
           </Stack>
         ) : (
@@ -279,7 +281,11 @@ export default function Canvas({
                               }}
                             />
                           ) : (
-                            <BlockRenderer block={block} resource={resource} />
+                            <BlockRenderer
+                              block={block}
+                              resource={resource}
+                              previewMode={previewMode}
+                            />
                           )}
                         </SortableBlock>
                       </CanvasRow>

--- a/src/components/admin/courseEditor/Sidebar/Properties.tsx
+++ b/src/components/admin/courseEditor/Sidebar/Properties.tsx
@@ -75,6 +75,14 @@ function clonePrompts(prompts: SmartDocPromptDraft[]): SmartDocPromptDraft[] {
   return prompts.map((prompt) => ({ ...prompt }));
 }
 
+function logSmartDocDebug(message: string, context?: Record<string, unknown>) {
+  if (context) {
+    console.log(`[SmartDoc] ${message}`, context);
+  } else {
+    console.log(`[SmartDoc] ${message}`);
+  }
+}
+
 function createEmptySmartDocDraft(docId: number | null = null): SmartDocDraft {
   return {
     docId,
@@ -317,6 +325,7 @@ export default function Properties({
 
     const load = async () => {
       try {
+        logSmartDocDebug('Fetching smart doc', { docId });
         const { data, error } = await supabase
           .from('smart_docs')
           .select(
@@ -328,6 +337,12 @@ export default function Properties({
           .single();
 
         if (cancelled) return;
+
+        logSmartDocDebug('Fetch complete', {
+          docId,
+          hasData: !!data,
+          error: error ? error.message : null,
+        });
 
         if (error) {
           setSmartDocError(error.message ?? 'Failed to load smart doc');
@@ -365,6 +380,7 @@ export default function Properties({
       } catch (err) {
         if (cancelled) return;
         const message = err instanceof Error ? err.message : 'Failed to load smart doc';
+        logSmartDocDebug('Fetch threw error', { docId, message });
         setSmartDocError(message);
         setSmartDocDraft(createEmptySmartDocDraft(docId));
       } finally {
@@ -480,19 +496,33 @@ export default function Properties({
     setSmartDocError(null);
     setSmartDocMessage(null);
 
+    logSmartDocDebug('Saving smart doc start', {
+      blockId: selectedBlock.id,
+      docId: smartDocDraft.docId,
+      promptCount: smartDocDraft.prompts.length,
+    });
+
     try {
-      let docId = smartDocDraft.docId;
       const title = smartDocDraft.title.trim();
       const description = smartDocDraft.description.trim();
+      let docId = smartDocDraft.docId;
 
       if (!docId) {
+        logSmartDocDebug('Creating smart doc', { title, description });
         const { data: doc, error } = await supabase
           .from('smart_docs')
           .insert({ title, description: description ? description : null, is_published: false })
           .select('id, title, description, is_published')
           .single();
+        logSmartDocDebug('Create result', {
+          receivedId: doc?.id ?? null,
+          error: error ? error.message : null,
+        });
         if (error) {
           throw new Error(error.message);
+        }
+        if (!doc) {
+          throw new Error('Failed to create smart doc');
         }
         docId = doc.id as number;
 
@@ -508,18 +538,33 @@ export default function Properties({
         }));
 
         if (promptsPayload.length > 0) {
+          logSmartDocDebug('Creating prompts', { docId, promptPayload: promptsPayload });
           const { error: promptError } = await supabase.from('smart_doc_prompts').insert(promptsPayload);
+          logSmartDocDebug('Create prompts result', {
+            docId,
+            error: promptError ? promptError.message : null,
+          });
           if (promptError) {
             throw new Error(promptError.message);
           }
         }
       } else {
+        logSmartDocDebug('Updating smart doc', {
+          docId,
+          title,
+          description,
+          is_published: smartDocDraft.is_published,
+        });
         const { error: updateError } = await supabase
           .from('smart_docs')
           .update({ title, description: description ? description : null, is_published: smartDocDraft.is_published })
           .eq('id', docId)
           .select('id')
           .single();
+        logSmartDocDebug('Update smart doc result', {
+          docId,
+          error: updateError ? updateError.message : null,
+        });
         if (updateError) {
           throw new Error(updateError.message);
         }
@@ -535,7 +580,12 @@ export default function Properties({
           .map((prompt) => prompt.id)
           .filter((id): id is number => id != null && !nextIds.has(id));
         if (toDeleteIds.length > 0) {
+          logSmartDocDebug('Deleting prompts', { docId, toDeleteIds });
           const { error: deleteError } = await supabase.from('smart_doc_prompts').delete().in('id', toDeleteIds);
+          logSmartDocDebug('Delete prompts result', {
+            docId,
+            error: deleteError ? deleteError.message : null,
+          });
           if (deleteError) {
             throw new Error(deleteError.message);
           }
@@ -552,6 +602,17 @@ export default function Properties({
             !!previous.required !== !!prompt.required ||
             previous.position !== prompt.position
           ) {
+            logSmartDocDebug('Updating prompt', {
+              docId,
+              promptId: prompt.id,
+              payload: {
+                label: prompt.label.trim(),
+                prompt_type: prompt.prompt_type,
+                help_text: prompt.help_text.trim() ? prompt.help_text.trim() : null,
+                required: !!prompt.required,
+                position: prompt.position,
+              },
+            });
             const { error: promptUpdateError } = await supabase
               .from('smart_doc_prompts')
               .update({
@@ -565,6 +626,11 @@ export default function Properties({
               })
               .eq('id', prompt.id)
               .eq('doc_id', docId);
+            logSmartDocDebug('Update prompt result', {
+              docId,
+              promptId: prompt.id,
+              error: promptUpdateError ? promptUpdateError.message : null,
+            });
             if (promptUpdateError) {
               throw new Error(promptUpdateError.message);
             }
@@ -573,6 +639,16 @@ export default function Properties({
 
         const toInsert = nextPrompts.filter((prompt) => !prompt.id);
         if (toInsert.length > 0) {
+          logSmartDocDebug('Inserting prompts', {
+            docId,
+            toInsert: toInsert.map((prompt) => ({
+              label: prompt.label.trim(),
+              prompt_type: prompt.prompt_type,
+              help_text: prompt.help_text.trim() ? prompt.help_text.trim() : null,
+              required: !!prompt.required,
+              position: prompt.position,
+            })),
+          });
           const { error: insertError } = await supabase.from('smart_doc_prompts').insert(
             toInsert.map((prompt) => ({
               doc_id: docId,
@@ -585,12 +661,17 @@ export default function Properties({
               position: prompt.position,
             })),
           );
+          logSmartDocDebug('Insert prompts result', {
+            docId,
+            error: insertError ? insertError.message : null,
+          });
           if (insertError) {
             throw new Error(insertError.message);
           }
         }
       }
 
+      logSmartDocDebug('Refreshing smart doc after save', { docId });
       const { data: refreshed, error: fetchError } = await supabase
         .from('smart_docs')
         .select(
@@ -600,6 +681,12 @@ export default function Properties({
         )
         .eq('id', docId!)
         .single();
+
+      logSmartDocDebug('Refresh result', {
+        docId,
+        hasData: !!refreshed,
+        error: fetchError ? fetchError.message : null,
+      });
 
       if (fetchError) {
         throw new Error(fetchError.message);
@@ -638,8 +725,14 @@ export default function Properties({
       }
 
       setSmartDocMessage('Smart doc saved');
+      logSmartDocDebug('Smart doc save complete', { docId, blockId: selectedBlock.id });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to save smart doc';
+      logSmartDocDebug('Smart doc save failed', {
+        docId: smartDocDraft.docId,
+        blockId: selectedBlock.id,
+        message,
+      });
       setSmartDocError(message);
     } finally {
       setSmartDocSaving(false);

--- a/src/components/admin/courseEditor/Sidebar/Properties.tsx
+++ b/src/components/admin/courseEditor/Sidebar/Properties.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Box,
@@ -26,6 +26,7 @@ import type { ContentBlock, NodeChild, NodeSubtree, NodeType } from '@/types/cou
 import type { SavingState } from '../state/editorStore';
 import type { RenderableResource } from '@/components/course/BlockRenderer';
 import { useUndoRedoInput } from '@/hooks/useUndoRedoInput';
+import { supabase } from '@/lib/supabaseClient';
 
 export type NodeDraft = {
   title: string;
@@ -36,6 +37,96 @@ export type NodeDraft = {
   objectives: string;
   metadata: string;
 };
+
+type SmartDocPromptDraft = {
+  id: number | null;
+  label: string;
+  prompt_type: 'text' | 'textarea';
+  help_text: string;
+  required: boolean;
+};
+
+type SmartDocDraft = {
+  docId: number | null;
+  title: string;
+  description: string;
+  is_published: boolean;
+  prompts: SmartDocPromptDraft[];
+  original: {
+    docId: number | null;
+    title: string;
+    description: string;
+    is_published: boolean;
+    prompts: SmartDocPromptDraft[];
+  } | null;
+};
+
+function createEmptyPromptDraft(): SmartDocPromptDraft {
+  return {
+    id: null,
+    label: '',
+    prompt_type: 'text',
+    help_text: '',
+    required: false,
+  };
+}
+
+function clonePrompts(prompts: SmartDocPromptDraft[]): SmartDocPromptDraft[] {
+  return prompts.map((prompt) => ({ ...prompt }));
+}
+
+function createEmptySmartDocDraft(docId: number | null = null): SmartDocDraft {
+  return {
+    docId,
+    title: '',
+    description: '',
+    is_published: false,
+    prompts: [createEmptyPromptDraft()],
+    original: null,
+  };
+}
+
+function promptsEqual(a: SmartDocPromptDraft[], b: SmartDocPromptDraft[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index];
+    const right = b[index];
+    if (
+      left.id !== right.id ||
+      left.label !== right.label ||
+      left.prompt_type !== right.prompt_type ||
+      (left.help_text ?? '') !== (right.help_text ?? '') ||
+      !!left.required !== !!right.required
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validateSmartDocDraft(draft: SmartDocDraft | null): string | null {
+  if (!draft) {
+    return 'Smart doc is not ready yet';
+  }
+  const title = draft.title.trim();
+  if (title.length < 3) {
+    return 'Title must be at least 3 characters';
+  }
+  if (draft.prompts.length === 0) {
+    return 'Add at least one prompt';
+  }
+  for (const prompt of draft.prompts) {
+    if (!prompt.label.trim()) {
+      return 'Each prompt requires a label';
+    }
+    if (prompt.prompt_type !== 'text' && prompt.prompt_type !== 'textarea') {
+      return 'Prompt type must be text or textarea';
+    }
+  }
+  return null;
+}
 
 export type PropertiesProps = {
   subtree: NodeSubtree | null;
@@ -51,6 +142,11 @@ export type PropertiesProps = {
   onUpdateBlock: (blockId: number, updates: Partial<ContentBlock>, options?: { debounce?: boolean }) => void;
   onDeleteBlock: (blockId: number) => void;
   onOpenResourcePicker: (mode: 'insert' | 'update', blockId?: number) => void;
+  onFinalizeSmartDocBlock: (
+    block: ContentBlock,
+    docId: number,
+    options?: { suppressToast?: boolean },
+  ) => Promise<void>;
   resources: Record<number, RenderableResource>;
   savingState: SavingState;
   savingMessage: string;
@@ -71,6 +167,7 @@ export default function Properties({
   onUpdateBlock,
   onDeleteBlock,
   onOpenResourcePicker,
+  onFinalizeSmartDocBlock,
   resources,
   savingState,
   savingMessage,
@@ -79,6 +176,12 @@ export default function Properties({
   const [childType, setChildType] = useState<NodeType>('lesson');
   const [settingsDraft, setSettingsDraft] = useState('');
   const [settingsError, setSettingsError] = useState<string | null>(null);
+  const [smartDocDraft, setSmartDocDraft] = useState<SmartDocDraft | null>(null);
+  const [smartDocLoading, setSmartDocLoading] = useState(false);
+  const [smartDocSaving, setSmartDocSaving] = useState(false);
+  const [smartDocError, setSmartDocError] = useState<string | null>(null);
+  const [smartDocMessage, setSmartDocMessage] = useState<string | null>(null);
+  const smartDocLoadedRef = useRef<number | null>(null);
 
   const nodeScopeKey = subtree?.node.id ?? null;
   const blockScopeKey = selectedBlock?.id ?? null;
@@ -180,6 +283,506 @@ export default function Properties({
     },
     [onUpdateBlock, selectedBlock, setSettingsDraft, setSettingsError],
   );
+
+  useEffect(() => {
+    if (!selectedBlock || selectedBlock.block_type !== 'smart_doc') {
+      setSmartDocDraft(null);
+      setSmartDocLoading(false);
+      setSmartDocSaving(false);
+      setSmartDocError(null);
+      setSmartDocMessage(null);
+      smartDocLoadedRef.current = null;
+      return;
+    }
+
+    if (!selectedBlock.smart_doc_id) {
+      smartDocLoadedRef.current = null;
+      setSmartDocDraft((prev) => (prev && prev.docId === null ? prev : createEmptySmartDocDraft(null)));
+      setSmartDocLoading(false);
+      setSmartDocError(null);
+      return;
+    }
+
+    const docId = selectedBlock.smart_doc_id;
+    if (smartDocLoadedRef.current === docId) {
+      return;
+    }
+
+    smartDocLoadedRef.current = docId;
+    setSmartDocLoading(true);
+    setSmartDocError(null);
+    setSmartDocMessage(null);
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('smart_docs')
+          .select(
+            `id, title, description, is_published, smart_doc_prompts:smart_doc_prompts (
+              id, position, label, prompt_type, help_text, required
+            )`,
+          )
+          .eq('id', docId)
+          .single();
+
+        if (cancelled) return;
+
+        if (error) {
+          setSmartDocError(error.message ?? 'Failed to load smart doc');
+          setSmartDocDraft(createEmptySmartDocDraft(docId));
+        } else if (data) {
+          const prompts = (data.smart_doc_prompts ?? [])
+            .slice()
+            .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+            .map((prompt) => ({
+              id: prompt.id ?? null,
+              label: prompt.label ?? '',
+              prompt_type: (prompt.prompt_type as 'text' | 'textarea') ?? 'text',
+              help_text: prompt.help_text ?? '',
+              required: !!prompt.required,
+            }));
+          const normalizedPrompts = prompts.length > 0 ? prompts : [createEmptyPromptDraft()];
+          const next: SmartDocDraft = {
+            docId: data.id ?? docId,
+            title: data.title ?? '',
+            description: data.description ?? '',
+            is_published: !!data.is_published,
+            prompts: clonePrompts(normalizedPrompts),
+            original: {
+              docId: data.id ?? docId,
+              title: data.title ?? '',
+              description: data.description ?? '',
+              is_published: !!data.is_published,
+              prompts: clonePrompts(normalizedPrompts),
+            },
+          };
+          setSmartDocDraft(next);
+        } else {
+          setSmartDocDraft(createEmptySmartDocDraft(docId));
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Failed to load smart doc';
+        setSmartDocError(message);
+        setSmartDocDraft(createEmptySmartDocDraft(docId));
+      } finally {
+        if (!cancelled) {
+          setSmartDocLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedBlock]);
+
+  const smartDocDirty = useMemo(() => {
+    if (!smartDocDraft) return false;
+    if (!smartDocDraft.original) return true;
+    if (smartDocDraft.title !== smartDocDraft.original.title) return true;
+    if (smartDocDraft.description !== smartDocDraft.original.description) return true;
+    if (smartDocDraft.is_published !== smartDocDraft.original.is_published) return true;
+    if (!promptsEqual(smartDocDraft.prompts, smartDocDraft.original.prompts)) return true;
+    return false;
+  }, [smartDocDraft]);
+
+  const smartDocValidationError = useMemo(() => validateSmartDocDraft(smartDocDraft), [smartDocDraft]);
+
+  const handleSmartDocFieldChange = useCallback((field: 'title' | 'description', value: string) => {
+    setSmartDocDraft((prev) => {
+      if (!prev) return prev;
+      return { ...prev, [field]: value };
+    });
+    setSmartDocError(null);
+    setSmartDocMessage(null);
+  }, []);
+
+  const handlePromptChange = useCallback(
+    (index: number, field: 'label' | 'prompt_type' | 'help_text', value: string) => {
+      setSmartDocDraft((prev) => {
+        if (!prev) return prev;
+        const prompts = prev.prompts.map((prompt, idx) =>
+          idx === index ? { ...prompt, [field]: value } : prompt,
+        );
+        return { ...prev, prompts };
+      });
+      setSmartDocError(null);
+      setSmartDocMessage(null);
+    },
+    [],
+  );
+
+  const handlePromptRequiredChange = useCallback((index: number, checked: boolean) => {
+    setSmartDocDraft((prev) => {
+      if (!prev) return prev;
+      const prompts = prev.prompts.map((prompt, idx) =>
+        idx === index ? { ...prompt, required: checked } : prompt,
+      );
+      return { ...prev, prompts };
+    });
+    setSmartDocError(null);
+    setSmartDocMessage(null);
+  }, []);
+
+  const handleAddPrompt = useCallback(() => {
+    setSmartDocDraft((prev) => {
+      if (!prev) return prev;
+      return { ...prev, prompts: [...prev.prompts, createEmptyPromptDraft()] };
+    });
+    setSmartDocError(null);
+    setSmartDocMessage(null);
+  }, []);
+
+  const handleRemovePrompt = useCallback((index: number) => {
+    setSmartDocDraft((prev) => {
+      if (!prev) return prev;
+      if (prev.prompts.length <= 1) {
+        return prev;
+      }
+      const prompts = prev.prompts.filter((_, idx) => idx !== index);
+      return { ...prev, prompts: prompts.length > 0 ? prompts : [createEmptyPromptDraft()] };
+    });
+    setSmartDocError(null);
+    setSmartDocMessage(null);
+  }, []);
+
+  const handleMovePrompt = useCallback((index: number, direction: 'up' | 'down') => {
+    setSmartDocDraft((prev) => {
+      if (!prev) return prev;
+      const nextIndex = direction === 'up' ? index - 1 : index + 1;
+      if (nextIndex < 0 || nextIndex >= prev.prompts.length) {
+        return prev;
+      }
+      const prompts = [...prev.prompts];
+      const [prompt] = prompts.splice(index, 1);
+      prompts.splice(nextIndex, 0, prompt);
+      return { ...prev, prompts };
+    });
+    setSmartDocError(null);
+    setSmartDocMessage(null);
+  }, []);
+
+  const handleSaveSmartDoc = useCallback(async () => {
+    if (!selectedBlock || selectedBlock.block_type !== 'smart_doc') return;
+    const validationError = validateSmartDocDraft(smartDocDraft);
+    if (validationError) {
+      setSmartDocError(validationError);
+      return;
+    }
+    if (!smartDocDraft) return;
+
+    setSmartDocSaving(true);
+    setSmartDocError(null);
+    setSmartDocMessage(null);
+
+    try {
+      let docId = smartDocDraft.docId;
+      const title = smartDocDraft.title.trim();
+      const description = smartDocDraft.description.trim();
+
+      if (!docId) {
+        const { data: doc, error } = await supabase
+          .from('smart_docs')
+          .insert({ title, description: description ? description : null, is_published: false })
+          .select('id, title, description, is_published')
+          .single();
+        if (error) {
+          throw new Error(error.message);
+        }
+        docId = doc.id as number;
+
+        const promptsPayload = smartDocDraft.prompts.map((prompt, index) => ({
+          doc_id: docId,
+          label: prompt.label.trim(),
+          prompt_type: prompt.prompt_type,
+          help_text: prompt.help_text.trim() ? prompt.help_text.trim() : null,
+          required: !!prompt.required,
+          options_json: null,
+          validation_json: null,
+          position: index,
+        }));
+
+        if (promptsPayload.length > 0) {
+          const { error: promptError } = await supabase.from('smart_doc_prompts').insert(promptsPayload);
+          if (promptError) {
+            throw new Error(promptError.message);
+          }
+        }
+      } else {
+        const { error: updateError } = await supabase
+          .from('smart_docs')
+          .update({ title, description: description ? description : null, is_published: smartDocDraft.is_published })
+          .eq('id', docId)
+          .select('id')
+          .single();
+        if (updateError) {
+          throw new Error(updateError.message);
+        }
+
+        const nextPrompts = smartDocDraft.prompts.map((prompt, index) => ({
+          ...prompt,
+          position: index,
+        }));
+
+        const existingPrompts = smartDocDraft.original?.prompts ?? [];
+        const nextIds = new Set(nextPrompts.map((prompt) => prompt.id).filter((id): id is number => id != null));
+        const toDeleteIds = existingPrompts
+          .map((prompt) => prompt.id)
+          .filter((id): id is number => id != null && !nextIds.has(id));
+        if (toDeleteIds.length > 0) {
+          const { error: deleteError } = await supabase.from('smart_doc_prompts').delete().in('id', toDeleteIds);
+          if (deleteError) {
+            throw new Error(deleteError.message);
+          }
+        }
+
+        for (const prompt of nextPrompts) {
+          if (!prompt.id) continue;
+          const previous = existingPrompts.find((item) => item.id === prompt.id);
+          if (!previous) continue;
+          if (
+            previous.label !== prompt.label ||
+            previous.prompt_type !== prompt.prompt_type ||
+            (previous.help_text ?? '') !== (prompt.help_text ?? '') ||
+            !!previous.required !== !!prompt.required ||
+            previous.position !== prompt.position
+          ) {
+            const { error: promptUpdateError } = await supabase
+              .from('smart_doc_prompts')
+              .update({
+                label: prompt.label.trim(),
+                prompt_type: prompt.prompt_type,
+                help_text: prompt.help_text.trim() ? prompt.help_text.trim() : null,
+                required: !!prompt.required,
+                options_json: null,
+                validation_json: null,
+                position: prompt.position,
+              })
+              .eq('id', prompt.id)
+              .eq('doc_id', docId);
+            if (promptUpdateError) {
+              throw new Error(promptUpdateError.message);
+            }
+          }
+        }
+
+        const toInsert = nextPrompts.filter((prompt) => !prompt.id);
+        if (toInsert.length > 0) {
+          const { error: insertError } = await supabase.from('smart_doc_prompts').insert(
+            toInsert.map((prompt) => ({
+              doc_id: docId,
+              label: prompt.label.trim(),
+              prompt_type: prompt.prompt_type,
+              help_text: prompt.help_text.trim() ? prompt.help_text.trim() : null,
+              required: !!prompt.required,
+              options_json: null,
+              validation_json: null,
+              position: prompt.position,
+            })),
+          );
+          if (insertError) {
+            throw new Error(insertError.message);
+          }
+        }
+      }
+
+      const { data: refreshed, error: fetchError } = await supabase
+        .from('smart_docs')
+        .select(
+          `id, title, description, is_published, smart_doc_prompts:smart_doc_prompts (
+            id, position, label, prompt_type, help_text, required
+          )`,
+        )
+        .eq('id', docId!)
+        .single();
+
+      if (fetchError) {
+        throw new Error(fetchError.message);
+      }
+
+      const prompts = (refreshed?.smart_doc_prompts ?? [])
+        .slice()
+        .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+        .map((prompt) => ({
+          id: prompt.id ?? null,
+          label: prompt.label ?? '',
+          prompt_type: (prompt.prompt_type as 'text' | 'textarea') ?? 'text',
+          help_text: prompt.help_text ?? '',
+          required: !!prompt.required,
+        }));
+      const normalizedPrompts = prompts.length > 0 ? prompts : [createEmptyPromptDraft()];
+
+      setSmartDocDraft({
+        docId: refreshed?.id ?? docId!,
+        title: refreshed?.title ?? '',
+        description: refreshed?.description ?? '',
+        is_published: !!refreshed?.is_published,
+        prompts: clonePrompts(normalizedPrompts),
+        original: {
+          docId: refreshed?.id ?? docId!,
+          title: refreshed?.title ?? '',
+          description: refreshed?.description ?? '',
+          is_published: !!refreshed?.is_published,
+          prompts: clonePrompts(normalizedPrompts),
+        },
+      });
+      smartDocLoadedRef.current = docId!;
+
+      if (!selectedBlock.smart_doc_id || selectedBlock.smart_doc_id !== docId) {
+        await onFinalizeSmartDocBlock(selectedBlock, docId!, { suppressToast: true });
+      }
+
+      setSmartDocMessage('Smart doc saved');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to save smart doc';
+      setSmartDocError(message);
+    } finally {
+      setSmartDocSaving(false);
+    }
+  }, [onFinalizeSmartDocBlock, selectedBlock, smartDocDraft]);
+
+  const renderSmartDocForm = () => {
+    if (!selectedBlock || selectedBlock.block_type !== 'smart_doc') {
+      return null;
+    }
+
+    if (smartDocLoading || !smartDocDraft) {
+      return <Typography color="text.secondary">Loading smart doc…</Typography>;
+    }
+
+    return (
+      <Stack spacing={2}>
+        {selectedBlock.id < 0 ? (
+          <Alert severity="info">Fill out the smart doc details, then save to create this block.</Alert>
+        ) : null}
+        {smartDocError ? <Alert severity="error">{smartDocError}</Alert> : null}
+        {smartDocMessage ? <Alert severity="success">{smartDocMessage}</Alert> : null}
+        <TextField
+          label="Smart doc title"
+          required
+          value={smartDocDraft.title}
+          onChange={(event) => handleSmartDocFieldChange('title', event.target.value)}
+        />
+        <TextField
+          label="Description"
+          value={smartDocDraft.description}
+          onChange={(event) => handleSmartDocFieldChange('description', event.target.value)}
+          multiline
+          minRows={3}
+        />
+        <Stack spacing={1}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Typography variant="subtitle2">Prompts</Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={handleAddPrompt}
+              disabled={smartDocSaving}
+            >
+              Add prompt
+            </Button>
+          </Stack>
+          <Stack spacing={1.5}>
+            {smartDocDraft.prompts.map((prompt, index) => (
+              <Stack
+                key={prompt.id ?? `prompt-${index}`}
+                spacing={1}
+                sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 2 }}
+              >
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Typography variant="subtitle2">Prompt {index + 1}</Typography>
+                  <Stack direction="row" spacing={1}>
+                    <Tooltip title="Move up">
+                      <span>
+                        <IconButton size="small" disabled={index === 0} onClick={() => handleMovePrompt(index, 'up')}>
+                          <ArrowUpwardIcon fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title="Move down">
+                      <span>
+                        <IconButton
+                          size="small"
+                          disabled={index === smartDocDraft.prompts.length - 1}
+                          onClick={() => handleMovePrompt(index, 'down')}
+                        >
+                          <ArrowDownwardIcon fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title="Remove prompt">
+                      <span>
+                        <IconButton
+                          size="small"
+                          color="error"
+                          disabled={smartDocDraft.prompts.length <= 1}
+                          onClick={() => handleRemovePrompt(index)}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  </Stack>
+                </Stack>
+                <TextField
+                  label="Label"
+                  value={prompt.label}
+                  onChange={(event) => handlePromptChange(index, 'label', event.target.value)}
+                  required
+                />
+                <TextField
+                  label="Prompt type"
+                  select
+                  value={prompt.prompt_type}
+                  onChange={(event) => handlePromptChange(index, 'prompt_type', event.target.value as 'text' | 'textarea')}
+                >
+                  <MenuItem value="text">Short text</MenuItem>
+                  <MenuItem value="textarea">Paragraph</MenuItem>
+                </TextField>
+                <TextField
+                  label="Help text"
+                  value={prompt.help_text}
+                  onChange={(event) => handlePromptChange(index, 'help_text', event.target.value)}
+                  multiline
+                  minRows={2}
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={prompt.required}
+                      onChange={(event) => handlePromptRequiredChange(index, event.target.checked)}
+                    />
+                  }
+                  label="Required"
+                />
+              </Stack>
+            ))}
+          </Stack>
+        </Stack>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Button
+            variant="contained"
+            onClick={handleSaveSmartDoc}
+            disabled={
+              smartDocSaving ||
+              !smartDocDraft ||
+              !!smartDocValidationError ||
+              (!smartDocDirty && smartDocDraft.docId != null)
+            }
+          >
+            {smartDocSaving ? 'Saving…' : smartDocDraft.docId ? 'Save smart doc' : 'Create smart doc'}
+          </Button>
+          {smartDocSaving ? <Typography color="text.secondary">Saving…</Typography> : null}
+        </Stack>
+      </Stack>
+    );
+  };
 
   const startInput = useUndoRedoInput({
     value:
@@ -410,74 +1013,80 @@ export default function Properties({
           <Alert severity="info">Text blocks are edited inline on the canvas.</Alert>
         ) : null}
 
-        {selectedBlock.block_type === 'asset' && (
-          <Stack spacing={2}>
-            <Button
-              variant="outlined"
-              startIcon={<SearchIcon />}
-              onClick={() => onOpenResourcePicker('update', selectedBlock.id)}
-              disabled={isPendingBlock}
-            >
-              {selectedBlock.resource_id ? 'Change resource' : 'Select resource'}
-            </Button>
-            <Typography variant="body2" color="text.secondary">
-              {blockResource ? blockResource.title : 'No resource selected'}
-            </Typography>
-            <Stack direction="row" spacing={2}>
-              <TextField
-                label="Start (ms)"
-                value={selectedBlock.start_ms != null ? String(selectedBlock.start_ms) : ''}
-                onChange={(event) => startInput.handleChange(event.target.value)}
-                onKeyDown={startInput.handleKeyDown}
-                disabled={isPendingBlock}
-              />
-              <TextField
-                label="End (ms)"
-                value={selectedBlock.end_ms != null ? String(selectedBlock.end_ms) : ''}
-                onChange={(event) => endInput.handleChange(event.target.value)}
-                onKeyDown={endInput.handleKeyDown}
-                disabled={isPendingBlock}
-              />
-            </Stack>
-          </Stack>
-        )}
+        {selectedBlock.block_type === 'smart_doc'
+          ? renderSmartDocForm()
+          : (
+              <>
+                {selectedBlock.block_type === 'asset' && (
+                  <Stack spacing={2}>
+                    <Button
+                      variant="outlined"
+                      startIcon={<SearchIcon />}
+                      onClick={() => onOpenResourcePicker('update', selectedBlock.id)}
+                      disabled={isPendingBlock}
+                    >
+                      {selectedBlock.resource_id ? 'Change resource' : 'Select resource'}
+                    </Button>
+                    <Typography variant="body2" color="text.secondary">
+                      {blockResource ? blockResource.title : 'No resource selected'}
+                    </Typography>
+                    <Stack direction="row" spacing={2}>
+                      <TextField
+                        label="Start (ms)"
+                        value={selectedBlock.start_ms != null ? String(selectedBlock.start_ms) : ''}
+                        onChange={(event) => startInput.handleChange(event.target.value)}
+                        onKeyDown={startInput.handleKeyDown}
+                        disabled={isPendingBlock}
+                      />
+                      <TextField
+                        label="End (ms)"
+                        value={selectedBlock.end_ms != null ? String(selectedBlock.end_ms) : ''}
+                        onChange={(event) => endInput.handleChange(event.target.value)}
+                        onKeyDown={endInput.handleKeyDown}
+                        disabled={isPendingBlock}
+                      />
+                    </Stack>
+                  </Stack>
+                )}
 
-        {(selectedBlock.block_type === 'asset' || selectedBlock.block_type === 'divider') && (
-          <Stack spacing={2}>
-            <TextField
-              label="Label"
-              value={selectedBlock.label ?? ''}
-              onChange={(event) => labelInput.handleChange(event.target.value)}
-              onKeyDown={labelInput.handleKeyDown}
-              disabled={isPendingBlock}
-            />
-            <TextField
-              label="Notes"
-              multiline
-              minRows={3}
-              value={selectedBlock.notes ?? ''}
-              onChange={(event) => notesInput.handleChange(event.target.value)}
-              onKeyDown={notesInput.handleKeyDown}
-              disabled={isPendingBlock}
-            />
-          </Stack>
-        )}
+                {(selectedBlock.block_type === 'asset' || selectedBlock.block_type === 'divider') && (
+                  <Stack spacing={2}>
+                    <TextField
+                      label="Label"
+                      value={selectedBlock.label ?? ''}
+                      onChange={(event) => labelInput.handleChange(event.target.value)}
+                      onKeyDown={labelInput.handleKeyDown}
+                      disabled={isPendingBlock}
+                    />
+                    <TextField
+                      label="Notes"
+                      multiline
+                      minRows={3}
+                      value={selectedBlock.notes ?? ''}
+                      onChange={(event) => notesInput.handleChange(event.target.value)}
+                      onKeyDown={notesInput.handleKeyDown}
+                      disabled={isPendingBlock}
+                    />
+                  </Stack>
+                )}
 
-        {selectedBlock.block_type === 'asset' && (selectedBlock.settings != null || settingsDraft) && (
-          <TextField
-            label="Settings (JSON)"
-            multiline
-            minRows={4}
-            value={settingsDraft}
-            onChange={(event) => settingsInput.handleChange(event.target.value)}
-            onKeyDown={settingsInput.handleKeyDown}
-            error={!!settingsError}
-            helperText={settingsError ?? 'Optional advanced configuration for this block.'}
-            disabled={isPendingBlock}
-          />
-        )}
+                {selectedBlock.block_type === 'asset' && (selectedBlock.settings != null || settingsDraft) && (
+                  <TextField
+                    label="Settings (JSON)"
+                    multiline
+                    minRows={4}
+                    value={settingsDraft}
+                    onChange={(event) => settingsInput.handleChange(event.target.value)}
+                    onKeyDown={settingsInput.handleKeyDown}
+                    error={!!settingsError}
+                    helperText={settingsError ?? 'Optional advanced configuration for this block.'}
+                    disabled={isPendingBlock}
+                  />
+                )}
+              </>
+            )}
 
-        {isPendingBlock && (
+        {isPendingBlock && selectedBlock.block_type !== 'smart_doc' && (
           <Alert severity="info">This block is being saved. Additional options will be available shortly.</Alert>
         )}
 

--- a/src/components/admin/courseEditor/index.tsx
+++ b/src/components/admin/courseEditor/index.tsx
@@ -336,7 +336,9 @@ function CourseEditorInner() {
   const nodeDebounceTimers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
   const optimisticSnapshot = useRef<NodeSubtree[] | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingBlockRef = useRef<{ tempId: number; position: number; type: BlockType; resourceId?: number } | null>(null);
+  const pendingBlockRef = useRef<
+    { tempId: number; position: number; type: BlockType; resourceId?: number; smartDocId?: number } | null
+  >(null);
   const pendingTextDrafts = useRef<Map<number, string>>(new Map());
 
   const applyAllPendingDrafts = useCallback(
@@ -640,6 +642,12 @@ function CourseEditorInner() {
       if (pending.type === 'asset' && pending.resourceId != null) {
         return block.resource_id === pending.resourceId && block.id > 0;
       }
+      if (pending.type === 'smart_doc') {
+        if (pending.smartDocId != null) {
+          return block.smart_doc_id === pending.smartDocId && block.id > 0;
+        }
+        return block.id > 0;
+      }
       return block.id > 0;
     });
     if (!candidate) return;
@@ -885,6 +893,19 @@ function CourseEditorInner() {
         return;
       }
 
+      if (type === 'smart_doc') {
+        const tempId = -Date.now();
+        const optimisticBlock = buildOptimisticBlock(nodeId, 'smart_doc', tempId, position, {
+          block_type: 'smart_doc',
+          smart_doc_id: null,
+        });
+        setTrees((prev) => insertBlockIntoForest(prev, nodeId, optimisticBlock));
+        pendingBlockRef.current = { tempId, position, type: 'smart_doc' };
+        setSelectedBlockId(tempId);
+        setEditingBlockId(null);
+        return;
+      }
+
       const payload: Partial<ContentBlock> & { block_type: BlockType } =
         type === 'text'
           ? { block_type: 'text', text_md: normalizeHtmlContent('') }
@@ -914,6 +935,27 @@ function CourseEditorInner() {
     handleInsertBlock(position, 'text');
   }, [handleInsertBlock, selectedSubtree]);
 
+  const handleFinalizeSmartDocBlock = useCallback(
+    async (block: ContentBlock, docId: number, options: { suppressToast?: boolean } = {}) => {
+      const insertPosition = sortedBlocks.findIndex((item) => item.id === block.id);
+      const position = insertPosition >= 0 ? insertPosition : block.position;
+
+      if (block.id < 0) {
+        setTrees((prev) => prev.map((tree) => updateBlockDraft(tree, block.id, { smart_doc_id: docId })));
+        pendingBlockRef.current = { tempId: block.id, position, type: 'smart_doc', smartDocId: docId };
+        await handleCreateBlock(
+          block.node_id,
+          { block_type: 'smart_doc', smart_doc_id: docId },
+          position,
+          { suppressToast: options.suppressToast ?? false },
+        );
+      } else if (block.smart_doc_id !== docId) {
+        queueBlockUpdate(block.id, { smart_doc_id: docId }, { debounce: false });
+      }
+    },
+    [handleCreateBlock, queueBlockUpdate, setTrees, sortedBlocks],
+  );
+
   const handleSequentialToggle = useCallback(
     async (courseId: number, on: boolean) => {
       setSequentialLoading(true);
@@ -940,6 +982,15 @@ function CourseEditorInner() {
 
   const handleDeleteBlock = useCallback(
     async (blockId: number) => {
+      if (blockId < 0) {
+        setTrees((prev) => removeBlockFromForest(prev, blockId));
+        if (pendingBlockRef.current?.tempId === blockId) {
+          pendingBlockRef.current = null;
+        }
+        setSelectedBlockId((prev) => (prev === blockId ? null : prev));
+        setEditingBlockId((prev) => (prev === blockId ? null : prev));
+        return;
+      }
       await runMutation(
         async () => {
           const subtree = await deleteBlock(blockId);
@@ -950,7 +1001,7 @@ function CourseEditorInner() {
       setSelectedBlockId((prev) => (prev === blockId ? null : prev));
       setEditingBlockId((prev) => (prev === blockId ? null : prev));
     },
-    [runMutation, setEditingBlockId, setSelectedBlockId],
+    [runMutation, setEditingBlockId, setSelectedBlockId, setTrees],
   );
 
   const handleReorderBlocks = useCallback(
@@ -1332,6 +1383,7 @@ function CourseEditorInner() {
                   setResourceDialogMode({ type: mode, blockId });
                   setResourceDialogOpen(true);
                 }}
+                onFinalizeSmartDocBlock={handleFinalizeSmartDocBlock}
                 resources={resourceCache}
                 savingState={savingState}
                 savingMessage={savingMessage}
@@ -1471,6 +1523,7 @@ function buildOptimisticBlock(
     position,
     text_md: type === 'text' ? normalizeHtmlContent(base.text_md) : null,
     resource_id: type === 'asset' ? base.resource_id ?? null : null,
+    smart_doc_id: type === 'smart_doc' ? base.smart_doc_id ?? null : null,
     start_ms: base.start_ms ?? null,
     end_ms: base.end_ms ?? null,
     label: base.label ?? null,
@@ -1505,6 +1558,33 @@ function insertBlockIntoTree(subtree: NodeSubtree, nodeId: number, block: Conten
     children: subtree.children.map((child) => ({
       edge: { ...child.edge },
       subtree: insertBlockIntoTree(child.subtree, nodeId, block),
+    })),
+  };
+}
+
+function removeBlockFromForest(forest: NodeSubtree[], blockId: number) {
+  return forest.map((tree) => removeBlockFromTree(tree, blockId));
+}
+
+function removeBlockFromTree(subtree: NodeSubtree, blockId: number): NodeSubtree {
+  let removed = false;
+  const blocks = subtree.blocks
+    .filter((block) => {
+      if (block.id === blockId) {
+        removed = true;
+        return false;
+      }
+      return true;
+    })
+    .map((block) => ({ ...block }));
+  const normalized = removed ? blocks.map((block, index) => ({ ...block, position: index })) : blocks;
+
+  return {
+    node: { ...subtree.node },
+    blocks: normalized,
+    children: subtree.children.map((child) => ({
+      edge: { ...child.edge },
+      subtree: removeBlockFromTree(child.subtree, blockId),
     })),
   };
 }

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
 import { Box, Button, Card, CardContent, CardMedia, CircularProgress, Divider, Stack, TextField, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
@@ -10,6 +11,7 @@ import HeadphonesIcon from '@mui/icons-material/Headphones';
 import InsertLinkIcon from '@mui/icons-material/InsertLink';
 import ImageIcon from '@mui/icons-material/Image';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 import { supabase } from '@/lib/supabaseClient';
 
@@ -67,41 +69,76 @@ function SmartDocPromptField({ prompt }: { prompt: SmartDocPrompt }) {
   const helperText = prompt.help_text?.trim().length ? prompt.help_text : undefined;
 
   return (
-    <Stack spacing={1.5} sx={{ px: { xs: 0, sm: 0.5 } }}>
-      <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '1.1rem' }}>
-        {label}
-        {prompt.required ? (
-          <Typography component="span" color="error.main" sx={{ ml: 0.5 }}>
-            *
-          </Typography>
-        ) : null}
-      </Typography>
-      {helperText ? (
-        <Typography variant="body2" color="text.secondary">
-          {helperText}
-        </Typography>
-      ) : null}
-      <TextField
-        fullWidth
-        variant="standard"
-        multiline={prompt.prompt_type === 'textarea'}
-        minRows={prompt.prompt_type === 'textarea' ? 4 : undefined}
-        InputProps={{
-          sx: {
-            fontSize: '1rem',
-            '& .MuiInputBase-input': {
-              py: 1.5,
-            },
-            '&:before': {
-              borderBottomColor: 'divider',
-            },
-            '&:after': {
-              borderBottomColor: 'primary.main',
-            },
-          },
+    <Stack
+      spacing={2}
+      sx={{
+        px: { xs: 0, sm: 0.5 },
+      }}
+    >
+      <Stack
+        spacing={1}
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 2.5,
+          bgcolor: 'grey.50',
+          px: { xs: 2, sm: 2.5 },
+          py: { xs: 2, sm: 2.5 },
+          boxShadow: 'none',
+          gap: 1.5,
         }}
-        placeholder=""
-      />
+      >
+        <Stack spacing={0.75}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '1.1rem' }}>
+            {label}
+            {prompt.required ? (
+              <Typography component="span" color="error.main" sx={{ ml: 0.5 }}>
+                *
+              </Typography>
+            ) : null}
+          </Typography>
+          {helperText ? (
+            <Typography variant="body2" color="text.secondary">
+              {helperText}
+            </Typography>
+          ) : null}
+        </Stack>
+        <TextField
+          fullWidth
+          variant="outlined"
+          multiline={prompt.prompt_type === 'textarea'}
+          minRows={prompt.prompt_type === 'textarea' ? 4 : undefined}
+          placeholder=""
+          InputProps={{
+            sx: {
+              alignItems: 'flex-start',
+              bgcolor: 'common.white',
+              borderRadius: 2,
+              px: 1.5,
+              py: 0,
+              '& fieldset': {
+                borderColor: 'divider',
+              },
+              '&:hover fieldset': {
+                borderColor: 'grey.400',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: 'primary.main',
+                borderWidth: 2,
+              },
+              '&.Mui-focused': {
+                boxShadow: (theme) => `0 0 0 3px ${alpha(theme.palette.primary.main, 0.2)}`,
+              },
+              '& .MuiInputBase-input': {
+                py: 1.5,
+              },
+              '& textarea': {
+                py: 1.5,
+              },
+            },
+          }}
+        />
+      </Stack>
     </Stack>
   );
 }
@@ -165,12 +202,13 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
 
   const containerStyles = {
     bgcolor: 'background.paper',
-    px: { xs: 2, sm: 3 },
-    py: { xs: 3, sm: 4 },
-    borderRadius: 2,
+    px: { xs: 2.5, sm: 4 },
+    py: { xs: 3.5, sm: 5 },
+    borderRadius: 3,
     boxShadow: 'none',
     border: 'none',
-  };
+    gap: 4,
+  } as const;
 
   if (state.status === 'idle' || state.status === 'loading') {
     return (
@@ -199,17 +237,32 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
 
   return (
     <Stack spacing={4} sx={containerStyles}>
-      <Stack spacing={1.5}>
+      <Stack spacing={2}>
         <Typography variant="h5" sx={{ fontWeight: 600 }}>
           {headerTitle}
         </Typography>
         {doc.description?.trim().length ? (
-          <Typography variant="body1" color="text.secondary" sx={{ maxWidth: '68ch' }}>
-            {doc.description}
-          </Typography>
+          <Box
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 2.5,
+              bgcolor: 'grey.50',
+              px: { xs: 2, sm: 2.5 },
+              py: { xs: 1.75, sm: 2 },
+              maxWidth: '72ch',
+            }}
+          >
+            <Stack direction="row" spacing={1.5} alignItems="flex-start">
+              <InfoOutlinedIcon color="primary" sx={{ mt: 0.25 }} />
+              <Typography variant="body1" color="text.secondary">
+                {doc.description}
+              </Typography>
+            </Stack>
+          </Box>
         ) : null}
       </Stack>
-      <Stack spacing={doc.prompts.length ? 3.5 : 2}>
+      <Stack spacing={doc.prompts.length ? 4 : 2.5}>
         {doc.prompts.length === 0 ? (
           <Typography variant="body2" color="text.secondary">
             This smart doc has no prompts yet.

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -2,7 +2,20 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
-import { Box, Button, Card, CardContent, CardMedia, CircularProgress, Divider, Stack, TextField, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardMedia,
+  CircularProgress,
+  Divider,
+  FormControl,
+  FormLabel,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
@@ -58,6 +71,39 @@ type SmartDocState =
   | { status: 'error'; message: string }
   | { status: 'ready'; doc: SmartDocRecord };
 
+/** ---------- Shared field/label styles (unifies look across the page) ---------- */
+const FIELD_SX = {
+  bgcolor: 'grey.100',
+  borderRadius: 2,
+  px: 2,
+  py: 1,
+  border: '1px solid',
+  borderColor: 'transparent',
+  alignItems: 'flex-start',
+  '& .MuiInputBase-input': { py: 1.25 },
+  '& textarea': { py: 1.25 },
+  '&:hover': { bgcolor: 'grey.100' },
+  '&.Mui-focused': {
+    bgcolor: 'common.white',
+    borderColor: 'primary.light',
+    boxShadow: (t: any) => `0 0 0 3px ${alpha(t.palette.primary.main, 0.18)}`,
+  },
+} as const;
+
+const LABEL_SX = {
+  fontWeight: 700,
+  fontSize: '1.6rem',   // slightly larger than body text
+  lineHeight: 1.3,
+  color: 'text.primary',
+  mb: 1,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 0.5,
+} as const;
+
+
+/** --------------------------------------------------------------------------- */
+
 export type BlockRendererProps = {
   block: RenderableBlock;
   resource: RenderableResource | null;
@@ -65,81 +111,37 @@ export type BlockRendererProps = {
 };
 
 function SmartDocPromptField({ prompt }: { prompt: SmartDocPrompt }) {
-  const label = useMemo(() => prompt.label.trim(), [prompt.label]);
-  const helperText = prompt.help_text?.trim().length ? prompt.help_text : undefined;
+  const isTextarea = prompt.prompt_type === 'textarea';
+  const label = useMemo(() => prompt.label?.trim() || 'Question', [prompt.label]);
+  const helper = prompt.help_text?.trim();
 
   return (
-    <Stack
-      spacing={2}
-      sx={{
-        px: { xs: 0, sm: 0.5 },
-      }}
-    >
-      <Stack
-        spacing={1}
-        sx={{
-          border: '1px solid',
-          borderColor: 'divider',
-          borderRadius: 2.5,
-          bgcolor: 'grey.50',
-          px: { xs: 2, sm: 2.5 },
-          py: { xs: 2, sm: 2.5 },
-          boxShadow: 'none',
-          gap: 1.5,
-        }}
-      >
-        <Stack spacing={0.75}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '1.1rem' }}>
-            {label}
-            {prompt.required ? (
-              <Typography component="span" color="error.main" sx={{ ml: 0.5 }}>
-                *
-              </Typography>
-            ) : null}
-          </Typography>
-          {helperText ? (
-            <Typography variant="body2" color="text.secondary">
-              {helperText}
-            </Typography>
-          ) : null}
-        </Stack>
-        <TextField
-          fullWidth
-          variant="outlined"
-          multiline={prompt.prompt_type === 'textarea'}
-          minRows={prompt.prompt_type === 'textarea' ? 4 : undefined}
-          placeholder=""
-          InputProps={{
-            sx: {
-              alignItems: 'flex-start',
-              bgcolor: 'common.white',
-              borderRadius: 2,
-              px: 1.5,
-              py: 0,
-              '& fieldset': {
-                borderColor: 'divider',
-              },
-              '&:hover fieldset': {
-                borderColor: 'grey.400',
-              },
-              '&.Mui-focused fieldset': {
-                borderColor: 'primary.main',
-                borderWidth: 2,
-              },
-              '&.Mui-focused': {
-                boxShadow: (theme) => `0 0 0 3px ${alpha(theme.palette.primary.main, 0.2)}`,
-              },
-              '& .MuiInputBase-input': {
-                py: 1.5,
-              },
-              '& textarea': {
-                py: 1.5,
-              },
-            },
-          }}
-        />
-      </Stack>
-    </Stack>
+    <FormControl fullWidth sx={{ mb: 4 }}>
+      <FormLabel sx={LABEL_SX}>
+        {label}
+        {prompt.required && (
+          <Box component="span" sx={{ color: 'error.main', lineHeight: 1 }}>
+            *
+          </Box>
+        )}
+      </FormLabel>
+
+      {helper && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          {helper}
+        </Typography>
+      )}
+
+      <TextField
+        fullWidth
+        variant="filled"
+        label={undefined}
+        placeholder=""
+        multiline={isTextarea}
+        minRows={isTextarea ? 6 : undefined}
+        InputProps={{ disableUnderline: true, sx: FIELD_SX }}
+      />
+    </FormControl>
   );
 }
 
@@ -148,10 +150,9 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
 
   useEffect(() => {
     let active = true;
-
     setState({ status: 'loading' });
 
-    const load = async () => {
+    (async () => {
       const { data, error } = await supabase
         .from('smart_docs')
         .select(
@@ -165,21 +166,20 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
       if (!active) return;
 
       if (error || !data) {
-        const message = error?.message ?? 'Smart doc not found';
-        setState({ status: 'error', message });
+        setState({ status: 'error', message: error?.message ?? 'Smart doc not found' });
         return;
       }
 
       const prompts = (data.smart_doc_prompts ?? [])
-        .map((prompt) => ({
-          id: prompt.id,
-          position: prompt.position,
-          label: prompt.label,
-          prompt_type: prompt.prompt_type,
-          help_text: prompt.help_text,
-          required: prompt.required,
+        .map((p: any) => ({
+          id: p.id,
+          position: p.position,
+          label: p.label,
+          prompt_type: p.prompt_type,
+          help_text: p.help_text,
+          required: p.required,
         }))
-        .sort((a, b) => a.position - b.position);
+        .sort((a: any, b: any) => a.position - b.position);
 
       setState({
         status: 'ready',
@@ -191,31 +191,21 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
           prompts,
         },
       });
-    };
-
-    void load();
+    })();
 
     return () => {
       active = false;
     };
   }, [docId]);
 
-  const containerStyles = {
-    bgcolor: 'background.paper',
-    px: { xs: 2.5, sm: 4 },
-    py: { xs: 3.5, sm: 5 },
-    borderRadius: 3,
-    boxShadow: 'none',
-    border: 'none',
-    gap: 4,
-  } as const;
+  const wrapSx = { maxWidth: 920, mx: 'auto', px: { xs: 2, sm: 0 } } as const;
 
   if (state.status === 'idle' || state.status === 'loading') {
     return (
-      <Stack spacing={2} alignItems="center" justifyContent="center" sx={containerStyles}>
-        <CircularProgress size={24} />
+      <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ ...wrapSx, py: 4 }}>
+        <CircularProgress size={22} />
         <Typography variant="body2" color="text.secondary">
-          Loading smart doc…
+          Loading…
         </Typography>
       </Stack>
     );
@@ -223,54 +213,48 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
 
   if (state.status === 'error') {
     return (
-      <Stack spacing={1.5} sx={containerStyles}>
+      <Stack spacing={1} sx={{ ...wrapSx, py: 2 }}>
         <Typography variant="h6">{fallbackLabel ?? 'Smart doc'}</Typography>
         <Typography variant="body2" color="error.main">
-          Failed to load smart doc: {state.message}
+          Failed to load: {state.message}
         </Typography>
       </Stack>
     );
   }
 
   const { doc } = state;
-  const headerTitle = doc.title.trim().length > 0 ? doc.title : fallbackLabel ?? 'Smart doc';
+  const title = doc.title?.trim() || fallbackLabel || 'Smart doc';
 
   return (
-    <Stack spacing={4} sx={containerStyles}>
-      <Stack spacing={2}>
-        <Typography variant="h5" sx={{ fontWeight: 600 }}>
-          {headerTitle}
-        </Typography>
-        {doc.description?.trim().length ? (
-          <Box
-            sx={{
-              border: '1px solid',
-              borderColor: 'divider',
-              borderRadius: 2.5,
-              bgcolor: 'grey.50',
-              px: { xs: 2, sm: 2.5 },
-              py: { xs: 1.75, sm: 2 },
-              maxWidth: '72ch',
-            }}
-          >
-            <Stack direction="row" spacing={1.5} alignItems="flex-start">
-              <InfoOutlinedIcon color="primary" sx={{ mt: 0.25 }} />
-              <Typography variant="body1" color="text.secondary">
-                {doc.description}
-              </Typography>
-            </Stack>
-          </Box>
-        ) : null}
-      </Stack>
-      <Stack spacing={doc.prompts.length ? 4 : 2.5}>
+    <Stack spacing={3} sx={wrapSx}>
+      {/* Section title */}
+      <Typography
+        component="h2"
+        variant="h2"
+        sx={{ fontWeight: 650, fontSize: { xs: '1.35rem', sm: '2rem' }, lineHeight: 1.25 }}
+      >
+        {title}
+      </Typography>
+
+      {/* Optional description box */}
+      {/* Optional description – plain text under title */}
+{doc.description?.trim() && (
+  <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 720 }}>
+    {doc.description}
+  </Typography>
+)}
+
+
+      {/* Prompts */}
+      <Box>
         {doc.prompts.length === 0 ? (
           <Typography variant="body2" color="text.secondary">
-            This smart doc has no prompts yet.
+            No questions yet.
           </Typography>
         ) : (
-          doc.prompts.map((prompt) => <SmartDocPromptField key={prompt.id} prompt={prompt} />)
+          doc.prompts.map((p) => <SmartDocPromptField key={p.id} prompt={p} />)
         )}
-      </Stack>
+      </Box>
     </Stack>
   );
 }
@@ -305,11 +289,7 @@ function VideoPreview({ resource }: { resource: RenderableResource }) {
   const isYoutube = lower.includes('youtube.com') || lower.includes('youtu.be');
   const isVimeo = lower.includes('vimeo.com');
 
-  const frameWrapper = (
-    src: string,
-    allow: string,
-    title: string,
-  ) => (
+  const frameWrapper = (src: string, allow: string, title: string) => (
     <Box
       sx={{
         position: 'relative',
@@ -368,12 +348,7 @@ function VideoPreview({ resource }: { resource: RenderableResource }) {
   return (
     <Card variant="outlined">
       {resource.thumbnail && (
-        <CardMedia
-          component="img"
-          image={resource.thumbnail}
-          alt={resource.title}
-          sx={{ maxHeight: 320, objectFit: 'cover' }}
-        />
+        <CardMedia component="img" image={resource.thumbnail} alt={resource.title} sx={{ maxHeight: 320, objectFit: 'cover' }} />
       )}
       <CardContent>
         <Stack spacing={1}>

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -2,18 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CardMedia,
-  CircularProgress,
-  Divider,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Box, Button, Card, CardContent, CardMedia, CircularProgress, Divider, Stack, TextField, Typography } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
@@ -21,7 +10,6 @@ import HeadphonesIcon from '@mui/icons-material/Headphones';
 import InsertLinkIcon from '@mui/icons-material/InsertLink';
 import ImageIcon from '@mui/icons-material/Image';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
-import DescriptionIcon from '@mui/icons-material/Description';
 
 import { supabase } from '@/lib/supabaseClient';
 
@@ -79,16 +67,42 @@ function SmartDocPromptField({ prompt }: { prompt: SmartDocPrompt }) {
   const helperText = prompt.help_text?.trim().length ? prompt.help_text : undefined;
 
   return (
-    <TextField
-      fullWidth
-      label={label}
-      required={prompt.required}
-      helperText={helperText}
-      variant="outlined"
-      multiline={prompt.prompt_type === 'textarea'}
-      minRows={prompt.prompt_type === 'textarea' ? 4 : undefined}
-      defaultValue=""
-    />
+    <Stack spacing={1.5} sx={{ px: { xs: 0, sm: 0.5 } }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '1.1rem' }}>
+        {label}
+        {prompt.required ? (
+          <Typography component="span" color="error.main" sx={{ ml: 0.5 }}>
+            *
+          </Typography>
+        ) : null}
+      </Typography>
+      {helperText ? (
+        <Typography variant="body2" color="text.secondary">
+          {helperText}
+        </Typography>
+      ) : null}
+      <TextField
+        fullWidth
+        variant="standard"
+        multiline={prompt.prompt_type === 'textarea'}
+        minRows={prompt.prompt_type === 'textarea' ? 4 : undefined}
+        InputProps={{
+          sx: {
+            fontSize: '1rem',
+            '& .MuiInputBase-input': {
+              py: 1.5,
+            },
+            '&:before': {
+              borderBottomColor: 'divider',
+            },
+            '&:after': {
+              borderBottomColor: 'primary.main',
+            },
+          },
+        }}
+        placeholder=""
+      />
+    </Stack>
   );
 }
 
@@ -149,36 +163,34 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
     };
   }, [docId]);
 
+  const containerStyles = {
+    bgcolor: 'background.paper',
+    px: { xs: 2, sm: 3 },
+    py: { xs: 3, sm: 4 },
+    borderRadius: 2,
+    boxShadow: 'none',
+    border: 'none',
+  };
+
   if (state.status === 'idle' || state.status === 'loading') {
     return (
-      <Card variant="outlined">
-        <CardContent>
-          <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ py: 4 }}>
-            <CircularProgress size={24} />
-            <Typography variant="body2" color="text.secondary">
-              Loading smart doc…
-            </Typography>
-          </Stack>
-        </CardContent>
-      </Card>
+      <Stack spacing={2} alignItems="center" justifyContent="center" sx={containerStyles}>
+        <CircularProgress size={24} />
+        <Typography variant="body2" color="text.secondary">
+          Loading smart doc…
+        </Typography>
+      </Stack>
     );
   }
 
   if (state.status === 'error') {
     return (
-      <Card variant="outlined">
-        <CardContent>
-          <Stack spacing={1}>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <DescriptionIcon fontSize="small" />
-              <Typography variant="subtitle1">{fallbackLabel ?? 'Smart doc'}</Typography>
-            </Stack>
-            <Typography variant="body2" color="error.main">
-              Failed to load smart doc: {state.message}
-            </Typography>
-          </Stack>
-        </CardContent>
-      </Card>
+      <Stack spacing={1.5} sx={containerStyles}>
+        <Typography variant="h6">{fallbackLabel ?? 'Smart doc'}</Typography>
+        <Typography variant="body2" color="error.main">
+          Failed to load smart doc: {state.message}
+        </Typography>
+      </Stack>
     );
   }
 
@@ -186,32 +198,27 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
   const headerTitle = doc.title.trim().length > 0 ? doc.title : fallbackLabel ?? 'Smart doc';
 
   return (
-    <Card variant="outlined">
-      <CardContent>
-        <Stack spacing={3}>
-          <Stack spacing={1}>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <DescriptionIcon fontSize="small" />
-              <Typography variant="h6">{headerTitle}</Typography>
-            </Stack>
-            {doc.description?.trim().length ? (
-              <Typography variant="body2" color="text.secondary">
-                {doc.description}
-              </Typography>
-            ) : null}
-          </Stack>
-          <Stack spacing={2}>
-            {doc.prompts.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">
-                This smart doc has no prompts yet.
-              </Typography>
-            ) : (
-              doc.prompts.map((prompt) => <SmartDocPromptField key={prompt.id} prompt={prompt} />)
-            )}
-          </Stack>
-        </Stack>
-      </CardContent>
-    </Card>
+    <Stack spacing={4} sx={containerStyles}>
+      <Stack spacing={1.5}>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          {headerTitle}
+        </Typography>
+        {doc.description?.trim().length ? (
+          <Typography variant="body1" color="text.secondary" sx={{ maxWidth: '68ch' }}>
+            {doc.description}
+          </Typography>
+        ) : null}
+      </Stack>
+      <Stack spacing={doc.prompts.length ? 3.5 : 2}>
+        {doc.prompts.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            This smart doc has no prompts yet.
+          </Typography>
+        ) : (
+          doc.prompts.map((prompt) => <SmartDocPromptField key={prompt.id} prompt={prompt} />)
+        )}
+      </Stack>
+    </Stack>
   );
 }
 
@@ -523,12 +530,9 @@ export function BlockRenderer({ block, resource, previewMode = false }: BlockRen
       <Card variant="outlined">
         <CardContent>
           <Stack spacing={1}>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <DescriptionIcon fontSize="small" />
-              <Typography variant="subtitle1">
-                {block.label ?? (block.smart_doc_id ? `Smart doc #${block.smart_doc_id}` : 'Smart doc')}
-              </Typography>
-            </Stack>
+            <Typography variant="subtitle1">
+              {block.label ?? (block.smart_doc_id ? `Smart doc #${block.smart_doc_id}` : 'Smart doc')}
+            </Typography>
             <Typography variant="body2" color="text.secondary">
               {block.smart_doc_id
                 ? `Smart doc ID ${block.smart_doc_id}.`

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -1,8 +1,19 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
-import { Box, Button, Card, CardContent, CardMedia, Divider, Stack, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardMedia,
+  CircularProgress,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
@@ -11,6 +22,8 @@ import InsertLinkIcon from '@mui/icons-material/InsertLink';
 import ImageIcon from '@mui/icons-material/Image';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
 import DescriptionIcon from '@mui/icons-material/Description';
+
+import { supabase } from '@/lib/supabaseClient';
 
 export type RenderableBlock = {
   id: number;
@@ -33,10 +46,174 @@ export type RenderableResource = {
   duration: number | null;
 };
 
+type SmartDocPrompt = {
+  id: number;
+  position: number;
+  label: string;
+  prompt_type: 'text' | 'textarea';
+  help_text: string | null;
+  required: boolean;
+};
+
+type SmartDocRecord = {
+  id: number;
+  title: string;
+  description: string | null;
+  is_published: boolean;
+  prompts: SmartDocPrompt[];
+};
+
+type SmartDocState =
+  | { status: 'idle' | 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; doc: SmartDocRecord };
+
 export type BlockRendererProps = {
   block: RenderableBlock;
   resource: RenderableResource | null;
+  previewMode?: boolean;
 };
+
+function SmartDocPromptField({ prompt }: { prompt: SmartDocPrompt }) {
+  const label = useMemo(() => prompt.label.trim(), [prompt.label]);
+  const helperText = prompt.help_text?.trim().length ? prompt.help_text : undefined;
+
+  return (
+    <TextField
+      fullWidth
+      label={label}
+      required={prompt.required}
+      helperText={helperText}
+      variant="outlined"
+      multiline={prompt.prompt_type === 'textarea'}
+      minRows={prompt.prompt_type === 'textarea' ? 4 : undefined}
+      defaultValue=""
+    />
+  );
+}
+
+function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabel: string | null }) {
+  const [state, setState] = useState<SmartDocState>({ status: 'idle' });
+
+  useEffect(() => {
+    let active = true;
+
+    setState({ status: 'loading' });
+
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('smart_docs')
+        .select(
+          `id, title, description, is_published, smart_doc_prompts:smart_doc_prompts (
+            id, position, label, prompt_type, help_text, required
+          )`,
+        )
+        .eq('id', docId)
+        .single();
+
+      if (!active) return;
+
+      if (error || !data) {
+        const message = error?.message ?? 'Smart doc not found';
+        setState({ status: 'error', message });
+        return;
+      }
+
+      const prompts = (data.smart_doc_prompts ?? [])
+        .map((prompt) => ({
+          id: prompt.id,
+          position: prompt.position,
+          label: prompt.label,
+          prompt_type: prompt.prompt_type,
+          help_text: prompt.help_text,
+          required: prompt.required,
+        }))
+        .sort((a, b) => a.position - b.position);
+
+      setState({
+        status: 'ready',
+        doc: {
+          id: data.id,
+          title: data.title,
+          description: data.description,
+          is_published: data.is_published,
+          prompts,
+        },
+      });
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [docId]);
+
+  if (state.status === 'idle' || state.status === 'loading') {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ py: 4 }}>
+            <CircularProgress size={24} />
+            <Typography variant="body2" color="text.secondary">
+              Loading smart doc…
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={1}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <DescriptionIcon fontSize="small" />
+              <Typography variant="subtitle1">{fallbackLabel ?? 'Smart doc'}</Typography>
+            </Stack>
+            <Typography variant="body2" color="error.main">
+              Failed to load smart doc: {state.message}
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { doc } = state;
+  const headerTitle = doc.title.trim().length > 0 ? doc.title : fallbackLabel ?? 'Smart doc';
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack spacing={3}>
+          <Stack spacing={1}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <DescriptionIcon fontSize="small" />
+              <Typography variant="h6">{headerTitle}</Typography>
+            </Stack>
+            {doc.description?.trim().length ? (
+              <Typography variant="body2" color="text.secondary">
+                {doc.description}
+              </Typography>
+            ) : null}
+          </Stack>
+          <Stack spacing={2}>
+            {doc.prompts.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                This smart doc has no prompts yet.
+              </Typography>
+            ) : (
+              doc.prompts.map((prompt) => <SmartDocPromptField key={prompt.id} prompt={prompt} />)
+            )}
+          </Stack>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
 
 function formatDuration(seconds: number | null) {
   if (!seconds || Number.isNaN(seconds)) return null;
@@ -282,7 +459,7 @@ function LinkPreview({ resource }: { resource: RenderableResource }) {
   );
 }
 
-export function BlockRenderer({ block, resource }: BlockRendererProps) {
+export function BlockRenderer({ block, resource, previewMode = false }: BlockRendererProps) {
   if (block.block_type === 'divider') {
     return <Divider sx={{ my: 3 }} />;
   }
@@ -338,6 +515,10 @@ export function BlockRenderer({ block, resource }: BlockRendererProps) {
   }
 
   if (block.block_type === 'smart_doc') {
+    if (block.smart_doc_id && previewMode) {
+      return <SmartDocPreview docId={block.smart_doc_id} fallbackLabel={block.label} />;
+    }
+
     return (
       <Card variant="outlined">
         <CardContent>

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -10,13 +10,15 @@ import HeadphonesIcon from '@mui/icons-material/Headphones';
 import InsertLinkIcon from '@mui/icons-material/InsertLink';
 import ImageIcon from '@mui/icons-material/Image';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
+import DescriptionIcon from '@mui/icons-material/Description';
 
 export type RenderableBlock = {
   id: number;
-  block_type: 'text' | 'asset' | 'divider';
+  block_type: 'text' | 'asset' | 'divider' | 'smart_doc';
   position: number;
   text_md: string | null;
   resource_id: number | null;
+  smart_doc_id: number | null;
   start_ms: number | null;
   end_ms: number | null;
   label: string | null;
@@ -332,6 +334,28 @@ export function BlockRenderer({ block, resource }: BlockRendererProps) {
         }}
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
       />
+    );
+  }
+
+  if (block.block_type === 'smart_doc') {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={1}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <DescriptionIcon fontSize="small" />
+              <Typography variant="subtitle1">
+                {block.label ?? (block.smart_doc_id ? `Smart doc #${block.smart_doc_id}` : 'Smart doc')}
+              </Typography>
+            </Stack>
+            <Typography variant="body2" color="text.secondary">
+              {block.smart_doc_id
+                ? `Smart doc ID ${block.smart_doc_id}.`
+                : 'Smart doc details will appear after it is saved.'}
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
     );
   }
 

--- a/src/lib/courseBuilder.ts
+++ b/src/lib/courseBuilder.ts
@@ -33,10 +33,11 @@ export type NodeChildRow = {
 export type ContentBlockRow = {
   id: number;
   node_id: number;
-  block_type: 'text' | 'asset' | 'divider';
+  block_type: 'text' | 'asset' | 'divider' | 'smart_doc';
   position: number;
   text_md: string | null;
   resource_id: number | null;
+  smart_doc_id: number | null;
   start_ms: number | null;
   end_ms: number | null;
   label: string | null;
@@ -181,7 +182,7 @@ export function validateBlockPayload(block: Partial<ContentBlockRow>) {
     throw new CourseBuilderError('Block type is required', 400);
   }
 
-  if (!['text', 'asset', 'divider'].includes(blockType)) {
+  if (!['text', 'asset', 'divider', 'smart_doc'].includes(blockType)) {
     throw new CourseBuilderError('Invalid block type', 400, { blockType });
   }
 
@@ -218,6 +219,22 @@ export function validateBlockPayload(block: Partial<ContentBlockRow>) {
 
     if (hasContent) {
       throw new CourseBuilderError('divider blocks cannot include content fields', 400);
+    }
+  }
+
+  if (blockType === 'smart_doc') {
+    if (!block.smart_doc_id) {
+      throw new CourseBuilderError('smart_doc blocks require smart_doc_id', 400);
+    }
+
+    const hasContent =
+      (block.text_md != null && block.text_md.trim().length > 0) ||
+      block.resource_id != null ||
+      block.start_ms != null ||
+      block.end_ms != null;
+
+    if (hasContent) {
+      throw new CourseBuilderError('smart_doc blocks cannot include text or media fields', 400);
     }
   }
 }

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,6 +1,6 @@
 export type NodeType = 'course' | 'lesson' | 'chapter' | 'collection' | 'playlist';
 export type NodeState = 'draft' | 'published' | 'archived';
-export type BlockType = 'text' | 'asset' | 'divider';
+export type BlockType = 'text' | 'asset' | 'divider' | 'smart_doc';
 
 export type ContentNode = {
   id: number;
@@ -34,6 +34,7 @@ export type ContentBlock = {
   /** Stores sanitized HTML (legacy name kept for API compatibility). */
   text_md: string | null;
   resource_id: number | null;
+  smart_doc_id: number | null;
   start_ms: number | null;
   end_ms: number | null;
   label: string | null;


### PR DESCRIPTION
## Summary
- add a smart doc block type to the course editor canvas and placeholder handling when inserting new blocks
- build a smart doc authoring form in the properties sidebar that saves docs and prompts through Supabase and attaches them to blocks
- update block persistence, duplication, validation, and rendering to support smart doc IDs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ef4d4b70208332aea9930b3a53f218