### PR TITLE
Fix Smart Doc submission gating and progress display

### DIFF
--- a/src/app/api/courses/[courseSlug]/unlocks/route.ts
+++ b/src/app/api/courses/[courseSlug]/unlocks/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireUser } from '@/lib/requireUser';
+import { adminClient } from '@/lib/courseBuilder';
+import type { ChildUnlockStatus } from '@/types/course';
+
+// Assumes DB RPC: get_child_unlock_status_bulk(_parent_ids bigint[], _user_id uuid)
+export async function POST(request: NextRequest, { params }: { params: { courseSlug: string } }) {
+  const guard = await requireUser(request);
+  if (!guard.ok) return guard.res;
+
+  const body = await request.json().catch(() => null) as { parentIds?: number[] } | null;
+  const parentIds = (body?.parentIds ?? []).filter((n) => Number.isFinite(n)) as number[];
+  if (parentIds.length === 0) {
+    return NextResponse.json({ unlockStatuses: {} });
+  }
+
+  const { data, error } = await adminClient.rpc('get_child_unlock_status_bulk', {
+    _parent_ids: parentIds,
+    _user_id: guard.user.id,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: 'Unlock refresh failed', details: error.message }, { status: 500 });
+  }
+
+  const unlockStatuses: Record<number, ChildUnlockStatus[]> = {};
+  for (const row of (data ?? []) as Array<{
+    parent_id: number; child_id: number; child_position: number; is_required: boolean; locked: boolean; reason: string | null;
+  }>) {
+    if (!unlockStatuses[row.parent_id]) unlockStatuses[row.parent_id] = [];
+    unlockStatuses[row.parent_id].push({
+      child_id: row.child_id,
+      child_position: row.child_position,
+      is_required: row.is_required,
+      locked: row.locked,
+      reason: row.reason ?? null,
+    });
+  }
+
+  // Keep children ordered for the UI
+  for (const pid of Object.keys(unlockStatuses)) {
+    unlockStatuses[+pid].sort((a, b) => a.child_position - b.child_position);
+  }
+
+  return NextResponse.json({ unlockStatuses });
+}

--- a/src/app/api/progress/route.ts
+++ b/src/app/api/progress/route.ts
@@ -16,11 +16,15 @@ export async function POST(request: NextRequest) {
 
   try {
     if (body.action === 'start') {
-      const { error } = await supabase.rpc('mark_node_started', { _node_id: body.nodeId });
-      if (error) throw new Error(error.message);
+      const { error } = await supabase.rpc('mark_node_started', {
+        _node_id: body.nodeId,
+      });
+      if (error) throw new Error(`mark_node_started failed: ${error.message}`);
     } else {
-      const { error } = await supabase.rpc('mark_node_completed', { _node_id: body.nodeId });
-      if (error) throw new Error(error.message);
+      const { error } = await supabase.rpc('mark_node_completed', {
+        _node_id: body.nodeId,
+      });
+      if (error) throw new Error(`mark_node_completed failed: ${error.message}`);
     }
     return NextResponse.json({ ok: true });
   } catch (e) {

--- a/src/app/api/smartdoc/submit/route.ts
+++ b/src/app/api/smartdoc/submit/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
+
 import { requireUser } from '@/lib/requireUser';
+
+type ResponseRow = {
+  id: number;
+  status: 'draft' | 'submitted';
+  submitted_at: string | null;
+};
 
 export async function POST(req: NextRequest) {
   const guard = await requireUser(req);
@@ -11,15 +18,72 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'content_block_id is required' }, { status: 400 });
   }
 
-  const { data, error } = await supabase.rpc('submit_smart_doc', {
+  const now = new Date().toISOString();
+
+  const { data: existing, error: existingError } = await supabase
+    .from('smart_doc_responses')
+    .select('id, status, submitted_at')
+    .eq('content_block_id', body.content_block_id)
+    .eq('user_id', user.id)
+    .maybeSingle<ResponseRow>();
+
+  if (existingError) {
+    return NextResponse.json({ error: 'Submit failed', details: existingError.message }, { status: 500 });
+  }
+
+  let responseRow: ResponseRow | null = existing ?? null;
+
+  if (responseRow?.id) {
+    const { data: updated, error: updateError } = await supabase
+      .from('smart_doc_responses')
+      .update({ status: 'submitted', submitted_at: now })
+      .eq('id', responseRow.id)
+      .select('id, status, submitted_at')
+      .single<ResponseRow>();
+
+    if (updateError) {
+      return NextResponse.json({ error: 'Submit failed', details: updateError.message }, { status: 500 });
+    }
+
+    responseRow = updated ?? { id: responseRow.id, status: 'submitted', submitted_at: now };
+  } else {
+    const { data: inserted, error: insertError } = await supabase
+      .from('smart_doc_responses')
+      .insert({
+        content_block_id: body.content_block_id,
+        user_id: user.id,
+        status: 'submitted',
+        submitted_at: now,
+      })
+      .select('id, status, submitted_at')
+      .single<ResponseRow>();
+
+    if (insertError) {
+      return NextResponse.json({ error: 'Submit failed', details: insertError.message }, { status: 500 });
+    }
+
+    responseRow = inserted ?? null;
+  }
+
+  const { data: progress, error: progressError } = await supabase.rpc('get_smart_doc_progress', {
     _content_block_id: body.content_block_id,
     _user_id: user.id,
   });
 
-  if (error) {
-    return NextResponse.json({ error: 'Submit failed', details: error.message }, { status: 500 });
+  if (progressError) {
+    // Progress metrics are nice-to-have; log and continue with defaults.
+    console.error('smartdoc progress fetch failed after submit', progressError);
   }
 
-  // data should include { fields_total, fields_completed, status, submitted_at }
-  return NextResponse.json({ result: data });
+  const fields_total = typeof progress?.fields_total === 'number' ? progress.fields_total : 0;
+  const fields_completed = typeof progress?.fields_completed === 'number' ? progress.fields_completed : 0;
+
+  return NextResponse.json({
+    result: {
+      fields_total,
+      fields_completed,
+      status: responseRow?.status ?? 'submitted',
+      submitted_at: responseRow?.submitted_at ?? now,
+    },
+  });
 }

--- a/src/components/admin/courseEditor/state/editorStore.tsx
+++ b/src/components/admin/courseEditor/state/editorStore.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from 'react';
 
 export type SavingState = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -13,9 +21,9 @@ export type EditorStoreValue = {
   savingState: SavingState;
   savingMessage: string;
   editorMode: EditorMode;
-  setSelectedNodeId: (nodeId: number | null) => void;
-  setSelectedBlockId: (blockId: number | null) => void;
-  setEditingBlockId: (blockId: number | null) => void;
+  setSelectedNodeId: Dispatch<SetStateAction<number | null>>;
+  setSelectedBlockId: Dispatch<SetStateAction<number | null>>;
+  setEditingBlockId: Dispatch<SetStateAction<number | null>>;
   setSavingState: (state: SavingState, message?: string) => void;
   setEditorMode: (mode: EditorMode) => void;
 };

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useLayoutEffect } from 'react';
 import DOMPurify from 'dompurify';
 import {
   Box,
@@ -125,6 +125,17 @@ export type BlockRendererProps = {
   onSmartDocProgress?: (contentBlockId: number, progress: SmartDocClientProgress) => void;
 };
 
+/** --------------------------------------------------------------------------- */
+/** Tiny in-memory cache per SmartDoc placement to hide StrictMode double-mount */
+type SmartDocCacheEntry = {
+  state: SmartDocState;
+  values: Record<number, string>;
+  submitted: boolean;
+};
+const smartDocCache = new Map<string, SmartDocCacheEntry>();
+const cacheKeyFor = (contentBlockId: number, docId: number) => `${contentBlockId}:${docId}`;
+/** --------------------------------------------------------------------------- */
+
 function SmartDocPromptField({
   prompt,
   value,
@@ -170,10 +181,9 @@ function SmartDocPromptField({
     </FormControl>
   );
 }
-
 function SmartDocPreview({
   docId,
-  contentBlockId, // <--- NEW: placement id (content_blocks.id)
+  contentBlockId, // placement id (content_blocks.id)
   fallbackLabel,
   onProgressChange,
 }: {
@@ -183,101 +193,134 @@ function SmartDocPreview({
   onProgressChange?: (progress: SmartDocClientProgress) => void;
 }) {
   const [state, setState] = useState<SmartDocState>({ status: 'idle' });
-
-  // Values keyed by prompt_id (string to handle TextField value)
   const [values, setValues] = useState<Record<number, string>>({});
   const [submitted, setSubmitted] = useState(false);
-
-  // Debounce timers per prompt
   const timers = useRef<Record<number, number | undefined>>({});
 
+  // Identity for this placement/doc
+  const renderKey = `${contentBlockId}:${docId}`;
+  const lastKeyRef = useRef(renderKey);
+  const identityChanged = lastKeyRef.current !== renderKey;
+
+  // EARLY GUARD: if identity changed, don't render stale content even for a frame
+  if (identityChanged) {
+    const wrapSx = { maxWidth: 920, mx: 'auto', px: { xs: 2, sm: 0 } } as const;
+    return (
+      <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ ...wrapSx, py: 4 }}>
+        <CircularProgress size={22} />
+        <Typography variant="body2" color="text.secondary">Loading…</Typography>
+      </Stack>
+    );
+  }
+
+  // Reset state BEFORE paint when identity changes
+  useLayoutEffect(() => {
+    if (!identityChanged) return;
+    lastKeyRef.current = renderKey;
+    setState({ status: 'loading' });
+    setValues({});
+    setSubmitted(false);
+  }, [identityChanged, renderKey]);
+
+  // Fetch doc + status + values together; only set "ready" once everything is in
   useEffect(() => {
     let active = true;
-    setState({ status: 'loading' });
 
-    (async () => {
-      // 1) load doc + prompts
-      const { data, error } = await supabase
-        .from('smart_docs')
-        .select(
-          `id, title, description, is_published, smart_doc_prompts:smart_doc_prompts (
-            id, position, label, prompt_type, help_text, required
-          )`,
-        )
-        .eq('id', docId)
-        .single();
-
-      if (!active) return;
-
-      if (error || !data) {
-        setState({ status: 'error', message: error?.message ?? 'Smart doc not found' });
-        return;
-      }
-
-      const rawPrompts = (data.smart_doc_prompts ?? []) as SmartDocPromptRow[];
-      const prompts: SmartDocPrompt[] = (rawPrompts ?? [])
-        .map((p): SmartDocPrompt => ({
-          id: p.id,
-          position: p.position,
-          label: p.label ?? '',
-          prompt_type: p.prompt_type,
-          help_text: p.help_text,
-          required: true,
-        }))
-        .sort((a, b) => a.position - b.position);
-
-      setState({
-        status: 'ready',
-        doc: {
-          id: data.id,
-          title: data.title,
-          description: data.description,
-          is_published: data.is_published,
-          prompts,
-        },
-      });
-
-      // 2) load existing submission status
+    async function loadAll() {
       try {
-        const statusRes = await fetch('/api/smartdoc/status', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ content_block_id: contentBlockId }),
+        // 1) Doc + prompts
+        const { data, error } = await supabase
+          .from('smart_docs')
+          .select(
+            `id, title, description, is_published, smart_doc_prompts:smart_doc_prompts (
+              id, position, label, prompt_type, help_text, required
+            )`,
+          )
+          .eq('id', docId)
+          .single();
+
+        if (!active) return;
+        if (error || !data) {
+          setState({ status: 'error', message: error?.message ?? 'Smart doc not found' });
+          return;
+        }
+
+        const rawPrompts = (data.smart_doc_prompts ?? []) as SmartDocPromptRow[];
+        const prompts: SmartDocPrompt[] = (rawPrompts ?? [])
+          .map((p): SmartDocPrompt => ({
+            id: p.id,
+            position: p.position,
+            label: p.label ?? '',
+            prompt_type: p.prompt_type,
+            help_text: p.help_text,
+            required: true, // product decision: all required
+          }))
+          .sort((a, b) => a.position - b.position);
+
+        // 2) In parallel: status + values (two-step for values)
+        const statusPromise = (async () => {
+          try {
+            const res = await fetch('/api/smartdoc/status', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ content_block_id: contentBlockId }),
+            });
+            if (!res.ok) return { status: 'draft' as const, submitted_at: null as string | null };
+            return (await res.json()) as { status: 'draft' | 'submitted'; submitted_at: string | null };
+          } catch {
+            return { status: 'draft' as const, submitted_at: null as string | null };
+          }
+        })();
+
+        const valuesPromise = (async () => {
+          // envelope row
+          const { data: resp, error: respErr } = await supabase
+            .from('smart_doc_responses')
+            .select('id')
+            .eq('content_block_id', contentBlockId)
+            .maybeSingle();
+
+          if (respErr || !resp?.id) return {} as Record<number, string>;
+
+          const { data: vals } = await supabase
+            .from('smart_doc_response_values')
+            .select('prompt_id, value_json')
+            .eq('response_id', resp.id);
+
+          const map: Record<number, string> = {};
+          for (const row of vals ?? []) {
+            map[row.prompt_id] =
+              typeof row.value_json === 'string'
+                ? row.value_json
+                : row.value_json?.value ?? row.value_json?.text ?? '';
+          }
+          return map;
+        })();
+
+        const [statusData, valueMap] = await Promise.all([statusPromise, valuesPromise]);
+        if (!active) return;
+
+        // Set everything in one go; avoid intermediate "ready with empty values"
+        setSubmitted(statusData.status === 'submitted');
+        setValues(valueMap);
+
+        setState({
+          status: 'ready',
+          doc: {
+            id: data.id,
+            title: data.title,
+            description: data.description,
+            is_published: data.is_published,
+            prompts,
+          },
         });
-        if (statusRes.ok) {
-          const s = (await statusRes.json()) as { status: 'draft' | 'submitted' };
-          if (active) setSubmitted(s.status === 'submitted');
-        }
-      } catch {
-        /* ignore */
+      } catch (e) {
+        if (!active) return;
+        setState({ status: 'error', message: e instanceof Error ? e.message : 'Failed to load smart doc' });
       }
+    }
 
-      // 3) load existing values for this content_block_id (current user via RLS)
-      //   first get (or not) the envelope row id
-      const { data: resp, error: respErr } = await supabase
-        .from('smart_doc_responses')
-        .select('id')
-        .eq('content_block_id', contentBlockId)
-        .maybeSingle();
-
-      if (!active) return;
-
-      if (!respErr && resp?.id) {
-        const { data: vals } = await supabase
-          .from('smart_doc_response_values')
-          .select('prompt_id, value_json')
-          .eq('response_id', resp.id);
-
-        const next: Record<number, string> = {};
-        for (const row of vals ?? []) {
-          next[row.prompt_id] =
-            typeof row.value_json === 'string'
-              ? row.value_json
-              : row.value_json?.value ?? row.value_json?.text ?? '';
-        }
-        if (active) setValues(next);
-      }
-    })();
+    void loadAll();
 
     return () => {
       active = false;
@@ -287,18 +330,14 @@ function SmartDocPreview({
       }
       timers.current = {};
     };
-  }, [docId, contentBlockId]);
+  }, [renderKey, docId, contentBlockId]);
 
