### PR TITLE
Enable chapter selection in student course view

### DIFF
--- a/src/app/api/courses/[courseSlug]/route.ts
+++ b/src/app/api/courses/[courseSlug]/route.ts
@@ -51,6 +51,7 @@ export async function GET(request: NextRequest, { params }: { params: { courseSl
   const courseSlug = params.courseSlug;
 
   try {
+    // Ensure we're looking at a published course
     const { data: courseRow, error: courseError } = await adminClient
       .from('content_nodes')
       .select('id, node_type, state')
@@ -65,39 +66,66 @@ export async function GET(request: NextRequest, { params }: { params: { courseSl
       return NextResponse.json({ error: 'Course not found' }, { status: 404 });
     }
 
-    const rawTree = await fetchNodeSubtree(courseRow.id);
+    // Build the sanitized tree (published-only)
+    const rawTree = await fetchNodeSubtree(courseRow.id, {
+      includeBlocks: false,       // we lazy-load per selected node
+      allowUnpublished: false,    // students see only published content
+    });
     const sanitized = sanitizeSubtree(rawTree);
 
     if (!sanitized) {
       return NextResponse.json({ error: 'Course not found' }, { status: 404 });
     }
 
-    const parentIds = new Set<number>();
-    collectParentIds(sanitized, parentIds);
+    // Collect all parent node IDs (nodes that have children)
+    const parentIdsSet = new Set<number>();
+    collectParentIds(sanitized, parentIdsSet);
+    const parentIds = Array.from(parentIdsSet);
 
-    const unlockEntries = await Promise.all(
-      Array.from(parentIds).map(async (parentId) => {
-        const { data, error } = await adminClient.rpc('get_child_unlock_status', {
-          _parent_id: parentId,
-          _user_id: guard.user.id,
-        });
-
-        if (error) {
-          throw new CourseBuilderError('Failed to load unlock status', 500, {
-            details: error.message,
-            parentId,
-            slug: courseSlug,
-          });
-        }
-
-        return [parentId, (data ?? []) as ChildUnlockStatus[]] as const;
-      }),
-    );
-
-    const unlockStatuses: Record<number, ChildUnlockStatus[]> = {};
-    for (const [parentId, rows] of unlockEntries) {
-      unlockStatuses[parentId] = rows;
+    // If no parents, nothing to lock
+    if (parentIds.length === 0) {
+      return NextResponse.json({ course: sanitized, unlockStatuses: {} });
     }
+
+    // Single BULK RPC call instead of N+1
+    const { data: bulkRows, error: bulkError } = await adminClient.rpc('get_child_unlock_status_bulk', {
+      _parent_ids: parentIds,
+      _user_id: guard.user.id,
+    });
+
+    if (bulkError) {
+      throw new CourseBuilderError('Failed to load unlock status', 500, {
+        details: bulkError.message,
+        slug: courseSlug,
+      });
+    }
+
+    // Group rows by parent_id to match frontend shape: Record<parentId, ChildUnlockStatus[]>
+    // Group rows by parent_id to match frontend shape: Record<parentId, ChildUnlockStatus[]>
+const unlockStatuses: Record<number, ChildUnlockStatus[]> = {};
+for (const row of (bulkRows ?? []) as Array<{
+  parent_id: number;
+  child_id: number;
+  child_position: number;
+  is_required: boolean;
+  locked: boolean;
+  reason: string | null;
+}>) {
+  if (!unlockStatuses[row.parent_id]) unlockStatuses[row.parent_id] = [];
+  unlockStatuses[row.parent_id].push({
+    child_id: row.child_id,
+    child_position: row.child_position,
+    is_required: row.is_required,
+    locked: row.locked,
+    reason: row.reason ?? null, // must be string | null
+  });
+}
+
+// (optional but recommended) keep deterministic order for UI
+for (const pid of Object.keys(unlockStatuses)) {
+  unlockStatuses[Number(pid)].sort((a, b) => a.child_position - b.child_position);
+}
+
 
     return NextResponse.json({ course: sanitized, unlockStatuses });
   } catch (error: unknown) {

--- a/src/app/api/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/nodes/[nodeId]/blocks/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireUser } from '@/lib/requireUser';
+import { CourseBuilderError, adminClient, handleCourseBuilderError } from '@/lib/courseBuilder';
+
+export async function GET(request: NextRequest, { params }: { params: { nodeId: string } }) {
+  const guard = await requireUser(request);
+  if (!guard.ok) return guard.res;
+
+  const nodeIdNum = Number(params.nodeId);
+  if (!Number.isFinite(nodeIdNum)) {
+    return NextResponse.json({ error: 'Invalid node id' }, { status: 400 });
+  }
+
+  try {
+    const { data, error } = await adminClient
+      .from('content_blocks')
+      .select('id, node_id, block_type, position, text_md, resource_id, smart_doc_id, start_ms, end_ms, label')
+      .eq('node_id', nodeIdNum)
+      .order('position', { ascending: true });
+
+    if (error) {
+      throw new CourseBuilderError('Failed to load content blocks', 500, { details: error.message, nodeId: nodeIdNum });
+    }
+
+    return NextResponse.json({ blocks: data ?? [] });
+  } catch (err) {
+    return handleCourseBuilderError(err);
+  }
+}

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -33,6 +33,16 @@ type Maps = {
   parentById: Map<number, number | null>;
 };
 
+function isContentNodeType(nodeType: string) {
+  return nodeType === 'lesson' || nodeType === 'chapter';
+}
+
+function formatContentLabel(nodeType: string) {
+  if (nodeType === 'chapter') return 'Chapter';
+  if (nodeType === 'lesson') return 'Lesson';
+  return 'Item';
+}
+
 function buildMaps(course: NodeSubtree): Maps {
   const nodeById = new Map<number, NodeSubtree>();
   const slugToId = new Map<string, number>();
@@ -79,7 +89,7 @@ function collectParentPath(nodeId: number, parentById: Map<number, number | null
   return path;
 }
 
-function findFirstUnlockedLesson(
+function findFirstUnlockedContent(
   course: NodeSubtree,
   lockMap: Record<number, Record<number, ChildUnlockStatus>>,
 ): NodeSubtree | null {
@@ -91,7 +101,7 @@ function findFirstUnlockedLesson(
       }
     }
 
-    if (subtree.node.node_type === 'lesson') {
+    if (isContentNodeType(subtree.node.node_type)) {
       return subtree;
     }
 
@@ -169,10 +179,10 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     if (state.status !== 'ready' || !maps) return;
 
     if (!lessonSlug && !redirected) {
-      const firstLesson = findFirstUnlockedLesson(state.course, lockMap);
-      if (firstLesson && firstLesson.node.slug) {
+      const firstContent = findFirstUnlockedContent(state.course, lockMap);
+      if (firstContent && firstContent.node.slug) {
         setRedirected(true);
-        router.replace(`/courses/${courseSlug}/${firstLesson.node.slug}`);
+        router.replace(`/courses/${courseSlug}/${firstContent.node.slug}`);
       }
     }
   }, [courseSlug, lessonSlug, lockMap, maps, redirected, router, state]);
@@ -181,22 +191,24 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
   const slugToId = maps?.slugToId ?? null;
   const parentById = maps?.parentById ?? null;
 
-  const requestedLessonId = lessonSlug && slugToId ? slugToId.get(lessonSlug) ?? null : null;
-  let selectedLesson: NodeSubtree | null = null;
-  let lessonError: string | null = null;
+  const requestedContentId = lessonSlug && slugToId ? slugToId.get(lessonSlug) ?? null : null;
+  let selectedContent: NodeSubtree | null = null;
+  let contentError: string | null = null;
 
-  if (requestedLessonId != null && nodeById && parentById) {
-    if (isNodeLocked(requestedLessonId, lockMap, parentById)) {
-      lessonError = 'This lesson is locked until you complete the previous required items.';
+  if (requestedContentId != null && nodeById && parentById) {
+    const candidate = nodeById.get(requestedContentId) ?? null;
+    if (!candidate || !isContentNodeType(candidate.node.node_type)) {
+      contentError = 'We couldn’t open this item.';
+    } else if (isNodeLocked(requestedContentId, lockMap, parentById)) {
+      const label = formatContentLabel(candidate.node.node_type).toLowerCase();
+      contentError = `This ${label} is locked until you complete the previous required items.`;
     } else {
-      selectedLesson = nodeById.get(requestedLessonId) ?? null;
+      selectedContent = candidate;
     }
   }
 
-  if (!selectedLesson && lessonSlug) {
-    if (!lessonError) {
-      lessonError = 'We couldn’t find this lesson.';
-    }
+  if (!selectedContent && lessonSlug && !contentError) {
+    contentError = 'We couldn’t find this item.';
   }
 
   const handleToggle = (nodeId: number) => {
@@ -211,14 +223,20 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     });
   };
 
-  const handleSelectLesson = (lesson: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => {
-    if (lockStatus?.locked) {
-      setSnackbar(lockStatus.reason ?? 'Complete the previous lesson to unlock this one.');
+  const handleSelectContent = (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => {
+    if (!isContentNodeType(node.node.node_type)) {
       return;
     }
 
-    if (!lesson.node.slug) {
-      setSnackbar('This lesson is missing a slug and cannot be opened.');
+    const label = formatContentLabel(node.node.node_type);
+
+    if (lockStatus?.locked) {
+      setSnackbar(lockStatus.reason ?? `Complete the previous ${label.toLowerCase()} to unlock this one.`);
+      return;
+    }
+
+    if (!node.node.slug) {
+      setSnackbar(`This ${label.toLowerCase()} is missing a slug and cannot be opened.`);
       return;
     }
 
@@ -227,26 +245,26 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
       return;
     }
 
-    const pathParents = collectParentPath(lesson.node.id, parentById);
+    const pathParents = collectParentPath(node.node.id, parentById);
     setExpanded((prev) => new Set([...prev, ...pathParents]));
-    router.push(`/courses/${courseSlug}/${lesson.node.slug}`);
+    router.push(`/courses/${courseSlug}/${node.node.slug}`);
   };
 
   useEffect(() => {
-    if (!selectedLesson || !parentById) return;
-    const pathParents = collectParentPath(selectedLesson.node.id, parentById);
+    if (!selectedContent || !parentById) return;
+    const pathParents = collectParentPath(selectedContent.node.id, parentById);
     setExpanded((prev) => new Set([...prev, ...pathParents]));
-  }, [parentById, selectedLesson]);
+  }, [parentById, selectedContent]);
 
   const nestedLockMap = lockMap;
-  const treeSelectedId = selectedLesson?.node.id ?? (lessonError && requestedLessonId ? requestedLessonId : null);
+  const treeSelectedId = selectedContent?.node.id ?? (contentError && requestedContentId ? requestedContentId : null);
 
   useEffect(() => {
-    if (!lessonError || !requestedLessonId || !parentById) return;
-    const pathParents = collectParentPath(requestedLessonId, parentById);
+    if (!contentError || !requestedContentId || !parentById) return;
+    const pathParents = collectParentPath(requestedContentId, parentById);
     if (pathParents.length === 0) return;
     setExpanded((prev) => new Set([...prev, ...pathParents]));
-  }, [lessonError, parentById, requestedLessonId]);
+  }, [contentError, parentById, requestedContentId]);
 
   if (state.status === 'loading') {
     return (
@@ -286,7 +304,7 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
           selectedNodeId={treeSelectedId}
           lockStatuses={nestedLockMap}
           onToggle={handleToggle}
-          onSelectLesson={handleSelectLesson}
+          onSelectContent={handleSelectContent}
           onBackToCourses={() => router.push('/courses')}
           fullHeight={false}
         />
@@ -305,7 +323,7 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
             selectedNodeId={treeSelectedId}
             lockStatuses={nestedLockMap}
             onToggle={handleToggle}
-            onSelectLesson={handleSelectLesson}
+            onSelectContent={handleSelectContent}
             onBackToCourses={() => router.push('/courses')}
           />
         </Box>
@@ -317,13 +335,13 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
                 {state.course.node.title ?? 'Course'}
               </Typography>
               <Typography color="text.secondary" sx={{ mt: 1 }}>
-                Select a lesson from the outline to start learning.
+                Select a chapter or lesson from the outline to start learning.
               </Typography>
               <Divider sx={{ my: 4 }} />
             </Box>
           )}
 
-          <LessonContent lesson={selectedLesson} loading={false} error={lessonError} />
+          <LessonContent lesson={selectedContent} loading={false} error={contentError} />
         </Box>
       </Box>
 

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -12,7 +12,6 @@ import {
   Typography,
 } from '@mui/material';
 
-import TopNav from '@/components/topNav';
 import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
 import StudentCourseTree from './StudentCourseTree';
 import LessonContent from './LessonContent';
@@ -80,40 +79,14 @@ function collectParentPath(nodeId: number, parentById: Map<number, number | null
   const path: number[] = [];
   let current: number | null | undefined = nodeId;
   while (current != null) {
-    const parent = parentById.get(current) ?? null;
+    // TS fix: annotate parent type explicitly
+    const parent: number | null = (parentById.get(current) ?? null) as number | null;
     if (parent != null) {
       path.push(parent);
     }
     current = parent;
   }
   return path;
-}
-
-function findFirstUnlockedContent(
-  course: NodeSubtree,
-  lockMap: Record<number, Record<number, ChildUnlockStatus>>,
-): NodeSubtree | null {
-  const walk = (subtree: NodeSubtree, parentId: number | null): NodeSubtree | null => {
-    if (parentId != null) {
-      const status = lockMap[parentId]?.[subtree.node.id];
-      if (status?.locked) {
-        return null;
-      }
-    }
-
-    if (isContentNodeType(subtree.node.node_type)) {
-      return subtree;
-    }
-
-    for (const child of subtree.children) {
-      const result = walk(child.subtree, subtree.node.id);
-      if (result) return result;
-    }
-
-    return null;
-  };
-
-  return walk(course, null);
 }
 
 function isNodeLocked(
@@ -128,30 +101,44 @@ function isNodeLocked(
   return !!parentLocks[nodeId]?.locked;
 }
 
+/** ------- simple per-session cache to avoid white flashes on remounts ------- */
+const courseCache = new Map<
+  string,
+  { course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]> }
+>();
+
 export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerProps) {
   const router = useRouter();
   const [state, setState] = useState<CourseState>({ status: 'loading' });
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const [snackbar, setSnackbar] = useState<string | null>(null);
-  const [redirected, setRedirected] = useState(false);
 
   useEffect(() => {
-    setRedirected(false);
     setExpanded(new Set());
   }, [courseSlug]);
 
+  // Use cache to prevent full-screen loading flash, and revalidate in background
   useEffect(() => {
     let active = true;
 
+    const cached = courseCache.get(courseSlug);
+    if (cached) {
+      setState({ status: 'ready', course: cached.course, lockStatuses: cached.lockStatuses });
+    } else {
+      setState({ status: 'loading' });
+    }
+
     (async () => {
       try {
-        const res = await fetch(`/api/courses/${courseSlug}`);
+        const res = await fetch(`/api/courses/${courseSlug}`, { cache: 'no-store' });
         if (!res.ok) {
           const data = (await res.json().catch(() => ({}))) as { error?: string };
           throw new Error(data.error ?? 'Failed to load course');
         }
         const data = (await res.json()) as { course: NodeSubtree; unlockStatuses: Record<number, ChildUnlockStatus[]> };
         if (!active) return;
+
+        courseCache.set(courseSlug, { course: data.course, lockStatuses: data.unlockStatuses });
         setState({ status: 'ready', course: data.course, lockStatuses: data.unlockStatuses });
       } catch (error) {
         if (!active) return;
@@ -174,18 +161,6 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     if (state.status !== 'ready') return {} as Record<number, Record<number, ChildUnlockStatus>>;
     return toNestedLockMap(state.lockStatuses);
   }, [state]);
-
-  useEffect(() => {
-    if (state.status !== 'ready' || !maps) return;
-
-    if (!lessonSlug && !redirected) {
-      const firstContent = findFirstUnlockedContent(state.course, lockMap);
-      if (firstContent && firstContent.node.slug) {
-        setRedirected(true);
-        router.replace(`/courses/${courseSlug}/${firstContent.node.slug}`);
-      }
-    }
-  }, [courseSlug, lessonSlug, lockMap, maps, redirected, router, state]);
 
   const nodeById = maps?.nodeById ?? null;
   const slugToId = maps?.slugToId ?? null;
@@ -224,9 +199,7 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
   };
 
   const handleSelectContent = (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => {
-    if (!isContentNodeType(node.node.node_type)) {
-      return;
-    }
+    if (!isContentNodeType(node.node.node_type)) return;
 
     const label = formatContentLabel(node.node.node_type);
 
@@ -266,14 +239,31 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     setExpanded((prev) => new Set([...prev, ...pathParents]));
   }, [contentError, parentById, requestedContentId]);
 
+  // ----- inline skeleton instead of white full-page -----
   if (state.status === 'loading') {
     return (
-      <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50' }}>
-        <TopNav />
-        <Stack alignItems="center" spacing={2} sx={{ py: 12 }}>
-          <CircularProgress />
-          <Typography color="text.secondary">Loading course…</Typography>
-        </Stack>
+      <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50', display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+          <Box sx={{ p: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="body2" color="text.secondary">Loading outline…</Typography>
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
+          <Box
+            sx={{
+              width: { xs: 0, md: 340 },
+              display: { xs: 'none', md: 'block' },
+              borderRight: '1px solid',
+              borderColor: 'divider',
+            }}
+          />
+          <Box sx={{ flex: 1, minWidth: 0, bgcolor: 'background.default' }}>
+            <Stack alignItems="center" spacing={2} sx={{ py: 12 }}>
+              <CircularProgress />
+              <Typography color="text.secondary">Loading course…</Typography>
+            </Stack>
+          </Box>
+        </Box>
       </Box>
     );
   }
@@ -281,7 +271,6 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
   if (state.status === 'error') {
     return (
       <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50' }}>
-        <TopNav />
         <Stack alignItems="center" spacing={2} sx={{ py: 12 }}>
           <Typography variant="h6">We couldn’t load this course.</Typography>
           <Typography color="text.secondary">{state.message}</Typography>
@@ -296,7 +285,6 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50', display: 'flex', flexDirection: 'column' }}>
-      <TopNav />
       <Box sx={{ display: { xs: 'block', md: 'none' } }}>
         <StudentCourseTree
           course={state.course}
@@ -309,13 +297,8 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
           fullHeight={false}
         />
       </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flex: 1,
-          minHeight: 0,
-        }}
-      >
+
+      <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
         <Box sx={{ width: { xs: 0, md: 340 }, display: { xs: 'none', md: 'flex' } }}>
           <StudentCourseTree
             course={state.course}

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -13,16 +13,13 @@ type LessonContentProps = {
   error?: string | null;
 };
 
-type ResourceState = 'idle' | 'loading' | 'ready' | 'error';
+type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+type ResourceState = LoadState;
 
 function getContentLabels(node: NodeSubtree | null) {
   const type = node?.node.node_type;
-  if (type === 'chapter') {
-    return { title: 'Chapter', lower: 'chapter' };
-  }
-  if (type === 'lesson') {
-    return { title: 'Lesson', lower: 'lesson' };
-  }
+  if (type === 'chapter') return { title: 'Chapter', lower: 'chapter' };
+  if (type === 'lesson') return { title: 'Lesson', lower: 'lesson' };
   return { title: 'Item', lower: 'item' };
 }
 
@@ -41,20 +38,69 @@ function toRenderableBlock(block: ContentBlock): RenderableBlock {
 }
 
 export default function LessonContent({ lesson, loading, error }: LessonContentProps) {
+  // Lazily loaded blocks for the currently selected lesson/chapter
+  const [blocks, setBlocks] = useState<RenderableBlock[]>([]);
+  const [blocksState, setBlocksState] = useState<LoadState>('idle');
+  const [blocksError, setBlocksError] = useState<string | null>(null);
+
+  // Media resources for asset blocks
   const [resources, setResources] = useState<Record<number, RenderableResource>>({});
   const [resourceState, setResourceState] = useState<ResourceState>('idle');
   const [resourceError, setResourceError] = useState<string | null>(null);
 
   const labels = getContentLabels(lesson);
 
-  const assetBlockIds = useMemo(() => {
-    if (!lesson) return [] as number[];
-    return lesson.blocks
-      .filter((block) => block.block_type === 'asset' && block.resource_id)
-      .map((block) => block.resource_id!)
-      .filter((id, index, arr) => arr.indexOf(id) === index);
+  // ===== 1) Lazy-load blocks whenever the selected node changes =====
+  useEffect(() => {
+    if (!lesson) {
+      setBlocks([]);
+      setBlocksState('idle');
+      setBlocksError(null);
+      return;
+    }
+
+    let active = true;
+    setBlocksState('loading');
+    setBlocksError(null);
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/nodes/${lesson.node.id}/blocks`);
+        if (!active) return;
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data?.error ?? 'Failed to load blocks');
+        }
+
+        const { blocks } = (await res.json()) as { blocks: ContentBlock[] };
+        if (!active) return;
+
+        const renderable = (blocks ?? []).map(toRenderableBlock).sort((a, b) => a.position - b.position);
+        setBlocks(renderable);
+        setBlocksState('ready');
+      } catch (e) {
+        if (!active) return;
+        setBlocks([]);
+        setBlocksState('error');
+        setBlocksError(e instanceof Error ? e.message : 'Failed to load blocks');
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
   }, [lesson]);
 
+  // Compute unique resource IDs from the *loaded blocks* (not from lesson.blocks)
+  const assetBlockIds = useMemo(() => {
+    return blocks
+      .filter((b) => b.block_type === 'asset' && b.resource_id)
+      .map((b) => b.resource_id!)
+      .filter((id, idx, arr) => arr.indexOf(id) === idx);
+  }, [blocks]);
+
+  // ===== 2) Load media resources for those asset blocks =====
   useEffect(() => {
     if (!lesson || assetBlockIds.length === 0) {
       setResources({});
@@ -102,6 +148,7 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
     };
   }, [assetBlockIds, lesson]);
 
+  // ===== Top-level loading/error/empty states =====
   if (loading) {
     return (
       <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
@@ -130,7 +177,6 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
     );
   }
 
-  const blocks = lesson.blocks.map(toRenderableBlock).sort((a, b) => a.position - b.position);
   const showResourceAlert = resourceState === 'error' && resourceError;
 
   return (
@@ -150,15 +196,31 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
           ) : null}
         </Box>
 
-        {blocks.length === 0 ? (
-          <Alert severity="info">This {labels.lower} doesn’t have any blocks yet.</Alert>
-        ) : (
-          <Stack spacing={3}>
-            {blocks.map((block) => {
-              const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
-              return <BlockRenderer key={block.id} block={block} resource={resource} previewMode />;
-            })}
+        {/* Blocks load state */}
+        {blocksState === 'loading' && (
+          <Stack alignItems="center" spacing={1}>
+            <CircularProgress size={20} />
+            <Typography variant="body2" color="text.secondary">
+              Loading content…
+            </Typography>
           </Stack>
+        )}
+
+        {blocksState === 'error' && <Alert severity="warning">{blocksError}</Alert>}
+
+        {blocksState === 'ready' && (
+          <>
+            {blocks.length === 0 ? (
+              <Alert severity="info">This {labels.lower} doesn’t have any blocks yet.</Alert>
+            ) : (
+              <Stack spacing={3}>
+                {blocks.map((block) => {
+                  const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
+                  return <BlockRenderer key={block.id} block={block} resource={resource} previewMode />;
+                })}
+              </Stack>
+            )}
+          </>
         )}
 
         {resourceState === 'loading' ? (

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -15,6 +15,17 @@ type LessonContentProps = {
 
 type ResourceState = 'idle' | 'loading' | 'ready' | 'error';
 
+function getContentLabels(node: NodeSubtree | null) {
+  const type = node?.node.node_type;
+  if (type === 'chapter') {
+    return { title: 'Chapter', lower: 'chapter' };
+  }
+  if (type === 'lesson') {
+    return { title: 'Lesson', lower: 'lesson' };
+  }
+  return { title: 'Item', lower: 'item' };
+}
+
 function toRenderableBlock(block: ContentBlock): RenderableBlock {
   return {
     id: block.id,
@@ -33,6 +44,8 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
   const [resources, setResources] = useState<Record<number, RenderableResource>>({});
   const [resourceState, setResourceState] = useState<ResourceState>('idle');
   const [resourceError, setResourceError] = useState<string | null>(null);
+
+  const labels = getContentLabels(lesson);
 
   const assetBlockIds = useMemo(() => {
     if (!lesson) return [] as number[];
@@ -93,7 +106,7 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
     return (
       <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
         <CircularProgress />
-        <Typography color="text.secondary">Loading lesson…</Typography>
+        <Typography color="text.secondary">Loading {labels.lower}…</Typography>
       </Stack>
     );
   }
@@ -109,9 +122,9 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
   if (!lesson) {
     return (
       <Stack alignItems="center" spacing={2} sx={{ py: 10 }}>
-        <Typography variant="h6">Select a lesson to get started</Typography>
+        <Typography variant="h6">Select a chapter or lesson to get started</Typography>
         <Typography color="text.secondary" align="center">
-          Choose an unlocked lesson from the outline to explore its content.
+          Choose an unlocked chapter or lesson from the outline to explore its content.
         </Typography>
       </Stack>
     );
@@ -125,10 +138,10 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
       <Stack spacing={3} sx={{ maxWidth: 860, mx: 'auto', px: { xs: 2, md: 4 } }}>
         <Box>
           <Typography variant="overline" sx={{ color: 'primary.main', fontWeight: 600 }}>
-            Lesson
+            {labels.title}
           </Typography>
           <Typography variant="h3" sx={{ fontWeight: 700 }}>
-            {lesson.node.title ?? 'Untitled lesson'}
+            {lesson.node.title ?? `Untitled ${labels.lower}`}
           </Typography>
           {lesson.node.description ? (
             <Typography color="text.secondary" sx={{ mt: 1 }}>
@@ -138,7 +151,7 @@ export default function LessonContent({ lesson, loading, error }: LessonContentP
         </Box>
 
         {blocks.length === 0 ? (
-          <Alert severity="info">This lesson doesn’t have any blocks yet.</Alert>
+          <Alert severity="info">This {labels.lower} doesn’t have any blocks yet.</Alert>
         ) : (
           <Stack spacing={3}>
             {blocks.map((block) => {

--- a/src/components/course/StudentCourseTree.tsx
+++ b/src/components/course/StudentCourseTree.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import {
   Box,
   Button,
@@ -25,7 +25,7 @@ import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 
 import type { ChildUnlockStatus, NodeSubtree } from '@/types/course';
 
-const NODE_ICONS: Record<string, JSX.Element> = {
+const NODE_ICONS: Record<string, React.ReactNode> = {
   course: <MenuBookIcon fontSize="small" />,
   lesson: <ArticleIcon fontSize="small" />,
   chapter: <LayersIcon fontSize="small" />,
@@ -53,6 +53,7 @@ type TreeNodeProps = {
   parentId: number | null;
   onToggle: (nodeId: number) => void;
   onSelectContent: (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
+  prefetchBlocks: (nodeId: number) => void;
 };
 
 function TreeNode({
@@ -64,6 +65,7 @@ function TreeNode({
   parentId,
   onToggle,
   onSelectContent,
+  prefetchBlocks,
 }: TreeNodeProps) {
   const { node } = subtree;
   const hasChildren = subtree.children.length > 0;
@@ -74,25 +76,22 @@ function TreeNode({
   const isSelected = selectedNodeId === node.id;
   const paddingLeft = 2 + depth * 2;
   const isContentNode = node.node_type === 'lesson' || node.node_type === 'chapter';
+  const canPrefetch = isContentNode && !isLocked;
 
   const handleClick = () => {
     if (isContentNode) {
+      if (canPrefetch) prefetchBlocks(node.id); // warm request just before navigate
       onSelectContent(subtree, lockStatus);
-      if (!hasChildren) {
-        return;
-      }
+      if (!hasChildren) return;
     }
-
-    if (hasChildren) {
-      if (!isExpanded) {
-        onToggle(node.id);
-      }
-    }
+    if (hasChildren && !isExpanded) onToggle(node.id);
   };
 
   const item = (
     <ListItemButton
       onClick={handleClick}
+      onMouseEnter={() => { if (canPrefetch) prefetchBlocks(node.id); }}
+      onFocus={() => { if (canPrefetch) prefetchBlocks(node.id); }}
       selected={isSelected}
       sx={{
         pl: paddingLeft,
@@ -156,6 +155,7 @@ function TreeNode({
                 parentId={subtree.node.id}
                 onToggle={onToggle}
                 onSelectContent={onSelectContent}
+                prefetchBlocks={prefetchBlocks}
               />
             ))}
           </List>
@@ -176,14 +176,26 @@ export default function StudentCourseTree({
   fullHeight = true,
 }: StudentCourseTreeProps) {
   const sequentialUnlock = !!course.node.sequential_unlock;
-  const childLocks = useMemo(
-    () => lockStatuses[course.node.id] ?? {},
-    [course.node.id, lockStatuses],
-  );
+  const childLocks = useMemo(() => lockStatuses[course.node.id] ?? {}, [course.node.id, lockStatuses]);
   const unlockedCount = useMemo(
     () => Object.values(childLocks).filter((status) => !status.locked).length,
     [childLocks],
   );
+
+  // Fire-and-forget prefetcher; uses browser cache or HTTP cache
+  const prefetchBlocks = (nodeId: number) => {
+    const run = () => { void fetch(`/api/nodes/${nodeId}/blocks`, { cache: 'force-cache' }).catch(() => {}); };
+    if (typeof window !== 'undefined') {
+      const ric = (window as any).requestIdleCallback as
+        | undefined
+        | ((cb: () => void, opts?: { timeout: number }) => number);
+      if (ric) {
+        ric(run, { timeout: 500 });
+        return;
+      }
+    }
+    run();
+  };
 
   return (
     <Box
@@ -229,6 +241,7 @@ export default function StudentCourseTree({
               parentId={course.node.id}
               onToggle={onToggle}
               onSelectContent={onSelectContent}
+              prefetchBlocks={prefetchBlocks}
             />
           ))}
         </List>

--- a/src/components/course/StudentCourseTree.tsx
+++ b/src/components/course/StudentCourseTree.tsx
@@ -39,7 +39,7 @@ type StudentCourseTreeProps = {
   selectedNodeId: number | null;
   lockStatuses: Record<number, Record<number, ChildUnlockStatus>>;
   onToggle: (nodeId: number) => void;
-  onSelectLesson: (lesson: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
+  onSelectContent: (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
   onBackToCourses: () => void;
   fullHeight?: boolean;
 };
@@ -52,7 +52,7 @@ type TreeNodeProps = {
   selectedNodeId: number | null;
   parentId: number | null;
   onToggle: (nodeId: number) => void;
-  onSelectLesson: (lesson: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
+  onSelectContent: (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
 };
 
 function TreeNode({
@@ -63,7 +63,7 @@ function TreeNode({
   selectedNodeId,
   parentId,
   onToggle,
-  onSelectLesson,
+  onSelectContent,
 }: TreeNodeProps) {
   const { node } = subtree;
   const hasChildren = subtree.children.length > 0;
@@ -73,14 +73,20 @@ function TreeNode({
   const icon = NODE_ICONS[node.node_type] ?? NODE_ICONS.lesson;
   const isSelected = selectedNodeId === node.id;
   const paddingLeft = 2 + depth * 2;
+  const isContentNode = node.node_type === 'lesson' || node.node_type === 'chapter';
 
   const handleClick = () => {
-    if (hasChildren) {
-      onToggle(node.id);
-      return;
+    if (isContentNode) {
+      onSelectContent(subtree, lockStatus);
+      if (!hasChildren) {
+        return;
+      }
     }
-    if (node.node_type === 'lesson') {
-      onSelectLesson(subtree, lockStatus);
+
+    if (hasChildren) {
+      if (!isExpanded) {
+        onToggle(node.id);
+      }
     }
   };
 
@@ -120,8 +126,8 @@ function TreeNode({
       <ListItemText
         primary={node.title ?? 'Untitled'}
         primaryTypographyProps={{
-          variant: node.node_type === 'lesson' ? 'body1' : 'subtitle2',
-          fontWeight: node.node_type === 'lesson' ? 600 : 500,
+          variant: isContentNode ? 'body1' : 'subtitle2',
+          fontWeight: isContentNode ? 600 : 500,
         }}
       />
 
@@ -149,7 +155,7 @@ function TreeNode({
                 selectedNodeId={selectedNodeId}
                 parentId={subtree.node.id}
                 onToggle={onToggle}
-                onSelectLesson={onSelectLesson}
+                onSelectContent={onSelectContent}
               />
             ))}
           </List>
@@ -165,7 +171,7 @@ export default function StudentCourseTree({
   selectedNodeId,
   lockStatuses,
   onToggle,
-  onSelectLesson,
+  onSelectContent,
   onBackToCourses,
   fullHeight = true,
 }: StudentCourseTreeProps) {
@@ -222,7 +228,7 @@ export default function StudentCourseTree({
               selectedNodeId={selectedNodeId}
               parentId={course.node.id}
               onToggle={onToggle}
-              onSelectLesson={onSelectLesson}
+              onSelectContent={onSelectContent}
             />
           ))}
         </List>

--- a/src/lib/courseBuilder.ts
+++ b/src/lib/courseBuilder.ts
@@ -59,14 +59,13 @@ export type NodeSubtree = {
 export async function fetchNodeById(nodeId: number) {
   const { data, error } = await adminClient
     .from('content_nodes')
-    .select('*')
+    .select('id, node_type, title, slug, description, state, sequential_unlock')
     .eq('id', nodeId)
     .maybeSingle();
 
   if (error) {
     throw new CourseBuilderError('Failed to load node', 500, { details: error.message, nodeId });
   }
-
   if (!data) {
     throw new CourseBuilderError('Node not found', 404, { nodeId });
   }
@@ -74,10 +73,11 @@ export async function fetchNodeById(nodeId: number) {
   return data as ContentNodeRow;
 }
 
+
 async function fetchNodeChildren(parentId: number) {
   const { data, error } = await adminClient
     .from('node_children')
-    .select('*')
+    .select('parent_id, child_id, position, is_required, label, notes')
     .eq('parent_id', parentId)
     .order('position', { ascending: true });
 
@@ -87,6 +87,7 @@ async function fetchNodeChildren(parentId: number) {
 
   return (data ?? []) as NodeChildRow[];
 }
+
 
 async function fetchNodeBlocks(nodeId: number) {
   const { data, error } = await adminClient
@@ -119,32 +120,48 @@ export async function fetchBlockById(blockId: number) {
 
   return data as ContentBlockRow;
 }
+export async function fetchNodeSubtree(
+  nodeId: number,
+  opts: { includeBlocks?: boolean; allowUnpublished?: boolean } = {},
+  visited = new Set<number>()
+): Promise<NodeSubtree> {
+  const includeBlocks = opts.includeBlocks ?? true;        // Builder default: include blocks
+  const allowUnpublished = opts.allowUnpublished ?? true;  // Builder default: show drafts
 
-export async function fetchNodeSubtree(nodeId: number, visited = new Set<number>()): Promise<NodeSubtree> {
   if (visited.has(nodeId)) {
     throw new CourseBuilderError('Cycle detected in node hierarchy', 500, { nodeId });
   }
-
   visited.add(nodeId);
 
+  // 1) Fetch node (minimal columns are fine)
   const node = await fetchNodeById(nodeId);
-  const blocks = await fetchNodeBlocks(nodeId);
+
+  // 2) For student view we may hide unpublished; builder keeps them
+  if (!allowUnpublished && node.state !== 'published') {
+    visited.delete(nodeId);
+    return { node, blocks: [], children: [] };
+  }
+
+  // 3) Children (always needed for the tree)
   const children = await fetchNodeChildren(nodeId);
 
-  const childSubtrees = [] as NodeSubtree['children'];
-  for (const child of children) {
-    const subtree = await fetchNodeSubtree(child.child_id, visited);
-    childSubtrees.push({ edge: child, subtree });
-  }
+  // 4) Recurse with same options
+  const childSubtrees = await Promise.all(
+    children.map(async (child) => {
+      const subtree = await fetchNodeSubtree(child.child_id, opts, visited);
+      return { edge: child, subtree };
+    })
+  );
 
   visited.delete(nodeId);
 
-  return {
-    node,
-    blocks,
-    children: childSubtrees,
-  };
+  // 5) Include blocks only when requested (builder) — student view passes includeBlocks:false
+  const blocks = includeBlocks ? await fetchNodeBlocks(nodeId) : [];
+
+  return { node, blocks, children: childSubtrees };
 }
+
+
 
 export async function validateNodeRelationship(parentId: number, childNodeType: string) {
   const parent = await fetchNodeById(parentId);


### PR DESCRIPTION
## Summary
- allow StudentCourseTree to invoke selection for chapter content and adjust outline styling
- generalize CourseViewer logic so chapters resolve, unlock, and navigate like lessons
- update the lesson content panel messaging so chapter details render with the correct labels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0e91ee7ac8332bc3ee4f20cebbaf5