### PR TITLE
Enable chapter leaf selection in student course viewer

### DIFF
--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Box, Divider, Stack } from '@mui/material';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { LessonContent } from './LessonContent';
+import { StudentCourseTree } from './StudentCourseTree';
+
+import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
+
+const LESSON_PARAM = 'lessonSlug';
+
+type CourseViewerProps = {
+  course: NodeSubtree;
+  unlockStatus?: ChildUnlockStatus[];
+};
+
+type UnlockMap = Map<number, ChildUnlockStatus>;
+
+type FlattenedNodeIndex = {
+  byId: Map<number, NodeSubtree>;
+  bySlug: Map<string, NodeSubtree>;
+};
+
+function slugForNode(node: NodeSubtree) {
+  return node.node.slug ?? `node-${node.node.id}`;
+}
+
+function isLeafNode(node: NodeSubtree) {
+  return node.children.length === 0;
+}
+
+function buildUnlockMap(status?: ChildUnlockStatus[]): UnlockMap {
+  const map = new Map<number, ChildUnlockStatus>();
+  if (!status) {
+    return map;
+  }
+
+  for (const item of status) {
+    map.set(item.child_id, item);
+  }
+
+  return map;
+}
+
+function buildIndexes(root: NodeSubtree): FlattenedNodeIndex {
+  const byId = new Map<number, NodeSubtree>();
+  const bySlug = new Map<string, NodeSubtree>();
+
+  const visit = (node: NodeSubtree) => {
+    byId.set(node.node.id, node);
+    const slug = slugForNode(node);
+    bySlug.set(slug, node);
+
+    for (const child of node.children) {
+      visit(child.subtree);
+    }
+  };
+
+  visit(root);
+
+  return { byId, bySlug };
+}
+
+function findFirstUnlockedLesson(root: NodeSubtree, unlocks: UnlockMap): NodeSubtree | null {
+  const queue: NodeSubtree[] = [root];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const unlock = unlocks.get(current.node.id);
+    const locked = unlock?.locked ?? false;
+
+    if (locked) {
+      continue;
+    }
+
+    if (isLeafNode(current)) {
+      return current;
+    }
+
+    queue.push(...current.children.map((child) => child.subtree));
+  }
+
+  return null;
+}
+
+function findNodeBySlug(slug: string | null, index: FlattenedNodeIndex) {
+  if (!slug) {
+    return null;
+  }
+
+  return index.bySlug.get(slug) ?? null;
+}
+
+export function CourseViewer({ course, unlockStatus }: CourseViewerProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
+
+  const indexes = useMemo(() => buildIndexes(course), [course]);
+  const unlocks = useMemo(() => buildUnlockMap(unlockStatus), [unlockStatus]);
+  const [selectedNode, setSelectedNode] = useState<NodeSubtree | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchKey);
+    const slug = params.get(LESSON_PARAM);
+    const node = findNodeBySlug(slug, indexes);
+    if (node) {
+      setSelectedNode(node);
+      return;
+    }
+
+    const fallback = findFirstUnlockedLesson(course, unlocks);
+    setSelectedNode(fallback);
+  }, [course, indexes, searchKey, unlocks]);
+
+  const handleSelectLesson = useCallback(
+    (node: NodeSubtree) => {
+      if (!node) {
+        return;
+      }
+
+      const unlock = unlocks.get(node.node.id);
+      if (unlock?.locked) {
+        return;
+      }
+
+      if (!isLeafNode(node)) {
+        return;
+      }
+
+      setSelectedNode(node);
+
+      const slug = slugForNode(node);
+      const currentSlug = selectedNode ? slugForNode(selectedNode) : null;
+      if (slug === currentSlug) {
+        return;
+      }
+      if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(searchKey);
+        params.set(LESSON_PARAM, slug);
+        router.push(`${pathname}?${params.toString()}`, { scroll: false });
+      }
+    },
+    [pathname, router, searchKey, selectedNode, unlocks],
+  );
+
+  const lockInfo = selectedNode ? unlocks.get(selectedNode.node.id) ?? null : null;
+
+  return (
+    <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} alignItems="flex-start">
+      <Box sx={{ flex: '0 0 320px', width: '100%' }}>
+        <StudentCourseTree
+          tree={course}
+          selectedNodeId={selectedNode?.node.id ?? null}
+          onSelectLesson={handleSelectLesson}
+          unlockStatus={unlocks}
+        />
+      </Box>
+
+      <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', md: 'block' } }} />
+
+      <Box sx={{ flex: 1, width: '100%' }}>
+        <LessonContent lesson={selectedNode} locked={lockInfo?.locked ?? false} lockReason={lockInfo?.reason ?? null} />
+      </Box>
+    </Stack>
+  );
+}
+
+export default CourseViewer;

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useMemo } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { BlockRenderer } from './BlockRenderer';
+
+import type { NodeSubtree, NodeType } from '@/types/course';
+
+const TYPE_LABELS: Record<NodeType, { heading: string; empty: string }> = {
+  course: {
+    heading: 'Course overview',
+    empty: 'This course does not have any blocks yet.',
+  },
+  lesson: {
+    heading: 'Lesson',
+    empty: 'This lesson does not contain any blocks yet.',
+  },
+  chapter: {
+    heading: 'Chapter',
+    empty: 'This chapter does not contain any blocks yet.',
+  },
+  collection: {
+    heading: 'Collection',
+    empty: 'This collection does not contain any blocks yet.',
+  },
+  playlist: {
+    heading: 'Playlist',
+    empty: 'This playlist does not contain any blocks yet.',
+  },
+};
+
+type LessonContentProps = {
+  lesson: NodeSubtree | null;
+  locked?: boolean;
+  lockReason?: string | null;
+};
+
+function toRenderableBlock(block: NodeSubtree['blocks'][number]) {
+  return {
+    id: block.id,
+    block_type: block.block_type,
+    position: block.position,
+    text_md: block.text_md,
+    resource_id: block.resource_id,
+    smart_doc_id: block.smart_doc_id,
+    start_ms: block.start_ms,
+    end_ms: block.end_ms,
+    label: block.label,
+  } as const;
+}
+
+export function LessonContent({ lesson, locked = false, lockReason = null }: LessonContentProps) {
+  const type: NodeType = lesson?.node.node_type ?? 'lesson';
+  const copy = TYPE_LABELS[type];
+
+  const sortedBlocks = useMemo(() => {
+    if (!lesson) {
+      return [];
+    }
+
+    return [...lesson.blocks].sort((a, b) => a.position - b.position).map(toRenderableBlock);
+  }, [lesson]);
+
+  if (!lesson) {
+    return (
+      <Box>
+        <Typography variant="h5" gutterBottom>
+          Select an item to begin
+        </Typography>
+        <Typography color="text.secondary">Pick an item from the course tree to view its content.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={3}>
+      <Stack spacing={1}>
+        <Typography variant="overline" color="text.secondary">
+          {copy.heading}
+        </Typography>
+        <Typography variant="h4" component="h1">
+          {lesson.node.title || 'Untitled node'}
+        </Typography>
+      </Stack>
+
+      {locked && (
+        <Alert severity="info">{lockReason || 'This content is currently locked.'}</Alert>
+      )}
+
+      {sortedBlocks.length === 0 ? (
+        <Alert severity="info">{copy.empty}</Alert>
+      ) : (
+        <Stack spacing={3}>
+          {sortedBlocks.map((block) => (
+            <BlockRenderer key={block.id} block={block} resource={null} previewMode />
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
+export default LessonContent;

--- a/src/components/course/StudentCourseTree.tsx
+++ b/src/components/course/StudentCourseTree.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FolderIcon from '@mui/icons-material/Folder';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { Collapse, IconButton, List, ListItemButton, ListItemIcon, ListItemText, Stack, Tooltip } from '@mui/material';
+
+import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
+
+export type StudentCourseTreeProps = {
+  tree: NodeSubtree;
+  selectedNodeId: number | null;
+  onSelectLesson: (node: NodeSubtree) => void;
+  unlockStatus?: ReadonlyMap<number, ChildUnlockStatus> | ChildUnlockStatus[];
+};
+
+type TreeNodeProps = {
+  node: NodeSubtree;
+  depth: number;
+  selectedNodeId: number | null;
+  onSelectLesson: (node: NodeSubtree) => void;
+  unlockMap: ReadonlyMap<number, ChildUnlockStatus>;
+};
+
+function buildUnlockMap(status?: ReadonlyMap<number, ChildUnlockStatus> | ChildUnlockStatus[]) {
+  if (!status) {
+    return new Map<number, ChildUnlockStatus>();
+  }
+
+  if (status instanceof Map) {
+    return status;
+  }
+
+  return status.reduce((map, entry) => {
+    map.set(entry.child_id, entry);
+    return map;
+  }, new Map<number, ChildUnlockStatus>());
+}
+
+function isLeafNode(node: NodeSubtree) {
+  return node.children.length === 0;
+}
+
+function getIconForNode(node: NodeSubtree, selectable: boolean) {
+  if (node.node.node_type === 'lesson') {
+    return <MenuBookIcon fontSize="small" color={selectable ? 'primary' : undefined} />;
+  }
+
+  if (node.node.node_type === 'chapter') {
+    return <PlayArrowIcon fontSize="small" color={selectable ? 'primary' : undefined} />;
+  }
+
+  return <FolderIcon fontSize="small" color={selectable ? 'primary' : undefined} />;
+}
+
+function TreeNode({ node, depth, selectedNodeId, onSelectLesson, unlockMap }: TreeNodeProps) {
+  const [expanded, setExpanded] = useState(true);
+  const unlock = unlockMap.get(node.node.id);
+  const locked = unlock?.locked ?? false;
+  const reason = unlock?.reason ?? null;
+
+  const selectable = !locked && isLeafNode(node);
+  const hasChildren = node.children.length > 0;
+
+  const handleClick = useCallback(() => {
+    if (locked) {
+      if (hasChildren && !isLeafNode(node)) {
+        setExpanded((prev) => !prev);
+      }
+      return;
+    }
+
+    if (isLeafNode(node)) {
+      onSelectLesson(node);
+      return;
+    }
+
+    if (hasChildren) {
+      setExpanded((prev) => !prev);
+    }
+  }, [hasChildren, locked, node, onSelectLesson]);
+
+  const content = (
+    <ListItemButton
+      onClick={handleClick}
+      sx={{
+        pl: depth * 2,
+        borderRadius: 1,
+        mb: 0.25,
+        bgcolor: node.node.id === selectedNodeId ? 'primary.50' : undefined,
+        cursor: locked && !hasChildren ? 'not-allowed' : undefined,
+      }}
+      selected={node.node.id === selectedNodeId}
+      aria-disabled={locked}
+    >
+      {hasChildren ? (
+        <IconButton size="small" edge="start" sx={{ mr: 1 }}>
+          {expanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+        </IconButton>
+      ) : (
+        <span style={{ width: 32 }} />
+      )}
+
+      <ListItemIcon sx={{ minWidth: 32 }}>{getIconForNode(node, selectable)}</ListItemIcon>
+      <ListItemText
+        primary={node.node.title || 'Untitled node'}
+        primaryTypographyProps={{
+          fontWeight: node.node.id === selectedNodeId ? 600 : 500,
+          color: locked ? 'text.disabled' : 'text.primary',
+        }}
+      />
+      {locked && (
+        <LockOutlinedIcon fontSize="small" color="action" sx={{ ml: 1 }} />
+      )}
+    </ListItemButton>
+  );
+
+  return (
+    <Stack spacing={0.25}>
+      {locked && reason ? (
+        <Tooltip title={reason} placement="right">
+          <span>{content}</span>
+        </Tooltip>
+      ) : (
+        content
+      )}
+
+      {node.children.length > 0 && (
+        <Collapse in={expanded && !isLeafNode(node)} timeout="auto" unmountOnExit>
+          <List disablePadding>
+            {node.children.map(({ subtree }) => (
+              <TreeNode
+                key={subtree.node.id}
+                node={subtree}
+                depth={depth + 1}
+                onSelectLesson={onSelectLesson}
+                selectedNodeId={selectedNodeId}
+                unlockMap={unlockMap}
+              />
+            ))}
+          </List>
+        </Collapse>
+      )}
+    </Stack>
+  );
+}
+
+export function StudentCourseTree({ tree, selectedNodeId, onSelectLesson, unlockStatus }: StudentCourseTreeProps) {
+  const unlockMap = useMemo(() => buildUnlockMap(unlockStatus), [unlockStatus]);
+
+  return (
+    <List disablePadding>
+      <TreeNode
+        node={tree}
+        depth={0}
+        selectedNodeId={selectedNodeId}
+        onSelectLesson={onSelectLesson}
+        unlockMap={unlockMap}
+      />
+    </List>
+  );
+}
+
+export default StudentCourseTree;


### PR DESCRIPTION
## Summary
- add a student course tree component that treats leaf nodes, including chapters, as selectable and preserves lock tooltips
- introduce a course viewer wrapper that finds the first unlocked leaf, updates the lessonSlug route param, and coordinates tree/content state
- render lesson content with node-type specific headings and empty states so selectable chapters display appropriate copy

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f0d41f29108332aed7d0805f3724c3