+  // ----- progress snapshot -----
   const progressSnapshot = useMemo<SmartDocClientProgress | null>(() => {
     if (state.status !== 'ready') return null;
-    const prompts = state.doc.prompts;
-    const total = prompts.length;
-    const completed = prompts.filter((p) => (values[p.id]?.trim()?.length ?? 0) > 0).length;
-    return {
-      total,
-      completed,
-      isComplete: total > 0 && completed === total,
-    };
+    const total = state.doc.prompts.length;
+    const completed = state.doc.prompts.filter((p) => (values[p.id]?.trim()?.length ?? 0) > 0).length;
+    return { total, completed, isComplete: total > 0 && completed === total };
   }, [state, values]);
 
   useEffect(() => {
@@ -306,32 +345,29 @@ function SmartDocPreview({
     onProgressChange(progressSnapshot);
   }, [progressSnapshot, onProgressChange]);
 
-  if (state.status !== 'ready') {
+  // Guard against stale ready doc
+  const isDocMismatch = state.status === 'ready' && state.doc.id !== docId;
+
+  if (state.status !== 'ready' || isDocMismatch) {
     const wrapSx = { maxWidth: 920, mx: 'auto', px: { xs: 2, sm: 0 } } as const;
 
-    switch (state.status) {
-      case 'idle':
-      case 'loading':
-        return (
-          <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ ...wrapSx, py: 4 }}>
-            <CircularProgress size={22} />
-            <Typography variant="body2" color="text.secondary">
-              Loading…
-            </Typography>
-          </Stack>
-        );
-      case 'error':
-        return (
-          <Stack spacing={1} sx={{ ...wrapSx, py: 2 }}>
-            <Typography variant="h6">{fallbackLabel ?? 'Smart doc'}</Typography>
-            <Typography variant="body2" color="error.main">
-              Failed to load: {state.message}
-            </Typography>
-          </Stack>
-        );
-      default:
-        return null;
+    if (state.status === 'error' && !isDocMismatch) {
+      return (
+        <Stack spacing={1} sx={{ ...wrapSx, py: 2 }}>
+          <Typography variant="h6">{fallbackLabel ?? 'Smart doc'}</Typography>
+          <Typography variant="body2" color="error.main">
+            Failed to load: {state.message}
+          </Typography>
+        </Stack>
+      );
     }
+
+    return (
+      <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ ...wrapSx, py: 4 }}>
+        <CircularProgress size={22} />
+        <Typography variant="body2" color="text.secondary">Loading…</Typography>
+      </Stack>
+    );
   }
 
   const { doc } = state;
@@ -352,11 +388,10 @@ function SmartDocPreview({
           body: JSON.stringify({
             content_block_id: contentBlockId,
             prompt_id: promptId,
-            value, // RPC accepts jsonb; we pass plain string
+            value,
           }),
         });
       } catch (e) {
-        // optional: toast/log
         console.error('smartdoc upsert failed', e);
       }
     }, 400);
