### PR TITLE
Add student courses experience with unlock-aware viewer

### DIFF
--- a/src/app/api/courses/[courseSlug]/route.ts
+++ b/src/app/api/courses/[courseSlug]/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireUser } from '@/lib/requireUser';
+import {
+  CourseBuilderError,
+  adminClient,
+  fetchNodeSubtree,
+  handleCourseBuilderError,
+  type NodeSubtree as BuilderNodeSubtree,
+} from '@/lib/courseBuilder';
+import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
+
+function sanitizeSubtree(subtree: BuilderNodeSubtree): NodeSubtree | null {
+  const nodeState = (subtree.node.state ?? 'draft') as string;
+  if (nodeState !== 'published') {
+    return null;
+  }
+
+  const children: NodeSubtree['children'] = [];
+  for (const child of subtree.children) {
+    const sanitizedChild = sanitizeSubtree(child.subtree);
+    if (!sanitizedChild) continue;
+    children.push({
+      edge: { ...child.edge },
+      subtree: sanitizedChild,
+    });
+  }
+
+  return {
+    node: { ...subtree.node } as NodeSubtree['node'],
+    blocks: subtree.blocks.map((block) => ({ ...block })),
+    children,
+  };
+}
+
+function collectParentIds(subtree: NodeSubtree, acc: Set<number>) {
+  if (subtree.children.length > 0) {
+    acc.add(subtree.node.id);
+  }
+  for (const child of subtree.children) {
+    collectParentIds(child.subtree, acc);
+  }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { courseSlug: string } }) {
+  const guard = await requireUser(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  const courseSlug = params.courseSlug;
+
+  try {
+    const { data: courseRow, error: courseError } = await adminClient
+      .from('content_nodes')
+      .select('id, node_type, state')
+      .eq('slug', courseSlug)
+      .maybeSingle();
+
+    if (courseError) {
+      throw new CourseBuilderError('Failed to load course', 500, { details: courseError.message, slug: courseSlug });
+    }
+
+    if (!courseRow || courseRow.node_type !== 'course' || courseRow.state !== 'published') {
+      return NextResponse.json({ error: 'Course not found' }, { status: 404 });
+    }
+
+    const rawTree = await fetchNodeSubtree(courseRow.id);
+    const sanitized = sanitizeSubtree(rawTree);
+
+    if (!sanitized) {
+      return NextResponse.json({ error: 'Course not found' }, { status: 404 });
+    }
+
+    const parentIds = new Set<number>();
+    collectParentIds(sanitized, parentIds);
+
+    const unlockEntries = await Promise.all(
+      Array.from(parentIds).map(async (parentId) => {
+        const { data, error } = await adminClient.rpc('get_child_unlock_status', {
+          _parent_id: parentId,
+          _user_id: guard.user.id,
+        });
+
+        if (error) {
+          throw new CourseBuilderError('Failed to load unlock status', 500, {
+            details: error.message,
+            parentId,
+            slug: courseSlug,
+          });
+        }
+
+        return [parentId, (data ?? []) as ChildUnlockStatus[]] as const;
+      }),
+    );
+
+    const unlockStatuses: Record<number, ChildUnlockStatus[]> = {};
+    for (const [parentId, rows] of unlockEntries) {
+      unlockStatuses[parentId] = rows;
+    }
+
+    return NextResponse.json({ course: sanitized, unlockStatuses });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/api/courses/route.ts
+++ b/src/app/api/courses/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireUser } from '@/lib/requireUser';
+import { CourseBuilderError, adminClient, handleCourseBuilderError } from '@/lib/courseBuilder';
+
+export async function GET(request: NextRequest) {
+  const guard = await requireUser(request);
+  if (!guard.ok) {
+    return guard.res;
+  }
+
+  try {
+    const { data, error } = await adminClient
+      .from('content_nodes')
+      .select(
+        `id, title, slug, description, hero_image, icon, objectives, metadata, sequential_unlock, state`,
+      )
+      .eq('node_type', 'course')
+      .eq('state', 'published')
+      .order('title', { ascending: true });
+
+    if (error) {
+      throw new CourseBuilderError('Failed to load courses', 500, { details: error.message });
+    }
+
+    const courses = (data ?? []).map((course) => ({
+      id: course.id,
+      title: course.title,
+      slug: course.slug,
+      description: course.description,
+      hero_image: course.hero_image,
+      icon: course.icon,
+      objectives: course.objectives,
+      metadata: course.metadata,
+      sequential_unlock: course.sequential_unlock,
+    }));
+
+    return NextResponse.json({ courses });
+  } catch (error: unknown) {
+    return handleCourseBuilderError(error);
+  }
+}

--- a/src/app/courses/[courseSlug]/[lessonSlug]/page.tsx
+++ b/src/app/courses/[courseSlug]/[lessonSlug]/page.tsx
@@ -1,0 +1,9 @@
+import CourseViewer from '@/components/course/CourseViewer';
+
+type LessonPageProps = {
+  params: { courseSlug: string; lessonSlug: string };
+};
+
+export default function LessonPage({ params }: LessonPageProps) {
+  return <CourseViewer courseSlug={params.courseSlug} lessonSlug={params.lessonSlug} />;
+}

--- a/src/app/courses/[courseSlug]/page.tsx
+++ b/src/app/courses/[courseSlug]/page.tsx
@@ -1,0 +1,9 @@
+import CourseViewer from '@/components/course/CourseViewer';
+
+type CoursePageProps = {
+  params: { courseSlug: string };
+};
+
+export default function CoursePage({ params }: CoursePageProps) {
+  return <CourseViewer courseSlug={params.courseSlug} />;
+}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,0 +1,5 @@
+import CoursesLanding from '@/components/course/CoursesLanding';
+
+export default function CoursesPage() {
+  return <CoursesLanding />;
+}

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -180,16 +180,18 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
       }
 
       const rawPrompts = (data.smart_doc_prompts ?? []) as SmartDocPromptRow[];
-      const prompts = rawPrompts
-        .map((p) => ({
-          id: p.id,
-          position: p.position,
-          label: p.label,
-          prompt_type: p.prompt_type,
-          help_text: p.help_text,
-          required: p.required,
-        }))
-        .sort((a, b) => a.position - b.position);
+const prompts: SmartDocPrompt[] = (rawPrompts ?? [])
+  .map((p): SmartDocPrompt => ({
+    id: p.id,
+    position: p.position,
+    // coerce null → empty string to satisfy SmartDocPrompt.label: string
+    label: p.label ?? '',
+    prompt_type: p.prompt_type,
+    help_text: p.help_text,
+    required: p.required,
+  }))
+  .sort((a, b) => a.position - b.position);
+
 
       setState({
         status: 'ready',
@@ -210,7 +212,9 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
 
   const wrapSx = { maxWidth: 920, mx: 'auto', px: { xs: 2, sm: 0 } } as const;
 
-  if (state.status === 'idle' || state.status === 'loading') {
+switch (state.status) {
+  case 'idle':
+  case 'loading':
     return (
       <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ ...wrapSx, py: 4 }}>
         <CircularProgress size={22} />
@@ -219,9 +223,8 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
         </Typography>
       </Stack>
     );
-  }
 
-  if (state.status === 'error') {
+  case 'error':
     return (
       <Stack spacing={1} sx={{ ...wrapSx, py: 2 }}>
         <Typography variant="h6">{fallbackLabel ?? 'Smart doc'}</Typography>
@@ -230,10 +233,14 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
         </Typography>
       </Stack>
     );
-  }
 
-  const { doc } = state;
-  const title = doc.title?.trim() || fallbackLabel || 'Smart doc';
+  case 'ready':
+    break;
+}
+
+const { doc } = state; // safely narrowed to 'ready'
+const title = doc.title?.trim() || fallbackLabel || 'Smart doc';
+
 
   return (
     <Stack spacing={3} sx={wrapSx}>
@@ -262,7 +269,10 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
             No questions yet.
           </Typography>
         ) : (
-          doc.prompts.map((p) => <SmartDocPromptField key={p.id} prompt={p} />)
+          doc.prompts.map((p: SmartDocPrompt) => (
+            <SmartDocPromptField key={p.id} prompt={p} />
+          ))
+          
         )}
       </Box>
     </Stack>

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -17,6 +17,7 @@ import {
   Typography,
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
@@ -24,7 +25,6 @@ import HeadphonesIcon from '@mui/icons-material/Headphones';
 import InsertLinkIcon from '@mui/icons-material/InsertLink';
 import ImageIcon from '@mui/icons-material/Image';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 import { supabase } from '@/lib/supabaseClient';
 
@@ -71,6 +71,15 @@ type SmartDocState =
   | { status: 'error'; message: string }
   | { status: 'ready'; doc: SmartDocRecord };
 
+type SmartDocPromptRow = {
+  id: number;
+  position: number;
+  label: string | null;
+  prompt_type: SmartDocPrompt['prompt_type'];
+  help_text: string | null;
+  required: boolean;
+};
+
 /** ---------- Shared field/label styles (unifies look across the page) ---------- */
 const FIELD_SX = {
   bgcolor: 'grey.100',
@@ -86,7 +95,7 @@ const FIELD_SX = {
   '&.Mui-focused': {
     bgcolor: 'common.white',
     borderColor: 'primary.light',
-    boxShadow: (t: any) => `0 0 0 3px ${alpha(t.palette.primary.main, 0.18)}`,
+    boxShadow: (t: Theme) => `0 0 0 3px ${alpha(t.palette.primary.main, 0.18)}`,
   },
 } as const;
 
@@ -170,8 +179,9 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
         return;
       }
 
-      const prompts = (data.smart_doc_prompts ?? [])
-        .map((p: any) => ({
+      const rawPrompts = (data.smart_doc_prompts ?? []) as SmartDocPromptRow[];
+      const prompts = rawPrompts
+        .map((p) => ({
           id: p.id,
           position: p.position,
           label: p.label,
@@ -179,7 +189,7 @@ function SmartDocPreview({ docId, fallbackLabel }: { docId: number; fallbackLabe
           help_text: p.help_text,
           required: p.required,
         }))
-        .sort((a: any, b: any) => a.position - b.position);
+        .sort((a, b) => a.position - b.position);
 
       setState({
         status: 'ready',

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -1,0 +1,342 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Divider,
+  Snackbar,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import TopNav from '@/components/topNav';
+import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
+import StudentCourseTree from './StudentCourseTree';
+import LessonContent from './LessonContent';
+
+type CourseViewerProps = {
+  courseSlug: string;
+  lessonSlug?: string;
+};
+
+type CourseState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]> };
+
+type Maps = {
+  nodeById: Map<number, NodeSubtree>;
+  slugToId: Map<string, number>;
+  parentById: Map<number, number | null>;
+};
+
+function buildMaps(course: NodeSubtree): Maps {
+  const nodeById = new Map<number, NodeSubtree>();
+  const slugToId = new Map<string, number>();
+  const parentById = new Map<number, number | null>();
+
+  const visit = (subtree: NodeSubtree, parentId: number | null) => {
+    nodeById.set(subtree.node.id, subtree);
+    parentById.set(subtree.node.id, parentId);
+    if (subtree.node.slug) {
+      slugToId.set(subtree.node.slug, subtree.node.id);
+    }
+    for (const child of subtree.children) {
+      visit(child.subtree, subtree.node.id);
+    }
+  };
+
+  visit(course, null);
+  return { nodeById, slugToId, parentById };
+}
+
+function toNestedLockMap(source: Record<number, ChildUnlockStatus[]>): Record<number, Record<number, ChildUnlockStatus>> {
+  const nested: Record<number, Record<number, ChildUnlockStatus>> = {};
+  for (const [parentIdString, rows] of Object.entries(source)) {
+    const parentId = Number(parentIdString);
+    const map: Record<number, ChildUnlockStatus> = {};
+    for (const row of rows) {
+      map[row.child_id] = row;
+    }
+    nested[parentId] = map;
+  }
+  return nested;
+}
+
+function collectParentPath(nodeId: number, parentById: Map<number, number | null>) {
+  const path: number[] = [];
+  let current: number | null | undefined = nodeId;
+  while (current != null) {
+    const parent = parentById.get(current) ?? null;
+    if (parent != null) {
+      path.push(parent);
+    }
+    current = parent;
+  }
+  return path;
+}
+
+function findFirstUnlockedLesson(
+  course: NodeSubtree,
+  lockMap: Record<number, Record<number, ChildUnlockStatus>>,
+): NodeSubtree | null {
+  const walk = (subtree: NodeSubtree, parentId: number | null): NodeSubtree | null => {
+    if (parentId != null) {
+      const status = lockMap[parentId]?.[subtree.node.id];
+      if (status?.locked) {
+        return null;
+      }
+    }
+
+    if (subtree.node.node_type === 'lesson') {
+      return subtree;
+    }
+
+    for (const child of subtree.children) {
+      const result = walk(child.subtree, subtree.node.id);
+      if (result) return result;
+    }
+
+    return null;
+  };
+
+  return walk(course, null);
+}
+
+function isNodeLocked(
+  nodeId: number,
+  lockMap: Record<number, Record<number, ChildUnlockStatus>>,
+  parentById: Map<number, number | null>,
+) {
+  const parentId = parentById.get(nodeId);
+  if (parentId == null) return false;
+  const parentLocks = lockMap[parentId];
+  if (!parentLocks) return false;
+  return !!parentLocks[nodeId]?.locked;
+}
+
+export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerProps) {
+  const router = useRouter();
+  const [state, setState] = useState<CourseState>({ status: 'loading' });
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [snackbar, setSnackbar] = useState<string | null>(null);
+  const [redirected, setRedirected] = useState(false);
+
+  useEffect(() => {
+    setRedirected(false);
+    setExpanded(new Set());
+  }, [courseSlug]);
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/courses/${courseSlug}`);
+        if (!res.ok) {
+          const data = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(data.error ?? 'Failed to load course');
+        }
+        const data = (await res.json()) as { course: NodeSubtree; unlockStatuses: Record<number, ChildUnlockStatus[]> };
+        if (!active) return;
+        setState({ status: 'ready', course: data.course, lockStatuses: data.unlockStatuses });
+      } catch (error) {
+        if (!active) return;
+        const message = error instanceof Error ? error.message : 'Failed to load course';
+        setState({ status: 'error', message });
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [courseSlug]);
+
+  const maps = useMemo(() => {
+    if (state.status !== 'ready') return null;
+    return buildMaps(state.course);
+  }, [state]);
+
+  const lockMap = useMemo(() => {
+    if (state.status !== 'ready') return {} as Record<number, Record<number, ChildUnlockStatus>>;
+    return toNestedLockMap(state.lockStatuses);
+  }, [state]);
+
+  useEffect(() => {
+    if (state.status !== 'ready' || !maps) return;
+
+    if (!lessonSlug && !redirected) {
+      const firstLesson = findFirstUnlockedLesson(state.course, lockMap);
+      if (firstLesson && firstLesson.node.slug) {
+        setRedirected(true);
+        router.replace(`/courses/${courseSlug}/${firstLesson.node.slug}`);
+      }
+    }
+  }, [courseSlug, lessonSlug, lockMap, maps, redirected, router, state]);
+
+  const nodeById = maps?.nodeById ?? null;
+  const slugToId = maps?.slugToId ?? null;
+  const parentById = maps?.parentById ?? null;
+
+  const requestedLessonId = lessonSlug && slugToId ? slugToId.get(lessonSlug) ?? null : null;
+  let selectedLesson: NodeSubtree | null = null;
+  let lessonError: string | null = null;
+
+  if (requestedLessonId != null && nodeById && parentById) {
+    if (isNodeLocked(requestedLessonId, lockMap, parentById)) {
+      lessonError = 'This lesson is locked until you complete the previous required items.';
+    } else {
+      selectedLesson = nodeById.get(requestedLessonId) ?? null;
+    }
+  }
+
+  if (!selectedLesson && lessonSlug) {
+    if (!lessonError) {
+      lessonError = 'We couldn’t find this lesson.';
+    }
+  }
+
+  const handleToggle = (nodeId: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      return next;
+    });
+  };
+
+  const handleSelectLesson = (lesson: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => {
+    if (lockStatus?.locked) {
+      setSnackbar(lockStatus.reason ?? 'Complete the previous lesson to unlock this one.');
+      return;
+    }
+
+    if (!lesson.node.slug) {
+      setSnackbar('This lesson is missing a slug and cannot be opened.');
+      return;
+    }
+
+    if (!parentById) {
+      setSnackbar('Course outline is still loading. Try again in a moment.');
+      return;
+    }
+
+    const pathParents = collectParentPath(lesson.node.id, parentById);
+    setExpanded((prev) => new Set([...prev, ...pathParents]));
+    router.push(`/courses/${courseSlug}/${lesson.node.slug}`);
+  };
+
+  useEffect(() => {
+    if (!selectedLesson || !parentById) return;
+    const pathParents = collectParentPath(selectedLesson.node.id, parentById);
+    setExpanded((prev) => new Set([...prev, ...pathParents]));
+  }, [parentById, selectedLesson]);
+
+  const nestedLockMap = lockMap;
+  const treeSelectedId = selectedLesson?.node.id ?? (lessonError && requestedLessonId ? requestedLessonId : null);
+
+  useEffect(() => {
+    if (!lessonError || !requestedLessonId || !parentById) return;
+    const pathParents = collectParentPath(requestedLessonId, parentById);
+    if (pathParents.length === 0) return;
+    setExpanded((prev) => new Set([...prev, ...pathParents]));
+  }, [lessonError, parentById, requestedLessonId]);
+
+  if (state.status === 'loading') {
+    return (
+      <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50' }}>
+        <TopNav />
+        <Stack alignItems="center" spacing={2} sx={{ py: 12 }}>
+          <CircularProgress />
+          <Typography color="text.secondary">Loading course…</Typography>
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50' }}>
+        <TopNav />
+        <Stack alignItems="center" spacing={2} sx={{ py: 12 }}>
+          <Typography variant="h6">We couldn’t load this course.</Typography>
+          <Typography color="text.secondary">{state.message}</Typography>
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (!maps || !nodeById || !parentById) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50', display: 'flex', flexDirection: 'column' }}>
+      <TopNav />
+      <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+        <StudentCourseTree
+          course={state.course}
+          expanded={expanded}
+          selectedNodeId={treeSelectedId}
+          lockStatuses={nestedLockMap}
+          onToggle={handleToggle}
+          onSelectLesson={handleSelectLesson}
+          onBackToCourses={() => router.push('/courses')}
+          fullHeight={false}
+        />
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        <Box sx={{ width: { xs: 0, md: 340 }, display: { xs: 'none', md: 'flex' } }}>
+          <StudentCourseTree
+            course={state.course}
+            expanded={expanded}
+            selectedNodeId={treeSelectedId}
+            lockStatuses={nestedLockMap}
+            onToggle={handleToggle}
+            onSelectLesson={handleSelectLesson}
+            onBackToCourses={() => router.push('/courses')}
+          />
+        </Box>
+
+        <Box sx={{ flex: 1, minWidth: 0, bgcolor: 'background.default' }}>
+          {lessonSlug ? null : (
+            <Box sx={{ px: { xs: 2, md: 4 }, py: 6 }}>
+              <Typography variant="h3" sx={{ fontWeight: 700 }}>
+                {state.course.node.title ?? 'Course'}
+              </Typography>
+              <Typography color="text.secondary" sx={{ mt: 1 }}>
+                Select a lesson from the outline to start learning.
+              </Typography>
+              <Divider sx={{ my: 4 }} />
+            </Box>
+          )}
+
+          <LessonContent lesson={selectedLesson} loading={false} error={lessonError} />
+        </Box>
+      </Box>
+
+      <Snackbar
+        open={!!snackbar}
+        autoHideDuration={6000}
+        onClose={() => setSnackbar(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="info" onClose={() => setSnackbar(null)} sx={{ width: '100%' }}>
+          {snackbar}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/src/components/course/CoursesLanding.tsx
+++ b/src/components/course/CoursesLanding.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  CardMedia,
+  CircularProgress,
+  Container,
+  Stack,
+  Typography,
+} from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+
+import TopNav from '@/components/topNav';
+
+type CourseSummary = {
+  id: number;
+  title: string | null;
+  slug: string | null;
+  description: string | null;
+  hero_image: string | null;
+  icon: string | null;
+  objectives: string | null;
+  metadata: Record<string, unknown> | null;
+  sequential_unlock: boolean | null;
+};
+
+type FetchState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; courses: CourseSummary[] };
+
+const CARD_MEDIA_HEIGHT = 180;
+
+export default function CoursesLanding() {
+  const [state, setState] = useState<FetchState>({ status: 'loading' });
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      try {
+        const res = await fetch('/api/courses');
+        if (!res.ok) {
+          const data = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(data.error ?? 'Failed to load courses');
+        }
+        const data = (await res.json()) as { courses: CourseSummary[] };
+        if (!active) return;
+        setState({ status: 'ready', courses: data.courses ?? [] });
+      } catch (error) {
+        if (!active) return;
+        const message = error instanceof Error ? error.message : 'Failed to load courses';
+        setState({ status: 'error', message });
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const content = useMemo(() => {
+    if (state.status === 'loading') {
+      return (
+        <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
+          <CircularProgress />
+          <Typography color="text.secondary">Loading courses…</Typography>
+        </Stack>
+      );
+    }
+
+    if (state.status === 'error') {
+      return (
+        <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
+          <Typography variant="h6">We couldn’t load your courses.</Typography>
+          <Typography color="text.secondary">{state.message}</Typography>
+        </Stack>
+      );
+    }
+
+    if (state.courses.length === 0) {
+      return (
+        <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
+          <Typography variant="h6">No courses available yet</Typography>
+          <Typography color="text.secondary" align="center">
+            Check back soon—new learning content will appear here once it’s published for your account.
+          </Typography>
+        </Stack>
+      );
+    }
+
+    return (
+      <Grid container spacing={3}>
+        {state.courses.map((course) => {
+          const slug = course.slug ?? undefined;
+          if (!slug) return null;
+
+          return (
+            <Grid key={course.id} xs={12} sm={6} lg={4}>
+              <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                <CardActionArea component={Link} href={`/courses/${slug}`} sx={{ flexGrow: 1 }}>
+                  {course.hero_image ? (
+                    <CardMedia
+                      component="div"
+                      sx={{ height: CARD_MEDIA_HEIGHT, backgroundSize: 'cover', backgroundPosition: 'center' }}
+                      image={course.hero_image}
+                    />
+                  ) : (
+                    <Box
+                      sx={{
+                        height: CARD_MEDIA_HEIGHT,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        bgcolor: 'grey.100',
+                      }}
+                    >
+                      <Avatar sx={{ bgcolor: 'primary.main', width: 64, height: 64 }}>
+                        <MenuBookIcon />
+                      </Avatar>
+                    </Box>
+                  )}
+
+                  <CardContent>
+                    <Stack spacing={1}>
+                      <Typography variant="h6">{course.title ?? 'Untitled course'}</Typography>
+                      {course.description ? (
+                        <Typography color="text.secondary" sx={{ display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                          {course.description}
+                        </Typography>
+                      ) : null}
+                    </Stack>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          );
+        })}
+      </Grid>
+    );
+  }, [state]);
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50' }}>
+      <TopNav />
+      <Container maxWidth="lg" sx={{ py: 6 }}>
+        <Stack spacing={3}>
+          <Box>
+            <Typography variant="h3" sx={{ fontWeight: 700 }}>
+              Courses
+            </Typography>
+            <Typography color="text.secondary">
+              Dive into your coaching curriculum. Select a course to view its lessons and track your progress.
+            </Typography>
+          </Box>
+
+          {content}
+        </Stack>
+      </Container>
+    </Box>
+  );
+}

--- a/src/components/course/CoursesLanding.tsx
+++ b/src/components/course/CoursesLanding.tsx
@@ -11,10 +11,10 @@ import {
   CardMedia,
   CircularProgress,
   Container,
+  Grid,
   Stack,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Unstable_Grid2';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 
 import TopNav from '@/components/topNav';
@@ -103,7 +103,7 @@ export default function CoursesLanding() {
           if (!slug) return null;
 
           return (
-            <Grid key={course.id} xs={12} sm={6} lg={4}>
+            <Grid item key={course.id} xs={12} sm={6} lg={4}>
               <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
                 <CardActionArea component={Link} href={`/courses/${slug}`} sx={{ flexGrow: 1 }}>
                   {course.hero_image ? (

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Alert, Box, CircularProgress, Stack, Typography } from '@mui/material';
+
+import type { ContentBlock, NodeSubtree } from '@/types/course';
+import { BlockRenderer, type RenderableBlock, type RenderableResource } from '@/components/course/BlockRenderer';
+import { supabase } from '@/lib/supabaseClient';
+
+type LessonContentProps = {
+  lesson: NodeSubtree | null;
+  loading: boolean;
+  error?: string | null;
+};
+
+type ResourceState = 'idle' | 'loading' | 'ready' | 'error';
+
+function toRenderableBlock(block: ContentBlock): RenderableBlock {
+  return {
+    id: block.id,
+    block_type: block.block_type,
+    position: block.position,
+    text_md: block.text_md,
+    resource_id: block.resource_id,
+    smart_doc_id: block.smart_doc_id,
+    start_ms: block.start_ms,
+    end_ms: block.end_ms,
+    label: block.label,
+  };
+}
+
+export default function LessonContent({ lesson, loading, error }: LessonContentProps) {
+  const [resources, setResources] = useState<Record<number, RenderableResource>>({});
+  const [resourceState, setResourceState] = useState<ResourceState>('idle');
+  const [resourceError, setResourceError] = useState<string | null>(null);
+
+  const assetBlockIds = useMemo(() => {
+    if (!lesson) return [] as number[];
+    return lesson.blocks
+      .filter((block) => block.block_type === 'asset' && block.resource_id)
+      .map((block) => block.resource_id!)
+      .filter((id, index, arr) => arr.indexOf(id) === index);
+  }, [lesson]);
+
+  useEffect(() => {
+    if (!lesson || assetBlockIds.length === 0) {
+      setResources({});
+      setResourceState('idle');
+      setResourceError(null);
+      return;
+    }
+
+    let active = true;
+    setResourceState('loading');
+    setResourceError(null);
+
+    (async () => {
+      const { data, error: resError } = await supabase
+        .from('resources')
+        .select('id, title, type, url, thumbnail, duration')
+        .in('id', assetBlockIds);
+
+      if (!active) return;
+
+      if (resError) {
+        setResourceState('error');
+        setResourceError(resError.message ?? 'Failed to load resources');
+        setResources({});
+        return;
+      }
+
+      const map: Record<number, RenderableResource> = {};
+      for (const row of data ?? []) {
+        map[row.id] = {
+          id: row.id,
+          title: row.title,
+          type: row.type,
+          url: row.url,
+          thumbnail: row.thumbnail,
+          duration: row.duration,
+        };
+      }
+      setResources(map);
+      setResourceState('ready');
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [assetBlockIds, lesson]);
+
+  if (loading) {
+    return (
+      <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
+        <CircularProgress />
+        <Typography color="text.secondary">Loading lesson…</Typography>
+      </Stack>
+    );
+  }
+
+  if (error) {
+    return (
+      <Stack spacing={2} sx={{ py: 6 }}>
+        <Alert severity="error">{error}</Alert>
+      </Stack>
+    );
+  }
+
+  if (!lesson) {
+    return (
+      <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
+        <Typography variant="h6">Select a lesson to get started</Typography>
+        <Typography color="text.secondary" align="center">
+          Choose an unlocked lesson from the outline to explore its content.
+        </Typography>
+      </Stack>
+    );
+  }
+
+  const blocks = lesson.blocks.map(toRenderableBlock).sort((a, b) => a.position - b.position);
+  const showResourceAlert = resourceState === 'error' && resourceError;
+
+  return (
+    <Box sx={{ py: { xs: 4, md: 6 } }}>
+      <Stack spacing={3} sx={{ maxWidth: 860, mx: 'auto', px: { xs: 2, md: 4 } }}>
+        <Box>
+          <Typography variant="overline" sx={{ color: 'primary.main', fontWeight: 600 }}>
+            Lesson
+          </Typography>
+          <Typography variant="h3" sx={{ fontWeight: 700 }}>
+            {lesson.node.title ?? 'Untitled lesson'}
+          </Typography>
+          {lesson.node.description ? (
+            <Typography color="text.secondary" sx={{ mt: 1 }}>
+              {lesson.node.description}
+            </Typography>
+          ) : null}
+        </Box>
+
+        {blocks.length === 0 ? (
+          <Alert severity="info">This lesson doesn’t have any blocks yet.</Alert>
+        ) : (
+          <Stack spacing={3}>
+            {blocks.map((block) => {
+              const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
+              return <BlockRenderer key={block.id} block={block} resource={resource} previewMode />;
+            })}
+          </Stack>
+        )}
+
+        {resourceState === 'loading' ? (
+          <Typography variant="body2" color="text.secondary">
+            Loading media resources…
+          </Typography>
+        ) : null}
+
+        {showResourceAlert ? <Alert severity="warning">{resourceError}</Alert> : null}
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/course/StudentCourseTree.tsx
+++ b/src/components/course/StudentCourseTree.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Box,
+  Button,
+  Collapse,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import ArticleIcon from '@mui/icons-material/Article';
+import LayersIcon from '@mui/icons-material/Layers';
+import CollectionsBookmarkIcon from '@mui/icons-material/CollectionsBookmark';
+import PlaylistPlayIcon from '@mui/icons-material/PlaylistPlay';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+
+import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
+
+const NODE_ICONS: Record<string, JSX.Element> = {
+  course: <MenuBookIcon fontSize="small" />,
+  lesson: <ArticleIcon fontSize="small" />,
+  chapter: <LayersIcon fontSize="small" />,
+  collection: <CollectionsBookmarkIcon fontSize="small" />,
+  playlist: <PlaylistPlayIcon fontSize="small" />,
+};
+
+type StudentCourseTreeProps = {
+  course: NodeSubtree;
+  expanded: Set<number>;
+  selectedNodeId: number | null;
+  lockStatuses: Record<number, Record<number, ChildUnlockStatus>>;
+  onToggle: (nodeId: number) => void;
+  onSelectLesson: (lesson: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
+  onBackToCourses: () => void;
+  fullHeight?: boolean;
+};
+
+type TreeNodeProps = {
+  subtree: NodeSubtree;
+  depth: number;
+  expanded: Set<number>;
+  lockStatuses: Record<number, Record<number, ChildUnlockStatus>>;
+  selectedNodeId: number | null;
+  parentId: number | null;
+  onToggle: (nodeId: number) => void;
+  onSelectLesson: (lesson: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
+};
+
+function TreeNode({
+  subtree,
+  depth,
+  expanded,
+  lockStatuses,
+  selectedNodeId,
+  parentId,
+  onToggle,
+  onSelectLesson,
+}: TreeNodeProps) {
+  const { node } = subtree;
+  const hasChildren = subtree.children.length > 0;
+  const isExpanded = expanded.has(node.id);
+  const lockStatus = parentId != null ? lockStatuses[parentId]?.[node.id] : undefined;
+  const isLocked = !!lockStatus?.locked;
+  const icon = NODE_ICONS[node.node_type] ?? NODE_ICONS.lesson;
+  const isSelected = selectedNodeId === node.id;
+  const paddingLeft = 2 + depth * 2;
+
+  const handleClick = () => {
+    if (hasChildren) {
+      onToggle(node.id);
+      return;
+    }
+    if (node.node_type === 'lesson') {
+      onSelectLesson(subtree, lockStatus);
+    }
+  };
+
+  const item = (
+    <ListItemButton
+      onClick={handleClick}
+      selected={isSelected}
+      sx={{
+        pl: paddingLeft,
+        pr: 2,
+        alignItems: 'center',
+        opacity: isLocked ? 0.65 : 1,
+        '&.Mui-selected': {
+          bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+          '&:hover': {
+            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.18),
+          },
+        },
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 40, mr: 1 }}>
+        {hasChildren ? (
+          <IconButton
+            size="small"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggle(node.id);
+            }}
+            sx={{ mr: 0.5 }}
+          >
+            {isExpanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+          </IconButton>
+        ) : null}
+        <Box sx={{ display: 'flex', alignItems: 'center', color: 'text.secondary' }}>{icon}</Box>
+      </Box>
+
+      <ListItemText
+        primary={node.title ?? 'Untitled'}
+        primaryTypographyProps={{
+          variant: node.node_type === 'lesson' ? 'body1' : 'subtitle2',
+          fontWeight: node.node_type === 'lesson' ? 600 : 500,
+        }}
+      />
+
+      {isLocked ? (
+        <Tooltip title={lockStatus?.reason ?? 'This lesson is locked until prerequisites are complete.'}>
+          <LockOutlinedIcon fontSize="small" sx={{ color: 'text.disabled' }} />
+        </Tooltip>
+      ) : null}
+    </ListItemButton>
+  );
+
+  return (
+    <>
+      {item}
+      {hasChildren ? (
+        <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+          <List disablePadding>
+            {subtree.children.map((child) => (
+              <TreeNode
+                key={child.subtree.node.id}
+                subtree={child.subtree}
+                depth={depth + 1}
+                expanded={expanded}
+                lockStatuses={lockStatuses}
+                selectedNodeId={selectedNodeId}
+                parentId={subtree.node.id}
+                onToggle={onToggle}
+                onSelectLesson={onSelectLesson}
+              />
+            ))}
+          </List>
+        </Collapse>
+      ) : null}
+    </>
+  );
+}
+
+export default function StudentCourseTree({
+  course,
+  expanded,
+  selectedNodeId,
+  lockStatuses,
+  onToggle,
+  onSelectLesson,
+  onBackToCourses,
+  fullHeight = true,
+}: StudentCourseTreeProps) {
+  const sequentialUnlock = !!course.node.sequential_unlock;
+  const childLocks = useMemo(
+    () => lockStatuses[course.node.id] ?? {},
+    [course.node.id, lockStatuses],
+  );
+  const unlockedCount = useMemo(
+    () => Object.values(childLocks).filter((status) => !status.locked).length,
+    [childLocks],
+  );
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: fullHeight ? '100%' : 'auto',
+        borderRight: fullHeight ? '1px solid' : 'none',
+        borderBottom: fullHeight ? 'none' : '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Box sx={{ px: 2.5, py: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={onBackToCourses} size="small" sx={{ mb: 1 }}>
+          All courses
+        </Button>
+        <Typography variant="h6" sx={{ fontWeight: 700 }}>
+          {course.node.title ?? 'Untitled course'}
+        </Typography>
+        {course.node.description ? (
+          <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+            {course.node.description}
+          </Typography>
+        ) : null}
+        {sequentialUnlock ? (
+          <Typography variant="body2" sx={{ mt: 1 }} color="text.secondary">
+            Lessons unlock sequentially. {unlockedCount} unlocked so far.
+          </Typography>
+        ) : null}
+      </Box>
+
+      <Box sx={{ flex: fullHeight ? 1 : undefined, overflowY: 'auto', maxHeight: fullHeight ? undefined : 360 }}>
+        <List disablePadding>
+          {course.children.map((child) => (
+            <TreeNode
+              key={child.subtree.node.id}
+              subtree={child.subtree}
+              depth={0}
+              expanded={expanded}
+              lockStatuses={lockStatuses}
+              selectedNodeId={selectedNodeId}
+              parentId={course.node.id}
+              onToggle={onToggle}
+              onSelectLesson={onSelectLesson}
+            />
+          ))}
+        </List>
+      </Box>
+    </Box>
+  );
+}

--- a/src/lib/requireUser.ts
+++ b/src/lib/requireUser.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient, type SupabaseClient } from '@supabase/ssr';
+import type { User } from '@supabase/supabase-js';
+
+export type RequireUserSuccess = {
+  ok: true;
+  user: User;
+  supabase: SupabaseClient;
+};
+
+export type RequireUserFailure = {
+  ok: false;
+  res: NextResponse;
+};
+
+export type RequireUserResult = RequireUserSuccess | RequireUserFailure;
+
+export async function requireUser(request?: NextRequest): Promise<RequireUserResult> {
+  try {
+    let supabase: SupabaseClient;
+
+    if (request) {
+      supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+          cookies: {
+            get: (name: string) => request.cookies.get(name)?.value,
+            set: () => {},
+            remove: () => {},
+          },
+        },
+      );
+    } else {
+      const { getServerAnonClient } = await import('./supabaseServer');
+      supabase = await getServerAnonClient();
+    }
+
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+
+    if (error) {
+      return {
+        ok: false,
+        res: NextResponse.json({ error: 'Authentication failed', details: error.message }, { status: 401 }),
+      };
+    }
+
+    if (!user) {
+      return {
+        ok: false,
+        res: NextResponse.json({ error: 'Unauthorized - No session' }, { status: 401 }),
+      };
+    }
+
+    return { ok: true, user, supabase };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      ok: false,
+      res: NextResponse.json({ error: 'Server error', details: message }, { status: 500 }),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable requireUser helper and authenticated API endpoints that expose published courses and per-user unlock statuses
- build a student-facing courses landing page and lesson viewer with an outline tree that respects sequential unlock rules
- update the shared block renderer typings so lint passes while rendering lesson content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0c0d09c908332aa2c53283780024e