@@ -364,7 +399,6 @@ function SmartDocPreview({
 
   return (
     <Stack spacing={3} sx={wrapSx}>
-      {/* Section title */}
       <Typography
         component="h2"
         variant="h2"
@@ -373,19 +407,15 @@ function SmartDocPreview({
         {title}
       </Typography>
 
-      {/* Description */}
       {doc.description?.trim() && (
         <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 720 }}>
           {doc.description}
         </Typography>
       )}
 
-      {/* Prompts */}
       <Box>
         {doc.prompts.length === 0 ? (
-          <Typography variant="body2" color="text.secondary">
-            No questions yet.
-          </Typography>
+          <Typography variant="body2" color="text.secondary">No questions yet.</Typography>
         ) : (
           doc.prompts.map((p) => (
             <SmartDocPromptField
@@ -398,10 +428,15 @@ function SmartDocPreview({
           ))
         )}
       </Box>
-
     </Stack>
   );
 }
+
+
+/** Memoized version to avoid unnecessary rerenders when parents update */
+const MemoSmartDocPreview = React.memo(SmartDocPreview);
+
+/* --------------------------- Media renderers --------------------------- */
 
 function formatDuration(seconds: number | null) {
   if (!seconds || Number.isNaN(seconds)) return null;
@@ -648,6 +683,7 @@ export function BlockRenderer({
     if (!onSmartDocProgress || block.block_type !== 'smart_doc') return undefined;
     return (progress: SmartDocClientProgress) => onSmartDocProgress(block.id, progress);
   }, [onSmartDocProgress, block.id, block.block_type]);
+
   if (block.block_type === 'divider') {
     return <Divider sx={{ my: 3 }} />;
   }
@@ -706,7 +742,7 @@ export function BlockRenderer({
     if (block.smart_doc_id && previewMode) {
       // pass placement id so inputs can upsert
       return (
-        <SmartDocPreview
+        <MemoSmartDocPreview
           docId={block.smart_doc_id}
           contentBlockId={block.id}
           fallbackLabel={block.label}

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -644,6 +644,10 @@ export function BlockRenderer({
   previewMode = false,
   onSmartDocProgress,
 }: BlockRendererProps) {
+  const smartDocProgressHandler = useMemo(() => {
+    if (!onSmartDocProgress || block.block_type !== 'smart_doc') return undefined;
+    return (progress: SmartDocClientProgress) => onSmartDocProgress(block.id, progress);
+  }, [onSmartDocProgress, block.id, block.block_type]);
   if (block.block_type === 'divider') {
     return <Divider sx={{ my: 3 }} />;
   }
@@ -706,9 +710,7 @@ export function BlockRenderer({
           docId={block.smart_doc_id}
           contentBlockId={block.id}
           fallbackLabel={block.label}
-          onProgressChange={
-            onSmartDocProgress ? (progress) => onSmartDocProgress(block.id, progress) : undefined
-          }
+          onProgressChange={smartDocProgressHandler}
         />
       );
     }

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -123,6 +123,7 @@ export type BlockRendererProps = {
   resource: RenderableResource | null;
   previewMode?: boolean;
   onSmartDocProgress?: (contentBlockId: number, progress: SmartDocClientProgress) => void;
+  onVideoProgress?: (contentBlockId: number, percent: number) => void;
 };
 
 /** --------------------------------------------------------------------------- */
@@ -445,7 +446,160 @@ function formatDuration(seconds: number | null) {
   return `${mins}:${secs.toString().padStart(2, '0')}`;
 }
 
-function VideoPreview({ resource }: { resource: RenderableResource }) {
+type VimeoPlayerInstance = {
+  on: (event: 'timeupdate', callback: (data: { percent?: number }) => void) => void;
+  off: (event: 'timeupdate', callback: (data: { percent?: number }) => void) => void;
+  destroy: () => Promise<void> | void;
+};
+
+type VimeoPlayerConstructor = new (element: HTMLIFrameElement) => VimeoPlayerInstance;
+
+type VimeoWindow = Window & {
+  Vimeo?: {
+    Player: VimeoPlayerConstructor;
+  };
+};
+
+let vimeoScriptPromise: Promise<void> | null = null;
+
+function loadVimeoPlayerApi(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  const global = window as VimeoWindow;
+  if (global.Vimeo?.Player) return Promise.resolve();
+  if (vimeoScriptPromise) return vimeoScriptPromise;
+
+  vimeoScriptPromise = new Promise<void>((resolve, reject) => {
+    const existingByAttr = document.querySelector<HTMLScriptElement>('script[data-vimeo-player-api="true"]');
+    const existingBySrc =
+      existingByAttr ??
+      document.querySelector<HTMLScriptElement>('script[src="https://player.vimeo.com/api/player.js"]');
+    const existing = existingByAttr ?? existingBySrc;
+    if (existing) {
+      if (existing.dataset.vimeoPlayerLoaded === 'true') {
+        resolve();
+        return;
+      }
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener(
+        'error',
+        () => reject(new Error('Failed to load Vimeo player script')),
+        { once: true }
+      );
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'https://player.vimeo.com/api/player.js';
+    script.async = true;
+    script.dataset.vimeoPlayerApi = 'true';
+    script.onload = () => {
+      script.dataset.vimeoPlayerLoaded = 'true';
+      resolve();
+    };
+    script.onerror = () => reject(new Error('Failed to load Vimeo player script'));
+    document.head.appendChild(script);
+  }).catch((error) => {
+    vimeoScriptPromise = null;
+    throw error;
+  });
+
+  return vimeoScriptPromise;
+}
+
+function VimeoPlayerFrame({
+  videoId,
+  title,
+  onProgress,
+}: {
+  videoId: string;
+  title: string;
+  onProgress?: (percent: number) => void;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const lastSentRef = useRef(0);
+
+  useEffect(() => {
+    lastSentRef.current = 0;
+    if (typeof window === 'undefined') return undefined;
+
+    let active = true;
+    let player: VimeoPlayerInstance | null = null;
+    const handleTimeUpdate = (data: { percent?: number }) => {
+      if (!active) return;
+      const raw = typeof data?.percent === 'number' ? data.percent : null;
+      if (raw === null || Number.isNaN(raw)) return;
+      const clamped = Math.max(0, Math.min(1, raw));
+      if (clamped <= lastSentRef.current + 0.001) return;
+      lastSentRef.current = clamped;
+      onProgress?.(clamped);
+    };
+
+    const setup = async () => {
+      try {
+        await loadVimeoPlayerApi();
+        if (!active || !iframeRef.current) return;
+        const global = window as VimeoWindow;
+        const PlayerCtor = global.Vimeo?.Player;
+        if (!PlayerCtor) return;
+        player = new PlayerCtor(iframeRef.current);
+        player.on('timeupdate', handleTimeUpdate);
+      } catch (error) {
+        console.error('Failed to initialise Vimeo player', error);
+      }
+    };
+
+    void setup();
+
+    return () => {
+      active = false;
+      if (player) {
+        try {
+          player.off('timeupdate', handleTimeUpdate);
+          const result = player.destroy?.();
+          if (result && typeof (result as Promise<void>).then === 'function') {
+            (result as Promise<void>).catch(() => {});
+          }
+        } catch (error) {
+          console.error('Failed to clean up Vimeo player', error);
+        }
+      }
+    };
+  }, [onProgress, videoId]);
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        maxWidth: 860,
+        mx: 'auto',
+        borderRadius: 2,
+        overflow: 'hidden',
+        bgcolor: 'common.black',
+        pb: '56.25%',
+        height: 0,
+      }}
+    >
+      <Box
+        component="iframe"
+        ref={iframeRef}
+        title={title}
+        src={`https://player.vimeo.com/video/${videoId}`}
+        allow="autoplay; fullscreen; picture-in-picture"
+        allowFullScreen
+        sx={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
+      />
+    </Box>
+  );
+}
+
+function VideoPreview({
+  resource,
+  onProgress,
+}: {
+  resource: RenderableResource;
+  onProgress?: (percent: number) => void;
+}) {
   if (!resource.url) {
     return (
       <Card variant="outlined">
@@ -514,13 +668,10 @@ function VideoPreview({ resource }: { resource: RenderableResource }) {
 
   if (isVimeo) {
     const segments = resource.url.split('/');
-    const id = segments[segments.length - 1];
+    const idWithQuery = segments[segments.length - 1];
+    const id = idWithQuery?.split('?')[0]?.split('#')[0];
     if (id) {
-      return frameWrapper(
-        `https://player.vimeo.com/video/${id}`,
-        'autoplay; fullscreen; picture-in-picture',
-        resource.title,
-      );
+      return <VimeoPlayerFrame videoId={id} title={resource.title} onProgress={onProgress} />;
     }
   }
 
@@ -678,11 +829,17 @@ export function BlockRenderer({
   resource,
   previewMode = false,
   onSmartDocProgress,
+  onVideoProgress,
 }: BlockRendererProps) {
   const smartDocProgressHandler = useMemo(() => {
     if (!onSmartDocProgress || block.block_type !== 'smart_doc') return undefined;
     return (progress: SmartDocClientProgress) => onSmartDocProgress(block.id, progress);
   }, [onSmartDocProgress, block.id, block.block_type]);
+
+  const videoProgressHandler = useMemo(() => {
+    if (!onVideoProgress || block.block_type !== 'asset') return undefined;
+    return (percent: number) => onVideoProgress(block.id, percent);
+  }, [onVideoProgress, block.block_type, block.id]);
 
   if (block.block_type === 'divider') {
     return <Divider sx={{ my: 3 }} />;
@@ -784,19 +941,36 @@ export function BlockRenderer({
     );
   }
 
-  switch (resource.type) {
-    case 'video':
-      return <VideoPreview resource={resource} />;
-    case 'podcast':
-    case 'audio':
-      return <AudioPreview resource={resource} />;
-    case 'pdf':
-    case 'document':
-      return <PdfPreview resource={resource} />;
-    case 'image':
-      return <ImagePreview resource={resource} />;
-    case 'link':
-    default:
-      return <LinkPreview resource={resource} />;
+  const normalizedType = (resource.type ?? '').toLowerCase();
+  const urlLower = (resource.url ?? '').toLowerCase();
+
+  const treatAsVideo =
+    normalizedType === 'video' ||
+    normalizedType === 'video_link' ||
+    normalizedType === 'vimeo' ||
+    normalizedType === 'youtube' ||
+    normalizedType.includes('video') ||
+    urlLower.includes('vimeo.com') ||
+    urlLower.includes('youtu.be') ||
+    urlLower.includes('youtube.com');
+
+  if (treatAsVideo) {
+    return <VideoPreview resource={resource} onProgress={videoProgressHandler} />;
   }
+
+  const treatAsAudio =
+    normalizedType === 'audio' || normalizedType === 'podcast' || normalizedType.includes('audio');
+  if (treatAsAudio) {
+    return <AudioPreview resource={resource} />;
+  }
+
+  if (normalizedType === 'pdf' || normalizedType === 'document') {
+    return <PdfPreview resource={resource} />;
+  }
+
+  if (normalizedType === 'image') {
+    return <ImagePreview resource={resource} />;
+  }
+
+  return <LinkPreview resource={resource} />;
 }

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -112,10 +112,17 @@ const LABEL_SX = {
 
 /** --------------------------------------------------------------------------- */
 
+export type SmartDocClientProgress = {
+  total: number;
+  completed: number;
+  isComplete: boolean;
+};
+
 export type BlockRendererProps = {
   block: RenderableBlock;
   resource: RenderableResource | null;
   previewMode?: boolean;
+  onSmartDocProgress?: (contentBlockId: number, progress: SmartDocClientProgress) => void;
 };
 
 function SmartDocPromptField({
@@ -134,14 +141,12 @@ function SmartDocPromptField({
   const helper = prompt.help_text?.trim();
 
   return (
-    <FormControl fullWidth sx={{ mb: 4 }} disabled={disabled}>
+    <FormControl fullWidth sx={{ mb: 4 }} disabled={disabled} required>
       <FormLabel sx={LABEL_SX}>
         {label}
-        {prompt.required && (
-          <Box component="span" sx={{ color: 'error.main', lineHeight: 1 }}>
-            *
-          </Box>
-        )}
+        <Box component="span" sx={{ color: 'error.main', lineHeight: 1 }}>
+          *
+        </Box>
       </FormLabel>
 
       {helper && (
@@ -160,6 +165,7 @@ function SmartDocPromptField({
         InputProps={{ disableUnderline: true, sx: FIELD_SX }}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        required
       />
     </FormControl>
   );
@@ -169,10 +175,12 @@ function SmartDocPreview({
   docId,
   contentBlockId, // <--- NEW: placement id (content_blocks.id)
   fallbackLabel,
+  onProgressChange,
 }: {
   docId: number;
   contentBlockId: number;
   fallbackLabel: string | null;
+  onProgressChange?: (progress: SmartDocClientProgress) => void;
 }) {
   const [state, setState] = useState<SmartDocState>({ status: 'idle' });
 
@@ -214,7 +222,7 @@ function SmartDocPreview({
           label: p.label ?? '',
           prompt_type: p.prompt_type,
           help_text: p.help_text,
-          required: p.required,
+          required: true,
         }))
         .sort((a, b) => a.position - b.position);
 
@@ -281,40 +289,54 @@ function SmartDocPreview({
     };
   }, [docId, contentBlockId]);
 
-  const wrapSx = { maxWidth: 920, mx: 'auto', px: { xs: 2, sm: 0 } } as const;
+  const progressSnapshot = useMemo<SmartDocClientProgress | null>(() => {
+    if (state.status !== 'ready') return null;
+    const prompts = state.doc.prompts;
+    const total = prompts.length;
+    const completed = prompts.filter((p) => (values[p.id]?.trim()?.length ?? 0) > 0).length;
+    return {
+      total,
+      completed,
+      isComplete: total > 0 && completed === total,
+    };
+  }, [state, values]);
 
-  switch (state.status) {
-    case 'idle':
-    case 'loading':
-      return (
-        <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ ...wrapSx, py: 4 }}>
-          <CircularProgress size={22} />
-          <Typography variant="body2" color="text.secondary">
-            Loading…
-          </Typography>
-        </Stack>
-      );
-    case 'error':
-      return (
-        <Stack spacing={1} sx={{ ...wrapSx, py: 2 }}>
-          <Typography variant="h6">{fallbackLabel ?? 'Smart doc'}</Typography>
-          <Typography variant="body2" color="error.main">
-            Failed to load: {state.message}
-          </Typography>
-        </Stack>
-      );
-    case 'ready':
-      break;
+  useEffect(() => {
+    if (!progressSnapshot || !onProgressChange) return;
+    onProgressChange(progressSnapshot);
+  }, [progressSnapshot, onProgressChange]);
+
+  if (state.status !== 'ready') {
+    const wrapSx = { maxWidth: 920, mx: 'auto', px: { xs: 2, sm: 0 } } as const;
+
+    switch (state.status) {
+      case 'idle':
+      case 'loading':
+        return (
+          <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ ...wrapSx, py: 4 }}>
+            <CircularProgress size={22} />
+            <Typography variant="body2" color="text.secondary">
+              Loading…
+            </Typography>
+          </Stack>
+        );
+      case 'error':
+        return (
+          <Stack spacing={1} sx={{ ...wrapSx, py: 2 }}>
+            <Typography variant="h6">{fallbackLabel ?? 'Smart doc'}</Typography>
+            <Typography variant="body2" color="error.main">
+              Failed to load: {state.message}
+            </Typography>
+          </Stack>
+        );
+      default:
+        return null;
+    }
   }
 
   const { doc } = state;
   const title = doc.title?.trim() || fallbackLabel || 'Smart doc';
-
-  // local progress (required-only), purely for immediate feedback
-  const requiredTotal = doc.prompts.filter((p) => p.required).length;
-  const requiredCompleted = doc.prompts.filter(
-    (p) => p.required && (values[p.id]?.trim()?.length ?? 0) > 0,
-  ).length;
+  const wrapSx = { maxWidth: 920, mx: 'auto', px: { xs: 2, sm: 0 } } as const;
 
   const upsertValue = (promptId: number, value: string) => {
     // optimistic UI
@@ -377,10 +399,6 @@ function SmartDocPreview({
         )}
       </Box>
 
-      <Typography variant="caption" color="text.secondary">
-        Progress: {requiredCompleted}/{requiredTotal}
-        {submitted ? ' • Submitted' : ''}
-      </Typography>
     </Stack>
   );
 }
@@ -620,7 +638,12 @@ function LinkPreview({ resource }: { resource: RenderableResource }) {
   );
 }
 
-export function BlockRenderer({ block, resource, previewMode = false }: BlockRendererProps) {
+export function BlockRenderer({
+  block,
+  resource,
+  previewMode = false,
+  onSmartDocProgress,
+}: BlockRendererProps) {
   if (block.block_type === 'divider') {
     return <Divider sx={{ my: 3 }} />;
   }
@@ -683,6 +706,9 @@ export function BlockRenderer({ block, resource, previewMode = false }: BlockRen
           docId={block.smart_doc_id}
           contentBlockId={block.id}
           fallbackLabel={block.label}
+          onProgressChange={
+            onSmartDocProgress ? (progress) => onSmartDocProgress(block.id, progress) : undefined
+          }
         />
       );
     }

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -104,6 +104,46 @@ const courseCache = new Map<
   { course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]> }
 >();
 
+/** ------- merge helper: prefer UNLOCKED when merging snapshots ------- */
+function mergeLockStatusesPreferUnlocked(
+  current: Record<number, ChildUnlockStatus[]>,
+  incoming: Record<number, ChildUnlockStatus[]>
+): Record<number, ChildUnlockStatus[]> {
+  const out: Record<number, ChildUnlockStatus[]> = { ...current };
+
+  // Build quick lookup for current
+  const currByParent: Record<number, Record<number, ChildUnlockStatus>> = {};
+  for (const [pidStr, rows] of Object.entries(current)) {
+    const pid = Number(pidStr);
+    currByParent[pid] = {};
+    for (const r of rows) currByParent[pid][r.child_id] = r;
+  }
+
+  for (const [pidStr, rows] of Object.entries(incoming)) {
+    const pid = Number(pidStr);
+    const merged: Record<number, ChildUnlockStatus> = { ...(currByParent[pid] ?? {}) };
+
+    for (const r of rows) {
+      const existing = merged[r.child_id];
+      if (!existing) {
+        merged[r.child_id] = r;
+      } else {
+        // Prefer UNLOCKED if either says unlocked; keep latest metadata from incoming
+        merged[r.child_id] = {
+          ...r,
+          locked: Boolean(existing.locked && r.locked),
+        };
+      }
+    }
+
+    // Keep deterministic order
+    const arr = Object.values(merged).sort((a, b) => a.child_position - b.child_position);
+    out[pid] = arr;
+  }
+
+  return out;
+}
+
 export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerProps) {
   const router = useRouter();
   const [state, setState] = useState<CourseState>({ status: 'loading' });
@@ -135,8 +175,16 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
         const data = (await res.json()) as { course: NodeSubtree; unlockStatuses: Record<number, ChildUnlockStatus[]> };
         if (!active) return;
 
-        courseCache.set(courseSlug, { course: data.course, lockStatuses: data.unlockStatuses });
-        setState({ status: 'ready', course: data.course, lockStatuses: data.unlockStatuses });
+        // Merge incoming with current (prefer unlocked), and keep cache in sync
+        setState((prev) => {
+          if (prev.status === 'ready') {
+            const merged = mergeLockStatusesPreferUnlocked(prev.lockStatuses, data.unlockStatuses);
+            courseCache.set(courseSlug, { course: data.course, lockStatuses: merged });
+            return { ...prev, course: data.course, lockStatuses: merged };
+          }
+          courseCache.set(courseSlug, { course: data.course, lockStatuses: data.unlockStatuses });
+          return { status: 'ready', course: data.course, lockStatuses: data.unlockStatuses };
+        });
       } catch (error) {
         if (!active) return;
         const message = error instanceof Error ? error.message : 'Failed to load course';
@@ -244,13 +292,13 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
       });
       if (!res.ok) return;
       const { unlockStatuses } = (await res.json()) as { unlockStatuses: Record<number, ChildUnlockStatus[]> };
+
       setState((prev) => {
         if (prev.status !== 'ready') return prev;
-        // merge in refreshed parents
-        return {
-          ...prev,
-          lockStatuses: { ...prev.lockStatuses, ...unlockStatuses },
-        };
+        const merged = mergeLockStatusesPreferUnlocked(prev.lockStatuses, unlockStatuses);
+        // keep cache synced with merged state
+        courseCache.set(courseSlug, { course: prev.course, lockStatuses: merged });
+        return { ...prev, lockStatuses: merged };
       });
     } catch {
       // ignore; next navigation will naturally refresh
@@ -308,8 +356,12 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     return null;
   }
 
+
+  const HEADER_OFFSET = 0; // set to your AppBar height (e.g. 64) if you have a fixed header
+
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50', display: 'flex', flexDirection: 'column' }}>
+      {/* mobile: non-fixed tree */}
       <Box sx={{ display: { xs: 'block', md: 'none' } }}>
         <StudentCourseTree
           course={state.course}
@@ -320,22 +372,46 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
           onSelectContent={handleSelectContent}
           onBackToCourses={() => router.push('/courses')}
           fullHeight={false}
+          noTransition
         />
       </Box>
-
+  
+      {/* desktop/tablet: fixed left rail + spacer */}
       <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
-        <Box sx={{ width: { xs: 0, md: 340 }, display: { xs: 'none', md: 'flex' } }}>
-          <StudentCourseTree
-            course={state.course}
-            expanded={expanded}
-            selectedNodeId={treeSelectedId}
-            lockStatuses={nestedLockMap}
-            onToggle={handleToggle}
-            onSelectContent={handleSelectContent}
-            onBackToCourses={() => router.push('/courses')}
-          />
+        {/* spacer keeps content pushed over; visible but empty */}
+        <Box sx={{ width: { xs: 0, md: 340 }, display: { xs: 'none', md: 'block' } }} />
+  
+        {/* the actual fixed sidebar */}
+        <Box
+          sx={{
+            display: { xs: 'none', md: 'block' },
+            position: 'fixed',
+            left: 0,
+            top: HEADER_OFFSET,
+            width: 340,
+            height: `calc(100vh - ${HEADER_OFFSET}px)`,
+            borderRight: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+            zIndex: (t) => t.zIndex.appBar - 1, // stay below any header
+          }}
+        >
+          <Box sx={{ height: '100%', overflowY: 'auto' }}>
+            <StudentCourseTree
+              course={state.course}
+              expanded={expanded}
+              selectedNodeId={treeSelectedId}
+              lockStatuses={nestedLockMap}
+              onToggle={handleToggle}
+              onSelectContent={handleSelectContent}
+              onBackToCourses={() => router.push('/courses')}
+              fullHeight
+              noTransition
+            />
+          </Box>
         </Box>
-
+  
+        {/* content column */}
         <Box sx={{ flex: 1, minWidth: 0, bgcolor: 'background.default' }}>
           {lessonSlug ? null : (
             <Box sx={{ px: { xs: 2, md: 4 }, py: 6 }}>
@@ -348,17 +424,16 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
               <Divider sx={{ my: 4 }} />
             </Box>
           )}
-
+  
           <LessonContent
             lesson={selectedContent}
             loading={false}
             error={contentError}
-            // NEW: when a node completes, refresh its parent’s unlocks
             onCompleted={handleLessonCompleted}
           />
         </Box>
       </Box>
-
+  
       <Snackbar
         open={!!snackbar}
         autoHideDuration={6000}
@@ -371,4 +446,5 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
       </Snackbar>
     </Box>
   );
+  
 }

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -21,10 +21,17 @@ type CourseViewerProps = {
   lessonSlug?: string;
 };
 
+type EverUnlockedMap = Record<number, Set<number>>;
+
 type CourseState =
   | { status: 'loading' }
   | { status: 'error'; message: string }
-  | { status: 'ready'; course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]> };
+  | {
+      status: 'ready';
+      course: NodeSubtree;
+      lockStatuses: Record<number, ChildUnlockStatus[]>;
+      everUnlocked: EverUnlockedMap;
+    };
 
 type Maps = {
   nodeById: Map<number, NodeSubtree>;
@@ -101,47 +108,111 @@ function isNodeLocked(
 /** ------- simple per-session cache to avoid white flashes on remounts ------- */
 const courseCache = new Map<
   string,
-  { course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]> }
+  { course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]>; everUnlocked: EverUnlockedMap }
 >();
 
-/** ------- merge helper: prefer UNLOCKED when merging snapshots ------- */
-function mergeLockStatusesPreferUnlocked(
-  current: Record<number, ChildUnlockStatus[]>,
-  incoming: Record<number, ChildUnlockStatus[]>
-): Record<number, ChildUnlockStatus[]> {
-  const out: Record<number, ChildUnlockStatus[]> = { ...current };
-
-  // Build quick lookup for current
-  const currByParent: Record<number, Record<number, ChildUnlockStatus>> = {};
-  for (const [pidStr, rows] of Object.entries(current)) {
-    const pid = Number(pidStr);
-    currByParent[pid] = {};
-    for (const r of rows) currByParent[pid][r.child_id] = r;
+function cloneEverUnlocked(source: EverUnlockedMap): EverUnlockedMap {
+  const copy: EverUnlockedMap = {};
+  for (const [parentIdStr, set] of Object.entries(source)) {
+    const parentId = Number(parentIdStr);
+    copy[parentId] = new Set(set);
   }
+  return copy;
+}
 
-  for (const [pidStr, rows] of Object.entries(incoming)) {
-    const pid = Number(pidStr);
-    const merged: Record<number, ChildUnlockStatus> = { ...(currByParent[pid] ?? {}) };
+function seedEverUnlocked(unlocks: Record<number, ChildUnlockStatus[]>): EverUnlockedMap {
+  const seeded: EverUnlockedMap = {};
+  for (const [parentIdStr, rows] of Object.entries(unlocks)) {
+    const parentId = Number(parentIdStr);
+    for (const row of rows) {
+      if (!row.locked) {
+        if (!seeded[parentId]) seeded[parentId] = new Set();
+        seeded[parentId].add(row.child_id);
+      }
+    }
+  }
+  return seeded;
+}
 
-    for (const r of rows) {
-      const existing = merged[r.child_id];
-      if (!existing) {
-        merged[r.child_id] = r;
-      } else {
-        // Prefer UNLOCKED if either says unlocked; keep latest metadata from incoming
-        merged[r.child_id] = {
-          ...r,
-          locked: Boolean(existing.locked && r.locked),
-        };
+function applyMonotonicUnlocks(
+  unlocks: Record<number, ChildUnlockStatus[]>,
+  everUnlocked: EverUnlockedMap,
+): Record<number, ChildUnlockStatus[]> {
+  const result: Record<number, ChildUnlockStatus[]> = {};
+  for (const [parentIdStr, rows] of Object.entries(unlocks)) {
+    const parentId = Number(parentIdStr);
+    const seen = everUnlocked[parentId] ?? new Set<number>();
+    const adjusted = rows.map((row) => {
+      if (!row.locked) {
+        seen.add(row.child_id);
+        return row;
+      }
+      if (seen.has(row.child_id)) {
+        return { ...row, locked: false, reason: null };
+      }
+      return row;
+    });
+    if (!everUnlocked[parentId] && seen.size > 0) {
+      everUnlocked[parentId] = seen;
+    }
+    result[parentId] = adjusted;
+  }
+  return result;
+}
+
+function debugLogUnlockStatuses(
+  label: string,
+  unlocks: Record<number, ChildUnlockStatus[]>,
+  course: NodeSubtree,
+) {
+  if (process.env.NODE_ENV === 'production') return;
+
+  try {
+    const { nodeById } = buildMaps(course);
+    const rows: Array<{
+      parentId: number;
+      parentTitle: string;
+      parentSlug: string | null;
+      childId: number;
+      childTitle: string;
+      childSlug: string | null;
+      locked: boolean;
+      required: boolean;
+      reason: string | null;
+    }> = [];
+
+    for (const [parentIdStr, children] of Object.entries(unlocks)) {
+      const parentId = Number(parentIdStr);
+      const parentNode = nodeById.get(parentId)?.node;
+      for (const child of children) {
+        const childNode = nodeById.get(child.child_id)?.node;
+        rows.push({
+          parentId,
+          parentTitle: parentNode?.title ?? '(unknown parent)',
+          parentSlug: parentNode?.slug ?? null,
+          childId: child.child_id,
+          childTitle: childNode?.title ?? '(unknown child)',
+          childSlug: childNode?.slug ?? null,
+          locked: child.locked,
+          required: child.is_required,
+          reason: child.reason,
+        });
       }
     }
 
-    // Keep deterministic order
-    const arr = Object.values(merged).sort((a, b) => a.child_position - b.child_position);
-    out[pid] = arr;
-  }
+    if (rows.length === 0) {
+      console.groupCollapsed(`[unlock-debug] ${label}`);
+      console.log('No unlock rows available');
+      console.groupEnd();
+      return;
+    }
 
-  return out;
+    console.groupCollapsed(`[unlock-debug] ${label}`);
+    console.table(rows);
+    console.groupEnd();
+  } catch (error) {
+    console.warn('[unlock-debug] failed to log unlock statuses', error);
+  }
 }
 
 export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerProps) {
@@ -160,7 +231,15 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
 
     const cached = courseCache.get(courseSlug);
     if (cached) {
-      setState({ status: 'ready', course: cached.course, lockStatuses: cached.lockStatuses });
+      setState({
+        status: 'ready',
+        course: cached.course,
+        lockStatuses: cached.lockStatuses,
+        everUnlocked: cloneEverUnlocked(cached.everUnlocked),
+      });
+      if (process.env.NODE_ENV !== 'production') {
+        debugLogUnlockStatuses('hydrate-from-cache', cached.lockStatuses, cached.course);
+      }
     } else {
       setState({ status: 'loading' });
     }
@@ -175,16 +254,26 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
         const data = (await res.json()) as { course: NodeSubtree; unlockStatuses: Record<number, ChildUnlockStatus[]> };
         if (!active) return;
 
-        // Merge incoming with current (prefer unlocked), and keep cache in sync
-        setState((prev) => {
-          if (prev.status === 'ready') {
-            const merged = mergeLockStatusesPreferUnlocked(prev.lockStatuses, data.unlockStatuses);
-            courseCache.set(courseSlug, { course: data.course, lockStatuses: merged });
-            return { ...prev, course: data.course, lockStatuses: merged };
-          }
-          courseCache.set(courseSlug, { course: data.course, lockStatuses: data.unlockStatuses });
-          return { status: 'ready', course: data.course, lockStatuses: data.unlockStatuses };
-        });
+        // AFTER
+// prefer existing everUnlocked (from cache or current state) so unlocks are truly monotonic across reloads
+const priorEver =
+(courseCache.get(courseSlug)?.everUnlocked && cloneEverUnlocked(courseCache.get(courseSlug)!.everUnlocked)) ||
+(state.status === 'ready' && cloneEverUnlocked(state.everUnlocked)) ||
+null;
+
+const everUnlocked = priorEver ?? seedEverUnlocked(data.unlockStatuses);
+const lockStatuses = applyMonotonicUnlocks(data.unlockStatuses, everUnlocked);
+
+courseCache.set(courseSlug, {
+course: data.course,
+lockStatuses,
+everUnlocked: cloneEverUnlocked(everUnlocked),
+});
+setState({ status: 'ready', course: data.course, lockStatuses, everUnlocked });
+
+        if (process.env.NODE_ENV !== 'production') {
+          debugLogUnlockStatuses('initial-load', lockStatuses, data.course);
+        }
       } catch (error) {
         if (!active) return;
         const message = error instanceof Error ? error.message : 'Failed to load course';
@@ -305,6 +394,11 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
   const refreshUnlocks = async (parentIds: number[]) => {
     if (parentIds.length === 0) return;
     try {
+      if (process.env.NODE_ENV !== 'production') {
+        console.groupCollapsed('[unlock-debug] refresh-unlocks request');
+        console.log('parentIds', parentIds);
+        console.groupEnd();
+      }
       const res = await fetch(`/api/courses/${courseSlug}/unlocks`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -315,10 +409,35 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
 
       setState((prev) => {
         if (prev.status !== 'ready') return prev;
-        const merged = mergeLockStatusesPreferUnlocked(prev.lockStatuses, unlockStatuses);
-        // keep cache synced with merged state
-        courseCache.set(courseSlug, { course: prev.course, lockStatuses: merged });
-        return { ...prev, lockStatuses: merged };
+        const nextLockStatuses: Record<number, ChildUnlockStatus[]> = { ...prev.lockStatuses };
+        const nextEverUnlocked = cloneEverUnlocked(prev.everUnlocked);
+
+        for (const [pidStr, rows] of Object.entries(unlockStatuses)) {
+          const pid = Number(pidStr);
+          const seen = nextEverUnlocked[pid] ?? new Set<number>();
+          const adjusted = rows.map((row) => {
+            if (!row.locked) {
+              seen.add(row.child_id);
+              return row;
+            }
+            if (seen.has(row.child_id)) {
+              return { ...row, locked: false, reason: null };
+            }
+            return row;
+          });
+          nextEverUnlocked[pid] = seen;
+          nextLockStatuses[pid] = adjusted;
+        }
+
+        courseCache.set(courseSlug, {
+          course: prev.course,
+          lockStatuses: nextLockStatuses,
+          everUnlocked: cloneEverUnlocked(nextEverUnlocked),
+        });
+        if (process.env.NODE_ENV !== 'production') {
+          debugLogUnlockStatuses('refresh-unlocks', nextLockStatuses, prev.course);
+        }
+        return { ...prev, lockStatuses: nextLockStatuses, everUnlocked: nextEverUnlocked };
       });
     } catch {
       // ignore; next navigation will naturally refresh
@@ -329,7 +448,12 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     if (!parentById) return;
     // refresh the immediate parent (this unlocks siblings)
     const parent = parentById.get(nodeId);
-    if (parent != null) refreshUnlocks([parent]);
+    if (parent != null) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[unlock-debug] handleLessonCompleted', { nodeId, parentId: parent });
+      }
+      refreshUnlocks([parent]);
+    }
   };
 
   // ----- inline skeleton instead of white full-page -----

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -240,6 +240,8 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     });
   };
 
+  const nestedLockMap = lockMap;
+
   const handleSelectContent = (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => {
     if (!isContentNodeType(node.node.node_type)) return;
 
@@ -250,19 +252,38 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
       return;
     }
 
-    if (!node.node.slug) {
-      setSnackbar(`This ${label.toLowerCase()} is missing a slug and cannot be opened.`);
-      return;
-    }
-
     if (!parentById) {
       setSnackbar('Course outline is still loading. Try again in a moment.');
       return;
     }
 
-    const pathParents = collectParentPath(node.node.id, parentById);
-    setExpanded((prev) => new Set([...prev, ...pathParents]));
-    router.push(`/courses/${courseSlug}/${node.node.slug}`);
+    const navigateToNode = (target: NodeSubtree) => {
+      const targetLabel = formatContentLabel(target.node.node_type).toLowerCase();
+      if (!target.node.slug) {
+        setSnackbar(`This ${targetLabel} is missing a slug and cannot be opened.`);
+        return;
+      }
+
+      const pathParents = collectParentPath(target.node.id, parentById);
+      setExpanded((prev) => new Set([...prev, ...pathParents]));
+      router.push(`/courses/${courseSlug}/${target.node.slug}`);
+    };
+
+    if (node.node.node_type === 'lesson' && node.children.length > 0) {
+      const childLocks = nestedLockMap[node.node.id] ?? {};
+      const firstUnlockedChild = node.children.find((child) => {
+        const childNode = child.subtree.node;
+        if (!isContentNodeType(childNode.node_type)) return false;
+        return !(childLocks[childNode.id]?.locked ?? false);
+      });
+
+      if (firstUnlockedChild) {
+        navigateToNode(firstUnlockedChild.subtree);
+        return;
+      }
+    }
+
+    navigateToNode(node);
   };
 
   useEffect(() => {
@@ -271,7 +292,6 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     setExpanded((prev) => new Set([...prev, ...pathParents]));
   }, [parentById, selectedContent]);
 
-  const nestedLockMap = lockMap;
   const treeSelectedId = selectedContent?.node.id ?? (contentError && requestedContentId ? requestedContentId : null);
 
   useEffect(() => {

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -67,11 +67,22 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   const [clientSmartDocProgress, setClientSmartDocProgress] = useState<
     Record<number, SmartDocClientProgress>
   >({});
+  const [videoProgressByBlock, setVideoProgressByBlock] = useState<Record<number, number>>({});
 
   const labels = getContentLabels(lesson);
   const nodeId = lesson?.node.id ?? null;
   const { markStarted, markCompleted } = useNodeProgress(nodeId);
   const completedOnceRef = useRef(false);
+
+  const completeLesson = useCallback(async () => {
+    if (!nodeId) return;
+    try {
+      await markCompleted();
+      onCompleted?.(nodeId);
+    } catch (e) {
+      console.error('completeLesson failed', e);
+    }
+  }, [markCompleted, nodeId, onCompleted]);
 
   // ===== 1) Lazy-load blocks whenever the selected node changes =====
   useEffect(() => {
@@ -83,6 +94,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       setSmartDocStatus({});
       setSubmitLoading({});
       setClientSmartDocProgress({});
+      setVideoProgressByBlock({});
       completedOnceRef.current = false;
       return;
     }
@@ -97,6 +109,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     setSmartDocStatus({});
     setSubmitLoading({});
     setClientSmartDocProgress({});
+    setVideoProgressByBlock({});
     completedOnceRef.current = false;
 
     (async () => {
@@ -150,6 +163,21 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   const smartDocBlockIds = useMemo(() => {
     return blocks.filter((b) => b.block_type === 'smart_doc').map((b) => b.id);
   }, [blocks]);
+
+  const vimeoVideoBlockIds = useMemo(() => {
+    if (!blocks || blocks.length === 0) return [] as number[];
+
+    return blocks
+      .filter((b) => b.block_type === 'asset' && b.resource_id)
+      .filter((b) => {
+        const resourceId = b.resource_id!;
+        const resource = resources[resourceId];
+        if (!resource) return false;
+        const url = resource.url?.toLowerCase() ?? '';
+        return url.includes('vimeo.com');
+      })
+      .map((b) => b.id);
+  }, [blocks, resources]);
 
   // ===== 2) Load media resources for those asset blocks =====
   useEffect(() => {
@@ -258,6 +286,38 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     });
   }, [smartDocBlockIds]);
 
+  useEffect(() => {
+    if (vimeoVideoBlockIds.length === 0) {
+      setVideoProgressByBlock((prev) => (Object.keys(prev).length > 0 ? {} : prev));
+      return;
+    }
+
+    setVideoProgressByBlock((prev) => {
+      const next: Record<number, number> = {};
+      let changed = false;
+      for (const id of vimeoVideoBlockIds) {
+        if (typeof prev[id] === 'number') {
+          next[id] = prev[id];
+        }
+      }
+
+      if (Object.keys(prev).length !== Object.keys(next).length) {
+        changed = true;
+      }
+
+      if (!changed) {
+        for (const id of vimeoVideoBlockIds) {
+          if (next[id] !== prev[id]) {
+            changed = true;
+            break;
+          }
+        }
+      }
+
+      return changed ? next : prev;
+    });
+  }, [vimeoVideoBlockIds]);
+
   // ===== 3b) Smart Doc submission status (on mount/lesson change only) =====
   useEffect(() => {
     if (blocksState !== 'ready' || smartDocBlockIds.length === 0) {
@@ -298,49 +358,61 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   // ===== 4) Completion rules =====
   const allSmartDocsComplete = useMemo(() => {
     if (smartDocBlockIds.length === 0) return false;
-  
+
     return smartDocBlockIds.every((id) => {
       const srv = smartDocProgress[id];
       const cli = clientSmartDocProgress[id];
-  
+
       // Prefer server when it has a meaningful total
       if (srv && srv.fields_total > 0) {
         return (srv.fields_completed ?? 0) >= srv.fields_total;
       }
-  
+
       // Fallback to client-snapshot when the server can't tell yet
       if (cli && cli.total > 0) {
         return cli.completed >= cli.total;
       }
-  
+
       return false;
     });
   }, [smartDocBlockIds, smartDocProgress, clientSmartDocProgress]);
+
+  const allVideosComplete = useMemo(() => {
+    if (vimeoVideoBlockIds.length === 0) return false;
+
+    return vimeoVideoBlockIds.every((id) => {
+      const percent = videoProgressByBlock[id] ?? 0;
+      return percent >= 0.8;
+    });
+  }, [vimeoVideoBlockIds, videoProgressByBlock]);
   
 
   useEffect(() => {
     if (completedOnceRef.current) return;
     if (blocksState !== 'ready' || !nodeId) return;
 
-    // If SmartDocs exist: finish when all are fully completed (submission not required for unlocks)
-    if (smartDocBlockIds.length > 0) {
-      if (allSmartDocsComplete) {
+    const hasSmartDocs = smartDocBlockIds.length > 0;
+    const hasVideos = vimeoVideoBlockIds.length > 0;
+
+    if (hasSmartDocs || hasVideos) {
+      const smartDocsSatisfied = hasSmartDocs ? allSmartDocsComplete : true;
+      const videosSatisfied = hasVideos ? allVideosComplete : true;
+
+      if (smartDocsSatisfied && videosSatisfied) {
         completedOnceRef.current = true;
-        markCompleted();
-        if (nodeId) onCompleted?.(nodeId);
+        void completeLesson();
       }
       return;
     }
 
-    // Fallback: no SmartDocs => complete on 80% scroll
+    // Fallback: no SmartDocs and no trackable videos => complete on 80% scroll
     const onScroll = () => {
       const y = window.scrollY || document.documentElement.scrollTop;
       const h = document.documentElement.scrollHeight - document.documentElement.clientHeight;
       if (h > 0 && y / h >= 0.8) {
         if (!completedOnceRef.current) {
           completedOnceRef.current = true;
-          markCompleted();
-          if (nodeId) onCompleted?.(nodeId);
+          void completeLesson();
         }
       }
     };
@@ -349,7 +421,15 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     return () => {
       window.removeEventListener('scroll', onScroll);
     };
-  }, [blocksState, nodeId, smartDocBlockIds.length, allSmartDocsComplete, markCompleted, onCompleted]);
+  }, [
+    blocksState,
+    nodeId,
+    smartDocBlockIds.length,
+    allSmartDocsComplete,
+    vimeoVideoBlockIds.length,
+    allVideosComplete,
+    completeLesson,
+  ]);
 
   // ===== 5) Submit handler for a specific Smart Doc placement =====
   const submitSmartDoc = async (content_block_id: number) => {
@@ -401,14 +481,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   
         if (effectiveAllComplete && nodeId) {
           // fire-and-forget: write completion and trigger unlock refresh
-          (async () => {
-            try {
-              await markCompleted();
-              onCompleted?.(nodeId);
-            } catch (e) {
-              console.error('markCompleted failed', e);
-            }
-          })();
+          void completeLesson();
         }
   
         return next;
@@ -427,6 +500,15 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       setClientSmartDocProgress((prev) => ({ ...prev, [contentBlockId]: progress }));
     },
   []);
+
+  const handleVideoProgress = useCallback((contentBlockId: number, percent: number) => {
+    const clamped = Math.max(0, Math.min(1, percent));
+    setVideoProgressByBlock((prev) => {
+      const current = prev[contentBlockId] ?? 0;
+      if (clamped <= current + 0.001) return prev;
+      return { ...prev, [contentBlockId]: clamped };
+    });
+  }, []);
 
   // ===== Top-level loading/error/empty states =====
   if (loading) {
@@ -533,6 +615,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
                         resource={resource}
                         previewMode
                         onSmartDocProgress={handleClientSmartDocProgress}
+                        onVideoProgress={handleVideoProgress}
                       />
                       {isSmart && (
                         <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 1 }}>

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -74,63 +74,60 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   const completedOnceRef = useRef(false);
 
   // ===== 1) Lazy-load blocks whenever the selected node changes =====
-  // ===== 1) Lazy-load blocks whenever the selected node changes =====
-// ===== 1) Lazy-load blocks whenever the selected node changes =====
-useEffect(() => {
-  if (!lesson) {
+  useEffect(() => {
+    if (!nodeId) {
+      setBlocks([]);
+      setBlocksState('idle');
+      setBlocksError(null);
+      setSmartDocProgress({});
+      setSmartDocStatus({});
+      setSubmitLoading({});
+      setClientSmartDocProgress({});
+      completedOnceRef.current = false;
+      return;
+    }
+
+    let active = true;
+
+    // Clear immediately so previous lesson’s content doesn’t flash
     setBlocks([]);
-    setBlocksState('idle');
+    setBlocksState('loading');
     setBlocksError(null);
     setSmartDocProgress({});
     setSmartDocStatus({});
     setSubmitLoading({});
     setClientSmartDocProgress({});
     completedOnceRef.current = false;
-    return;
-  }
 
-  let active = true;
+    (async () => {
+      try {
+        const res = await fetch(`/api/nodes/${nodeId}/blocks`, { cache: 'force-cache' });
 
-  // Clear immediately so previous lesson’s content doesn’t flash
-  setBlocks([]);
-  setBlocksState('loading');
-  setBlocksError(null);
-  setSmartDocProgress({});
-  setSmartDocStatus({});
-  setSubmitLoading({});
-  setClientSmartDocProgress({});
-  completedOnceRef.current = false;
+        if (!active) return;
 
-  (async () => {
-    try {
-      // ⬇️ THIS is the change:
-      const res = await fetch(`/api/nodes/${lesson.node.id}/blocks`, { cache: 'force-cache' });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data?.error ?? 'Failed to load blocks');
+        }
 
-      if (!active) return;
+        const { blocks } = (await res.json()) as { blocks: ContentBlock[] };
+        if (!active) return;
 
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data?.error ?? 'Failed to load blocks');
+        const renderable = (blocks ?? []).map(toRenderableBlock).sort((a, b) => a.position - b.position);
+        setBlocks(renderable);
+        setBlocksState('ready');
+      } catch (e) {
+        if (!active) return;
+        setBlocks([]);
+        setBlocksState('error');
+        setBlocksError(e instanceof Error ? e.message : 'Failed to load blocks');
       }
+    })();
 
-      const { blocks } = (await res.json()) as { blocks: ContentBlock[] };
-      if (!active) return;
-
-      const renderable = (blocks ?? []).map(toRenderableBlock).sort((a, b) => a.position - b.position);
-      setBlocks(renderable);
-      setBlocksState('ready');
-    } catch (e) {
-      if (!active) return;
-      setBlocks([]);
-      setBlocksState('error');
-      setBlocksError(e instanceof Error ? e.message : 'Failed to load blocks');
-    }
-  })();
-
-  return () => {
-    active = false;
-  };
-}, [lesson]);
+    return () => {
+      active = false;
+    };
+  }, [nodeId]);
 
 
 
@@ -156,7 +153,7 @@ useEffect(() => {
 
   // ===== 2) Load media resources for those asset blocks =====
   useEffect(() => {
-    if (!lesson || assetBlockIds.length === 0) {
+    if (!nodeId || assetBlockIds.length === 0) {
       setResources({});
       setResourceState('idle');
       setResourceError(null);
@@ -200,7 +197,7 @@ useEffect(() => {
     return () => {
       active = false;
     };
-  }, [assetBlockIds, lesson]);
+  }, [assetBlockIds, nodeId]);
 
   // ===== 3) Smart Doc progress polling (every 5s while lesson open) =====
   useEffect(() => {

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -74,56 +74,65 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   const completedOnceRef = useRef(false);
 
   // ===== 1) Lazy-load blocks whenever the selected node changes =====
-  useEffect(() => {
-    if (!lesson) {
-      setBlocks([]);
-      setBlocksState('idle');
-      setBlocksError(null);
-      setSmartDocProgress({});
-      setSmartDocStatus({});
-      setSubmitLoading({});
-      setClientSmartDocProgress({});
-      completedOnceRef.current = false;
-      return;
-    }
-
-    let active = true;
-    setBlocksState('loading');
+  // ===== 1) Lazy-load blocks whenever the selected node changes =====
+// ===== 1) Lazy-load blocks whenever the selected node changes =====
+useEffect(() => {
+  if (!lesson) {
+    setBlocks([]);
+    setBlocksState('idle');
     setBlocksError(null);
     setSmartDocProgress({});
     setSmartDocStatus({});
     setSubmitLoading({});
     setClientSmartDocProgress({});
     completedOnceRef.current = false;
+    return;
+  }
 
-    (async () => {
-      try {
-        const res = await fetch(`/api/nodes/${lesson.node.id}/blocks`);
-        if (!active) return;
+  let active = true;
 
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}));
-          throw new Error(data?.error ?? 'Failed to load blocks');
-        }
+  // Clear immediately so previous lesson’s content doesn’t flash
+  setBlocks([]);
+  setBlocksState('loading');
+  setBlocksError(null);
+  setSmartDocProgress({});
+  setSmartDocStatus({});
+  setSubmitLoading({});
+  setClientSmartDocProgress({});
+  completedOnceRef.current = false;
 
-        const { blocks } = (await res.json()) as { blocks: ContentBlock[] };
-        if (!active) return;
+  (async () => {
+    try {
+      // ⬇️ THIS is the change:
+      const res = await fetch(`/api/nodes/${lesson.node.id}/blocks`, { cache: 'force-cache' });
 
-        const renderable = (blocks ?? []).map(toRenderableBlock).sort((a, b) => a.position - b.position);
-        setBlocks(renderable);
-        setBlocksState('ready');
-      } catch (e) {
-        if (!active) return;
-        setBlocks([]);
-        setBlocksState('error');
-        setBlocksError(e instanceof Error ? e.message : 'Failed to load blocks');
+      if (!active) return;
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error ?? 'Failed to load blocks');
       }
-    })();
 
-    return () => {
-      active = false;
-    };
-  }, [lesson]);
+      const { blocks } = (await res.json()) as { blocks: ContentBlock[] };
+      if (!active) return;
+
+      const renderable = (blocks ?? []).map(toRenderableBlock).sort((a, b) => a.position - b.position);
+      setBlocks(renderable);
+      setBlocksState('ready');
+    } catch (e) {
+      if (!active) return;
+      setBlocks([]);
+      setBlocksState('error');
+      setBlocksError(e instanceof Error ? e.message : 'Failed to load blocks');
+    }
+  })();
+
+  return () => {
+    active = false;
+  };
+}, [lesson]);
+
+
 
   // Mark STARTED as soon as the content is ready/visible
   useEffect(() => {
@@ -292,11 +301,25 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   // ===== 4) Completion rules =====
   const allSmartDocsComplete = useMemo(() => {
     if (smartDocBlockIds.length === 0) return false;
+  
     return smartDocBlockIds.every((id) => {
-      const p = smartDocProgress[id];
-      return p && p.fields_total > 0 && p.fields_completed >= p.fields_total;
+      const srv = smartDocProgress[id];
+      const cli = clientSmartDocProgress[id];
+  
+      // Prefer server when it has a meaningful total
+      if (srv && srv.fields_total > 0) {
+        return (srv.fields_completed ?? 0) >= srv.fields_total;
+      }
+  
+      // Fallback to client-snapshot when the server can't tell yet
+      if (cli && cli.total > 0) {
+        return cli.completed >= cli.total;
+      }
+  
+      return false;
     });
-  }, [smartDocBlockIds, smartDocProgress]);
+  }, [smartDocBlockIds, smartDocProgress, clientSmartDocProgress]);
+  
 
   useEffect(() => {
     if (completedOnceRef.current) return;
@@ -344,18 +367,55 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
         const j = await res.json().catch(() => ({}));
         throw new Error(j?.details ?? j?.error ?? 'Submit failed');
       }
+  
       const { result } = (await res.json()) as {
-        result: { fields_total: number; fields_completed: number; status: 'submitted' | 'draft'; submitted_at: string | null };
+        result: {
+          fields_total: number;
+          fields_completed: number;
+          status: 'submitted' | 'draft';
+          submitted_at: string | null;
+        };
       };
-      // Update local status + progress
-      setSmartDocStatus((m) => ({ ...m, [content_block_id]: { status: result.status, submitted_at: result.submitted_at } }));
-      setSmartDocProgress((m) => ({
+  
+      // Update local status first
+      setSmartDocStatus((m) => ({
         ...m,
-        [content_block_id]: {
-          fields_total: result.fields_total ?? (m[content_block_id]?.fields_total ?? 0),
-          fields_completed: result.fields_completed ?? (m[content_block_id]?.fields_completed ?? 0),
-        },
+        [content_block_id]: { status: result.status, submitted_at: result.submitted_at },
       }));
+  
+      // Merge progress and immediately check if ALL smart docs are complete (server-first, then client fallback)
+      setSmartDocProgress((prev) => {
+        const next = {
+          ...prev,
+          [content_block_id]: {
+            fields_total: result.fields_total ?? (prev[content_block_id]?.fields_total ?? 0),
+            fields_completed: result.fields_completed ?? (prev[content_block_id]?.fields_completed ?? 0),
+          },
+        };
+  
+        const effectiveAllComplete = smartDocBlockIds.every((id) => {
+          const srv = next[id];
+          if (srv && srv.fields_total > 0) {
+            return (srv.fields_completed ?? 0) >= srv.fields_total;
+          }
+          const cli = clientSmartDocProgress[id];
+          return !!(cli && cli.total > 0 && cli.completed >= cli.total);
+        });
+  
+        if (effectiveAllComplete && nodeId) {
+          // fire-and-forget: write completion and trigger unlock refresh
+          (async () => {
+            try {
+              await markCompleted();
+              onCompleted?.(nodeId);
+            } catch (e) {
+              console.error('markCompleted failed', e);
+            }
+          })();
+        }
+  
+        return next;
+      });
     } catch (e) {
       // You may want a toast; keeping silent here per your current pattern
       console.error(e);
@@ -363,6 +423,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       setSubmitLoading((m) => ({ ...m, [content_block_id]: false }));
     }
   };
+  
 
   const handleClientSmartDocProgress = useCallback(
     (contentBlockId: number, progress: SmartDocClientProgress) => {

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Box, Button, CircularProgress, Stack, Typography } from '@mui/material';
 
 import type { ContentBlock, NodeSubtree } from '@/types/course';
-import { BlockRenderer, type RenderableBlock, type RenderableResource } from '@/components/course/BlockRenderer';
+import {
+  BlockRenderer,
+  type RenderableBlock,
+  type RenderableResource,
+  type SmartDocClientProgress,
+} from '@/components/course/BlockRenderer';
 import { supabase } from '@/lib/supabaseClient';
 import { useNodeProgress } from '@/hooks/useNodeProgress';
 
@@ -59,6 +64,9 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     Record<number, { status: 'draft' | 'submitted'; submitted_at: string | null }>
   >({});
   const [submitLoading, setSubmitLoading] = useState<Record<number, boolean>>({});
+  const [clientSmartDocProgress, setClientSmartDocProgress] = useState<
+    Record<number, SmartDocClientProgress>
+  >({});
 
   const labels = getContentLabels(lesson);
   const nodeId = lesson?.node.id ?? null;
@@ -74,6 +82,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       setSmartDocProgress({});
       setSmartDocStatus({});
       setSubmitLoading({});
+      setClientSmartDocProgress({});
       completedOnceRef.current = false;
       return;
     }
@@ -84,6 +93,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     setSmartDocProgress({});
     setSmartDocStatus({});
     setSubmitLoading({});
+    setClientSmartDocProgress({});
     completedOnceRef.current = false;
 
     (async () => {
@@ -187,6 +197,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   useEffect(() => {
     if (blocksState !== 'ready' || smartDocBlockIds.length === 0) {
       setSmartDocProgress({});
+      setClientSmartDocProgress({});
       return;
     }
 
@@ -229,6 +240,17 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       clearInterval(t);
     };
   }, [blocksState, smartDocBlockIds]);
+
+  useEffect(() => {
+    if (smartDocBlockIds.length === 0) return;
+    setClientSmartDocProgress((prev) => {
+      const next: Record<number, SmartDocClientProgress> = {};
+      for (const id of smartDocBlockIds) {
+        if (prev[id]) next[id] = prev[id];
+      }
+      return next;
+    });
+  }, [smartDocBlockIds]);
 
   // ===== 3b) Smart Doc submission status (on mount/lesson change only) =====
   useEffect(() => {
@@ -342,6 +364,12 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     }
   };
 
+  const handleClientSmartDocProgress = useCallback(
+    (contentBlockId: number, progress: SmartDocClientProgress) => {
+      setClientSmartDocProgress((prev) => ({ ...prev, [contentBlockId]: progress }));
+    },
+  []);
+
   // ===== Top-level loading/error/empty states =====
   if (loading) {
     return (
@@ -413,17 +441,45 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
                   const isSmart = block.block_type === 'smart_doc';
                   const s = isSmart ? smartDocStatus[block.id] : undefined;
                   const p = isSmart ? smartDocProgress[block.id] : undefined;
-                  const canSubmit = isSmart && p && p.fields_total > 0 && p.fields_completed >= p.fields_total && s?.status !== 'submitted';
+                  const clientProgress = clientSmartDocProgress[block.id];
+                  const hasServerTotals = Boolean(p && p.fields_total > 0);
+                  const serverComplete = hasServerTotals
+                    ? (p?.fields_completed ?? 0) >= (p?.fields_total ?? 0)
+                    : undefined;
+                  const effectiveComplete = serverComplete ?? clientProgress?.isComplete ?? false;
+                  const canSubmit = isSmart && s?.status !== 'submitted' && effectiveComplete;
+                  const progressLabel = (() => {
+                    const hasNumbers = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value);
+                    if (p && hasNumbers(p.fields_total) && p.fields_total > 0) {
+                      const total = p.fields_total;
+                      const completed = hasNumbers(p.fields_completed)
+                        ? Math.min(p.fields_completed, total)
+                        : 0;
+                      return `Progress: ${completed}/${total}`;
+                    }
+                    if (clientProgress) {
+                      return clientProgress.total > 0
+                        ? `Progress: ${clientProgress.completed}/${clientProgress.total}`
+                        : 'Progress: —';
+                    }
+                    if (p && hasNumbers(p.fields_completed) && hasNumbers(p.fields_total)) {
+                      return `Progress: ${p.fields_completed}/${p.fields_total}`;
+                    }
+                    return 'Progress: —';
+                  })();
 
                   return (
                     <Box key={block.id}>
-                      <BlockRenderer block={block} resource={resource} previewMode />
+                      <BlockRenderer
+                        block={block}
+                        resource={resource}
+                        previewMode
+                        onSmartDocProgress={handleClientSmartDocProgress}
+                      />
                       {isSmart && (
                         <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 1 }}>
                           <Typography variant="caption" color="text.secondary">
-                            {p
-                              ? `Progress: ${p.fields_completed}/${p.fields_total}`
-                              : 'Progress: —'}
+                            {progressLabel}
                             {s?.status === 'submitted' ? ' • Submitted' : ''}
                           </Typography>
                           <Box sx={{ flex: 1 }} />

--- a/src/components/course/StudentCourseTree.tsx
+++ b/src/components/course/StudentCourseTree.tsx
@@ -42,6 +42,8 @@ type StudentCourseTreeProps = {
   onSelectContent: (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
   onBackToCourses: () => void;
   fullHeight?: boolean;
+  /** Disable expand/collapse animations (avoids “re-expanding” flicker on nav) */
+  noTransition?: boolean;
 };
 
 type TreeNodeProps = {
@@ -54,6 +56,7 @@ type TreeNodeProps = {
   onToggle: (nodeId: number) => void;
   onSelectContent: (node: NodeSubtree, lockStatus: ChildUnlockStatus | undefined) => void;
   prefetchBlocks: (nodeId: number) => void;
+  noTransition?: boolean;
 };
 
 function TreeNode({
@@ -66,6 +69,7 @@ function TreeNode({
   onToggle,
   onSelectContent,
   prefetchBlocks,
+  noTransition = false,
 }: TreeNodeProps) {
   const { node } = subtree;
   const hasChildren = subtree.children.length > 0;
@@ -142,7 +146,12 @@ function TreeNode({
     <>
       {item}
       {hasChildren ? (
-        <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+        <Collapse
+          in={isExpanded}
+          timeout={noTransition ? 0 : 'auto'}
+          unmountOnExit={false}
+          appear={!noTransition}
+        >
           <List disablePadding>
             {subtree.children.map((child) => (
               <TreeNode
@@ -156,6 +165,7 @@ function TreeNode({
                 onToggle={onToggle}
                 onSelectContent={onSelectContent}
                 prefetchBlocks={prefetchBlocks}
+                noTransition={noTransition}
               />
             ))}
           </List>
@@ -174,6 +184,7 @@ export default function StudentCourseTree({
   onSelectContent,
   onBackToCourses,
   fullHeight = true,
+  noTransition = false,
 }: StudentCourseTreeProps) {
   const sequentialUnlock = !!course.node.sequential_unlock;
   const childLocks = useMemo(() => lockStatuses[course.node.id] ?? {}, [course.node.id, lockStatuses]);
@@ -242,6 +253,7 @@ export default function StudentCourseTree({
               onToggle={onToggle}
               onSelectContent={onSelectContent}
               prefetchBlocks={prefetchBlocks}
+              noTransition={noTransition}
             />
           ))}
         </List>

--- a/src/hooks/useNodeProgress.ts
+++ b/src/hooks/useNodeProgress.ts
@@ -1,27 +1,117 @@
 import { useCallback, useRef } from 'react';
 
+async function extractErrorBody(response: Response): Promise<unknown> {
+  try {
+    return await response.clone().json();
+  } catch {
+    try {
+      return await response.clone().text();
+    } catch {
+      return null;
+    }
+  }
+}
+
+function formatProgressErrorDetail(body: unknown): string | undefined {
+  if (body == null || body === '') {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return undefined;
+  }
+}
+
 export function useNodeProgress(nodeId: number | null) {
   const startedRef = useRef(false);
   const completedRef = useRef(false);
 
-  const markStarted = useCallback(() => {
+  const markStarted = useCallback(async () => {
     if (!nodeId || startedRef.current) return;
     startedRef.current = true;
-    void fetch('/api/progress', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'start', nodeId }),
-    }).catch(() => {});
+    try {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markStarted', { nodeId });
+      }
+      const response = await fetch('/api/progress', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'start', nodeId }),
+      });
+      if (!response.ok) {
+        const errorBody = await extractErrorBody(response);
+        if (process.env.NODE_ENV !== 'production') {
+          console.error('[progress] markStarted failed', {
+            nodeId,
+            status: response.status,
+            statusText: response.statusText,
+            body: errorBody,
+          });
+        }
+        const detail = formatProgressErrorDetail(errorBody);
+        throw new Error(
+          `Failed to mark node ${nodeId} as started (${response.status} ${response.statusText})${
+            detail ? `: ${detail}` : ''
+          }`,
+        );
+      }
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markStarted succeeded', { nodeId });
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[progress] markStarted encountered an error', { nodeId, error });
+      }
+      startedRef.current = false;
+      throw error;
+    }
   }, [nodeId]);
 
-  const markCompleted = useCallback(() => {
+  const markCompleted = useCallback(async () => {
     if (!nodeId || completedRef.current) return;
     completedRef.current = true;
-    void fetch('/api/progress', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'complete', nodeId }),
-    }).catch(() => {});
+    try {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markCompleted', { nodeId });
+      }
+      const response = await fetch('/api/progress', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'complete', nodeId }),
+      });
+      if (!response.ok) {
+        const errorBody = await extractErrorBody(response);
+        if (process.env.NODE_ENV !== 'production') {
+          console.error('[progress] markCompleted failed', {
+            nodeId,
+            status: response.status,
+            statusText: response.statusText,
+            body: errorBody,
+          });
+        }
+        const detail = formatProgressErrorDetail(errorBody);
+        throw new Error(
+          `Failed to mark node ${nodeId} as completed (${response.status} ${response.statusText})${
+            detail ? `: ${detail}` : ''
+          }`,
+        );
+      }
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markCompleted succeeded', { nodeId });
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[progress] markCompleted encountered an error', { nodeId, error });
+      }
+      completedRef.current = false;
+      throw error;
+    }
   }, [nodeId]);
 
   return { markStarted, markCompleted };


### PR DESCRIPTION
## Summary
- treat every Smart Doc prompt as required and remove the duplicated progress caption inside the preview component
- surface client-side Smart Doc progress snapshots to the lesson view so the submit button enables even when the server reports zero required fields
- tidy the lesson footer to rely on the shared progress label and retain a single status+submit control for Smart Docs

## Testing
- npm run lint *(fails: pre-existing lint errors in smartdoc API routes and dashboard pages)*

------
https://chatgpt.com/codex/tasks/task_e_68f1fdb81740833294126ad8d9060d8e