### PR TITLE
Track Vimeo video progress to gate lesson completion

### DIFF
--- a/src/app/api/progress/route.ts
+++ b/src/app/api/progress/route.ts
@@ -16,11 +16,15 @@ export async function POST(request: NextRequest) {
 
   try {
     if (body.action === 'start') {
-      const { error } = await supabase.rpc('mark_node_started', { _node_id: body.nodeId });
-      if (error) throw new Error(error.message);
+      const { error } = await supabase.rpc('mark_node_started', {
+        _node_id: body.nodeId,
+      });
+      if (error) throw new Error(`mark_node_started failed: ${error.message}`);
     } else {
-      const { error } = await supabase.rpc('mark_node_completed', { _node_id: body.nodeId });
-      if (error) throw new Error(error.message);
+      const { error } = await supabase.rpc('mark_node_completed', {
+        _node_id: body.nodeId,
+      });
+      if (error) throw new Error(`mark_node_completed failed: ${error.message}`);
     }
     return NextResponse.json({ ok: true });
   } catch (e) {

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -941,19 +941,36 @@ export function BlockRenderer({
     );
   }
 
-  switch (resource.type) {
-    case 'video':
-      return <VideoPreview resource={resource} onProgress={videoProgressHandler} />;
-    case 'podcast':
-    case 'audio':
-      return <AudioPreview resource={resource} />;
-    case 'pdf':
-    case 'document':
-      return <PdfPreview resource={resource} />;
-    case 'image':
-      return <ImagePreview resource={resource} />;
-    case 'link':
-    default:
-      return <LinkPreview resource={resource} />;
+  const normalizedType = (resource.type ?? '').toLowerCase();
+  const urlLower = (resource.url ?? '').toLowerCase();
+
+  const treatAsVideo =
+    normalizedType === 'video' ||
+    normalizedType === 'video_link' ||
+    normalizedType === 'vimeo' ||
+    normalizedType === 'youtube' ||
+    normalizedType.includes('video') ||
+    urlLower.includes('vimeo.com') ||
+    urlLower.includes('youtu.be') ||
+    urlLower.includes('youtube.com');
+
+  if (treatAsVideo) {
+    return <VideoPreview resource={resource} onProgress={videoProgressHandler} />;
   }
+
+  const treatAsAudio =
+    normalizedType === 'audio' || normalizedType === 'podcast' || normalizedType.includes('audio');
+  if (treatAsAudio) {
+    return <AudioPreview resource={resource} />;
+  }
+
+  if (normalizedType === 'pdf' || normalizedType === 'document') {
+    return <PdfPreview resource={resource} />;
+  }
+
+  if (normalizedType === 'image') {
+    return <ImagePreview resource={resource} />;
+  }
+
+  return <LinkPreview resource={resource} />;
 }

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -123,6 +123,7 @@ export type BlockRendererProps = {
   resource: RenderableResource | null;
   previewMode?: boolean;
   onSmartDocProgress?: (contentBlockId: number, progress: SmartDocClientProgress) => void;
+  onVideoProgress?: (contentBlockId: number, percent: number) => void;
 };
 
 /** --------------------------------------------------------------------------- */
@@ -445,7 +446,160 @@ function formatDuration(seconds: number | null) {
   return `${mins}:${secs.toString().padStart(2, '0')}`;
 }
 
-function VideoPreview({ resource }: { resource: RenderableResource }) {
+type VimeoPlayerInstance = {
+  on: (event: 'timeupdate', callback: (data: { percent?: number }) => void) => void;
+  off: (event: 'timeupdate', callback: (data: { percent?: number }) => void) => void;
+  destroy: () => Promise<void> | void;
+};
+
+type VimeoPlayerConstructor = new (element: HTMLIFrameElement) => VimeoPlayerInstance;
+
+type VimeoWindow = Window & {
+  Vimeo?: {
+    Player: VimeoPlayerConstructor;
+  };
+};
+
+let vimeoScriptPromise: Promise<void> | null = null;
+
+function loadVimeoPlayerApi(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  const global = window as VimeoWindow;
+  if (global.Vimeo?.Player) return Promise.resolve();
+  if (vimeoScriptPromise) return vimeoScriptPromise;
+
+  vimeoScriptPromise = new Promise<void>((resolve, reject) => {
+    const existingByAttr = document.querySelector<HTMLScriptElement>('script[data-vimeo-player-api="true"]');
+    const existingBySrc =
+      existingByAttr ??
+      document.querySelector<HTMLScriptElement>('script[src="https://player.vimeo.com/api/player.js"]');
+    const existing = existingByAttr ?? existingBySrc;
+    if (existing) {
+      if (existing.dataset.vimeoPlayerLoaded === 'true') {
+        resolve();
+        return;
+      }
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener(
+        'error',
+        () => reject(new Error('Failed to load Vimeo player script')),
+        { once: true }
+      );
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'https://player.vimeo.com/api/player.js';
+    script.async = true;
+    script.dataset.vimeoPlayerApi = 'true';
+    script.onload = () => {
+      script.dataset.vimeoPlayerLoaded = 'true';
+      resolve();
+    };
+    script.onerror = () => reject(new Error('Failed to load Vimeo player script'));
+    document.head.appendChild(script);
+  }).catch((error) => {
+    vimeoScriptPromise = null;
+    throw error;
+  });
+
+  return vimeoScriptPromise;
+}
+
+function VimeoPlayerFrame({
+  videoId,
+  title,
+  onProgress,
+}: {
+  videoId: string;
+  title: string;
+  onProgress?: (percent: number) => void;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const lastSentRef = useRef(0);
+
+  useEffect(() => {
+    lastSentRef.current = 0;
+    if (typeof window === 'undefined') return undefined;
+
+    let active = true;
+    let player: VimeoPlayerInstance | null = null;
+    const handleTimeUpdate = (data: { percent?: number }) => {
+      if (!active) return;
+      const raw = typeof data?.percent === 'number' ? data.percent : null;
+      if (raw === null || Number.isNaN(raw)) return;
+      const clamped = Math.max(0, Math.min(1, raw));
+      if (clamped <= lastSentRef.current + 0.001) return;
+      lastSentRef.current = clamped;
+      onProgress?.(clamped);
+    };
+
+    const setup = async () => {
+      try {
+        await loadVimeoPlayerApi();
+        if (!active || !iframeRef.current) return;
+        const global = window as VimeoWindow;
+        const PlayerCtor = global.Vimeo?.Player;
+        if (!PlayerCtor) return;
+        player = new PlayerCtor(iframeRef.current);
+        player.on('timeupdate', handleTimeUpdate);
+      } catch (error) {
+        console.error('Failed to initialise Vimeo player', error);
+      }
+    };
+
+    void setup();
+
+    return () => {
+      active = false;
+      if (player) {
+        try {
+          player.off('timeupdate', handleTimeUpdate);
+          const result = player.destroy?.();
+          if (result && typeof (result as Promise<void>).then === 'function') {
+            (result as Promise<void>).catch(() => {});
+          }
+        } catch (error) {
+          console.error('Failed to clean up Vimeo player', error);
+        }
+      }
+    };
+  }, [onProgress, videoId]);
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        maxWidth: 860,
+        mx: 'auto',
+        borderRadius: 2,
+        overflow: 'hidden',
+        bgcolor: 'common.black',
+        pb: '56.25%',
+        height: 0,
+      }}
+    >
+      <Box
+        component="iframe"
+        ref={iframeRef}
+        title={title}
+        src={`https://player.vimeo.com/video/${videoId}`}
+        allow="autoplay; fullscreen; picture-in-picture"
+        allowFullScreen
+        sx={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
+      />
+    </Box>
+  );
+}
+
+function VideoPreview({
+  resource,
+  onProgress,
+}: {
+  resource: RenderableResource;
+  onProgress?: (percent: number) => void;
+}) {
   if (!resource.url) {
     return (
       <Card variant="outlined">
@@ -514,13 +668,10 @@ function VideoPreview({ resource }: { resource: RenderableResource }) {
 
   if (isVimeo) {
     const segments = resource.url.split('/');
-    const id = segments[segments.length - 1];
+    const idWithQuery = segments[segments.length - 1];
+    const id = idWithQuery?.split('?')[0]?.split('#')[0];
     if (id) {
-      return frameWrapper(
-        `https://player.vimeo.com/video/${id}`,
-        'autoplay; fullscreen; picture-in-picture',
-        resource.title,
-      );
+      return <VimeoPlayerFrame videoId={id} title={resource.title} onProgress={onProgress} />;
     }
   }
 
@@ -678,11 +829,17 @@ export function BlockRenderer({
   resource,
   previewMode = false,
   onSmartDocProgress,
+  onVideoProgress,
 }: BlockRendererProps) {
   const smartDocProgressHandler = useMemo(() => {
     if (!onSmartDocProgress || block.block_type !== 'smart_doc') return undefined;
     return (progress: SmartDocClientProgress) => onSmartDocProgress(block.id, progress);
   }, [onSmartDocProgress, block.id, block.block_type]);
+
+  const videoProgressHandler = useMemo(() => {
+    if (!onVideoProgress || block.block_type !== 'asset') return undefined;
+    return (percent: number) => onVideoProgress(block.id, percent);
+  }, [onVideoProgress, block.block_type, block.id]);
 
   if (block.block_type === 'divider') {
     return <Divider sx={{ my: 3 }} />;
@@ -786,7 +943,7 @@ export function BlockRenderer({
 
   switch (resource.type) {
     case 'video':
-      return <VideoPreview resource={resource} />;
+      return <VideoPreview resource={resource} onProgress={videoProgressHandler} />;
     case 'podcast':
     case 'audio':
       return <AudioPreview resource={resource} />;

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -21,10 +21,17 @@ type CourseViewerProps = {
   lessonSlug?: string;
 };
 
+type EverUnlockedMap = Record<number, Set<number>>;
+
 type CourseState =
   | { status: 'loading' }
   | { status: 'error'; message: string }
-  | { status: 'ready'; course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]> };
+  | {
+      status: 'ready';
+      course: NodeSubtree;
+      lockStatuses: Record<number, ChildUnlockStatus[]>;
+      everUnlocked: EverUnlockedMap;
+    };
 
 type Maps = {
   nodeById: Map<number, NodeSubtree>;
@@ -101,47 +108,111 @@ function isNodeLocked(
 /** ------- simple per-session cache to avoid white flashes on remounts ------- */
 const courseCache = new Map<
   string,
-  { course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]> }
+  { course: NodeSubtree; lockStatuses: Record<number, ChildUnlockStatus[]>; everUnlocked: EverUnlockedMap }
 >();
 
-/** ------- merge helper: prefer UNLOCKED when merging snapshots ------- */
-function mergeLockStatusesPreferUnlocked(
-  current: Record<number, ChildUnlockStatus[]>,
-  incoming: Record<number, ChildUnlockStatus[]>
-): Record<number, ChildUnlockStatus[]> {
-  const out: Record<number, ChildUnlockStatus[]> = { ...current };
-
-  // Build quick lookup for current
-  const currByParent: Record<number, Record<number, ChildUnlockStatus>> = {};
-  for (const [pidStr, rows] of Object.entries(current)) {
-    const pid = Number(pidStr);
-    currByParent[pid] = {};
-    for (const r of rows) currByParent[pid][r.child_id] = r;
+function cloneEverUnlocked(source: EverUnlockedMap): EverUnlockedMap {
+  const copy: EverUnlockedMap = {};
+  for (const [parentIdStr, set] of Object.entries(source)) {
+    const parentId = Number(parentIdStr);
+    copy[parentId] = new Set(set);
   }
+  return copy;
+}
 
-  for (const [pidStr, rows] of Object.entries(incoming)) {
-    const pid = Number(pidStr);
-    const merged: Record<number, ChildUnlockStatus> = { ...(currByParent[pid] ?? {}) };
+function seedEverUnlocked(unlocks: Record<number, ChildUnlockStatus[]>): EverUnlockedMap {
+  const seeded: EverUnlockedMap = {};
+  for (const [parentIdStr, rows] of Object.entries(unlocks)) {
+    const parentId = Number(parentIdStr);
+    for (const row of rows) {
+      if (!row.locked) {
+        if (!seeded[parentId]) seeded[parentId] = new Set();
+        seeded[parentId].add(row.child_id);
+      }
+    }
+  }
+  return seeded;
+}
 
-    for (const r of rows) {
-      const existing = merged[r.child_id];
-      if (!existing) {
-        merged[r.child_id] = r;
-      } else {
-        // Prefer UNLOCKED if either says unlocked; keep latest metadata from incoming
-        merged[r.child_id] = {
-          ...r,
-          locked: Boolean(existing.locked && r.locked),
-        };
+function applyMonotonicUnlocks(
+  unlocks: Record<number, ChildUnlockStatus[]>,
+  everUnlocked: EverUnlockedMap,
+): Record<number, ChildUnlockStatus[]> {
+  const result: Record<number, ChildUnlockStatus[]> = {};
+  for (const [parentIdStr, rows] of Object.entries(unlocks)) {
+    const parentId = Number(parentIdStr);
+    const seen = everUnlocked[parentId] ?? new Set<number>();
+    const adjusted = rows.map((row) => {
+      if (!row.locked) {
+        seen.add(row.child_id);
+        return row;
+      }
+      if (seen.has(row.child_id)) {
+        return { ...row, locked: false, reason: null };
+      }
+      return row;
+    });
+    if (!everUnlocked[parentId] && seen.size > 0) {
+      everUnlocked[parentId] = seen;
+    }
+    result[parentId] = adjusted;
+  }
+  return result;
+}
+
+function debugLogUnlockStatuses(
+  label: string,
+  unlocks: Record<number, ChildUnlockStatus[]>,
+  course: NodeSubtree,
+) {
+  if (process.env.NODE_ENV === 'production') return;
+
+  try {
+    const { nodeById } = buildMaps(course);
+    const rows: Array<{
+      parentId: number;
+      parentTitle: string;
+      parentSlug: string | null;
+      childId: number;
+      childTitle: string;
+      childSlug: string | null;
+      locked: boolean;
+      required: boolean;
+      reason: string | null;
+    }> = [];
+
+    for (const [parentIdStr, children] of Object.entries(unlocks)) {
+      const parentId = Number(parentIdStr);
+      const parentNode = nodeById.get(parentId)?.node;
+      for (const child of children) {
+        const childNode = nodeById.get(child.child_id)?.node;
+        rows.push({
+          parentId,
+          parentTitle: parentNode?.title ?? '(unknown parent)',
+          parentSlug: parentNode?.slug ?? null,
+          childId: child.child_id,
+          childTitle: childNode?.title ?? '(unknown child)',
+          childSlug: childNode?.slug ?? null,
+          locked: child.locked,
+          required: child.is_required,
+          reason: child.reason,
+        });
       }
     }
 
-    // Keep deterministic order
-    const arr = Object.values(merged).sort((a, b) => a.child_position - b.child_position);
-    out[pid] = arr;
-  }
+    if (rows.length === 0) {
+      console.groupCollapsed(`[unlock-debug] ${label}`);
+      console.log('No unlock rows available');
+      console.groupEnd();
+      return;
+    }
 
-  return out;
+    console.groupCollapsed(`[unlock-debug] ${label}`);
+    console.table(rows);
+    console.groupEnd();
+  } catch (error) {
+    console.warn('[unlock-debug] failed to log unlock statuses', error);
+  }
 }
 
 export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerProps) {
@@ -160,7 +231,15 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
 
     const cached = courseCache.get(courseSlug);
     if (cached) {
-      setState({ status: 'ready', course: cached.course, lockStatuses: cached.lockStatuses });
+      setState({
+        status: 'ready',
+        course: cached.course,
+        lockStatuses: cached.lockStatuses,
+        everUnlocked: cloneEverUnlocked(cached.everUnlocked),
+      });
+      if (process.env.NODE_ENV !== 'production') {
+        debugLogUnlockStatuses('hydrate-from-cache', cached.lockStatuses, cached.course);
+      }
     } else {
       setState({ status: 'loading' });
     }
@@ -175,16 +254,26 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
         const data = (await res.json()) as { course: NodeSubtree; unlockStatuses: Record<number, ChildUnlockStatus[]> };
         if (!active) return;
 
-        // Merge incoming with current (prefer unlocked), and keep cache in sync
-        setState((prev) => {
-          if (prev.status === 'ready') {
-            const merged = mergeLockStatusesPreferUnlocked(prev.lockStatuses, data.unlockStatuses);
-            courseCache.set(courseSlug, { course: data.course, lockStatuses: merged });
-            return { ...prev, course: data.course, lockStatuses: merged };
-          }
-          courseCache.set(courseSlug, { course: data.course, lockStatuses: data.unlockStatuses });
-          return { status: 'ready', course: data.course, lockStatuses: data.unlockStatuses };
-        });
+        // AFTER
+// prefer existing everUnlocked (from cache or current state) so unlocks are truly monotonic across reloads
+const priorEver =
+(courseCache.get(courseSlug)?.everUnlocked && cloneEverUnlocked(courseCache.get(courseSlug)!.everUnlocked)) ||
+(state.status === 'ready' && cloneEverUnlocked(state.everUnlocked)) ||
+null;
+
+const everUnlocked = priorEver ?? seedEverUnlocked(data.unlockStatuses);
+const lockStatuses = applyMonotonicUnlocks(data.unlockStatuses, everUnlocked);
+
+courseCache.set(courseSlug, {
+course: data.course,
+lockStatuses,
+everUnlocked: cloneEverUnlocked(everUnlocked),
+});
+setState({ status: 'ready', course: data.course, lockStatuses, everUnlocked });
+
+        if (process.env.NODE_ENV !== 'production') {
+          debugLogUnlockStatuses('initial-load', lockStatuses, data.course);
+        }
       } catch (error) {
         if (!active) return;
         const message = error instanceof Error ? error.message : 'Failed to load course';
@@ -305,6 +394,11 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
   const refreshUnlocks = async (parentIds: number[]) => {
     if (parentIds.length === 0) return;
     try {
+      if (process.env.NODE_ENV !== 'production') {
+        console.groupCollapsed('[unlock-debug] refresh-unlocks request');
+        console.log('parentIds', parentIds);
+        console.groupEnd();
+      }
       const res = await fetch(`/api/courses/${courseSlug}/unlocks`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -315,10 +409,35 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
 
       setState((prev) => {
         if (prev.status !== 'ready') return prev;
-        const merged = mergeLockStatusesPreferUnlocked(prev.lockStatuses, unlockStatuses);
-        // keep cache synced with merged state
-        courseCache.set(courseSlug, { course: prev.course, lockStatuses: merged });
-        return { ...prev, lockStatuses: merged };
+        const nextLockStatuses: Record<number, ChildUnlockStatus[]> = { ...prev.lockStatuses };
+        const nextEverUnlocked = cloneEverUnlocked(prev.everUnlocked);
+
+        for (const [pidStr, rows] of Object.entries(unlockStatuses)) {
+          const pid = Number(pidStr);
+          const seen = nextEverUnlocked[pid] ?? new Set<number>();
+          const adjusted = rows.map((row) => {
+            if (!row.locked) {
+              seen.add(row.child_id);
+              return row;
+            }
+            if (seen.has(row.child_id)) {
+              return { ...row, locked: false, reason: null };
+            }
+            return row;
+          });
+          nextEverUnlocked[pid] = seen;
+          nextLockStatuses[pid] = adjusted;
+        }
+
+        courseCache.set(courseSlug, {
+          course: prev.course,
+          lockStatuses: nextLockStatuses,
+          everUnlocked: cloneEverUnlocked(nextEverUnlocked),
+        });
+        if (process.env.NODE_ENV !== 'production') {
+          debugLogUnlockStatuses('refresh-unlocks', nextLockStatuses, prev.course);
+        }
+        return { ...prev, lockStatuses: nextLockStatuses, everUnlocked: nextEverUnlocked };
       });
     } catch {
       // ignore; next navigation will naturally refresh
@@ -329,7 +448,12 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
     if (!parentById) return;
     // refresh the immediate parent (this unlocks siblings)
     const parent = parentById.get(nodeId);
-    if (parent != null) refreshUnlocks([parent]);
+    if (parent != null) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[unlock-debug] handleLessonCompleted', { nodeId, parentId: parent });
+      }
+      refreshUnlocks([parent]);
+    }
   };
 
   // ----- inline skeleton instead of white full-page -----

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -74,6 +74,16 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   const { markStarted, markCompleted } = useNodeProgress(nodeId);
   const completedOnceRef = useRef(false);
 
+  const completeLesson = useCallback(async () => {
+    if (!nodeId) return;
+    try {
+      await markCompleted();
+      onCompleted?.(nodeId);
+    } catch (e) {
+      console.error('completeLesson failed', e);
+    }
+  }, [markCompleted, nodeId, onCompleted]);
+
   // ===== 1) Lazy-load blocks whenever the selected node changes =====
   useEffect(() => {
     if (!nodeId) {
@@ -390,8 +400,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
 
       if (smartDocsSatisfied && videosSatisfied) {
         completedOnceRef.current = true;
-        markCompleted();
-        if (nodeId) onCompleted?.(nodeId);
+        void completeLesson();
       }
       return;
     }
@@ -403,8 +412,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       if (h > 0 && y / h >= 0.8) {
         if (!completedOnceRef.current) {
           completedOnceRef.current = true;
-          markCompleted();
-          if (nodeId) onCompleted?.(nodeId);
+          void completeLesson();
         }
       }
     };
@@ -420,8 +428,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     allSmartDocsComplete,
     vimeoVideoBlockIds.length,
     allVideosComplete,
-    markCompleted,
-    onCompleted,
+    completeLesson,
   ]);
 
   // ===== 5) Submit handler for a specific Smart Doc placement =====
@@ -474,14 +481,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   
         if (effectiveAllComplete && nodeId) {
           // fire-and-forget: write completion and trigger unlock refresh
-          (async () => {
-            try {
-              await markCompleted();
-              onCompleted?.(nodeId);
-            } catch (e) {
-              console.error('markCompleted failed', e);
-            }
-          })();
+          void completeLesson();
         }
   
         return next;

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -67,6 +67,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   const [clientSmartDocProgress, setClientSmartDocProgress] = useState<
     Record<number, SmartDocClientProgress>
   >({});
+  const [videoProgressByBlock, setVideoProgressByBlock] = useState<Record<number, number>>({});
 
   const labels = getContentLabels(lesson);
   const nodeId = lesson?.node.id ?? null;
@@ -83,6 +84,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       setSmartDocStatus({});
       setSubmitLoading({});
       setClientSmartDocProgress({});
+      setVideoProgressByBlock({});
       completedOnceRef.current = false;
       return;
     }
@@ -97,6 +99,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     setSmartDocStatus({});
     setSubmitLoading({});
     setClientSmartDocProgress({});
+    setVideoProgressByBlock({});
     completedOnceRef.current = false;
 
     (async () => {
@@ -150,6 +153,21 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   const smartDocBlockIds = useMemo(() => {
     return blocks.filter((b) => b.block_type === 'smart_doc').map((b) => b.id);
   }, [blocks]);
+
+  const vimeoVideoBlockIds = useMemo(() => {
+    if (!blocks || blocks.length === 0) return [] as number[];
+
+    return blocks
+      .filter((b) => b.block_type === 'asset' && b.resource_id)
+      .filter((b) => {
+        const resourceId = b.resource_id!;
+        const resource = resources[resourceId];
+        if (!resource || resource.type !== 'video') return false;
+        const url = resource.url?.toLowerCase();
+        return Boolean(url && url.includes('vimeo.com'));
+      })
+      .map((b) => b.id);
+  }, [blocks, resources]);
 
   // ===== 2) Load media resources for those asset blocks =====
   useEffect(() => {
@@ -258,6 +276,38 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     });
   }, [smartDocBlockIds]);
 
+  useEffect(() => {
+    if (vimeoVideoBlockIds.length === 0) {
+      setVideoProgressByBlock((prev) => (Object.keys(prev).length > 0 ? {} : prev));
+      return;
+    }
+
+    setVideoProgressByBlock((prev) => {
+      const next: Record<number, number> = {};
+      let changed = false;
+      for (const id of vimeoVideoBlockIds) {
+        if (typeof prev[id] === 'number') {
+          next[id] = prev[id];
+        }
+      }
+
+      if (Object.keys(prev).length !== Object.keys(next).length) {
+        changed = true;
+      }
+
+      if (!changed) {
+        for (const id of vimeoVideoBlockIds) {
+          if (next[id] !== prev[id]) {
+            changed = true;
+            break;
+          }
+        }
+      }
+
+      return changed ? next : prev;
+    });
+  }, [vimeoVideoBlockIds]);
+
   // ===== 3b) Smart Doc submission status (on mount/lesson change only) =====
   useEffect(() => {
     if (blocksState !== 'ready' || smartDocBlockIds.length === 0) {
@@ -298,33 +348,47 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   // ===== 4) Completion rules =====
   const allSmartDocsComplete = useMemo(() => {
     if (smartDocBlockIds.length === 0) return false;
-  
+
     return smartDocBlockIds.every((id) => {
       const srv = smartDocProgress[id];
       const cli = clientSmartDocProgress[id];
-  
+
       // Prefer server when it has a meaningful total
       if (srv && srv.fields_total > 0) {
         return (srv.fields_completed ?? 0) >= srv.fields_total;
       }
-  
+
       // Fallback to client-snapshot when the server can't tell yet
       if (cli && cli.total > 0) {
         return cli.completed >= cli.total;
       }
-  
+
       return false;
     });
   }, [smartDocBlockIds, smartDocProgress, clientSmartDocProgress]);
+
+  const allVideosComplete = useMemo(() => {
+    if (vimeoVideoBlockIds.length === 0) return false;
+
+    return vimeoVideoBlockIds.every((id) => {
+      const percent = videoProgressByBlock[id] ?? 0;
+      return percent >= 0.8;
+    });
+  }, [vimeoVideoBlockIds, videoProgressByBlock]);
   
 
   useEffect(() => {
     if (completedOnceRef.current) return;
     if (blocksState !== 'ready' || !nodeId) return;
 
-    // If SmartDocs exist: finish when all are fully completed (submission not required for unlocks)
-    if (smartDocBlockIds.length > 0) {
-      if (allSmartDocsComplete) {
+    const hasSmartDocs = smartDocBlockIds.length > 0;
+    const hasVideos = vimeoVideoBlockIds.length > 0;
+
+    if (hasSmartDocs || hasVideos) {
+      const smartDocsSatisfied = hasSmartDocs ? allSmartDocsComplete : true;
+      const videosSatisfied = hasVideos ? allVideosComplete : true;
+
+      if (smartDocsSatisfied && videosSatisfied) {
         completedOnceRef.current = true;
         markCompleted();
         if (nodeId) onCompleted?.(nodeId);
@@ -332,7 +396,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       return;
     }
 
-    // Fallback: no SmartDocs => complete on 80% scroll
+    // Fallback: no SmartDocs and no trackable videos => complete on 80% scroll
     const onScroll = () => {
       const y = window.scrollY || document.documentElement.scrollTop;
       const h = document.documentElement.scrollHeight - document.documentElement.clientHeight;
@@ -349,7 +413,16 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     return () => {
       window.removeEventListener('scroll', onScroll);
     };
-  }, [blocksState, nodeId, smartDocBlockIds.length, allSmartDocsComplete, markCompleted, onCompleted]);
+  }, [
+    blocksState,
+    nodeId,
+    smartDocBlockIds.length,
+    allSmartDocsComplete,
+    vimeoVideoBlockIds.length,
+    allVideosComplete,
+    markCompleted,
+    onCompleted,
+  ]);
 
   // ===== 5) Submit handler for a specific Smart Doc placement =====
   const submitSmartDoc = async (content_block_id: number) => {
@@ -427,6 +500,15 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       setClientSmartDocProgress((prev) => ({ ...prev, [contentBlockId]: progress }));
     },
   []);
+
+  const handleVideoProgress = useCallback((contentBlockId: number, percent: number) => {
+    const clamped = Math.max(0, Math.min(1, percent));
+    setVideoProgressByBlock((prev) => {
+      const current = prev[contentBlockId] ?? 0;
+      if (clamped <= current + 0.001) return prev;
+      return { ...prev, [contentBlockId]: clamped };
+    });
+  }, []);
 
   // ===== Top-level loading/error/empty states =====
   if (loading) {
@@ -533,6 +615,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
                         resource={resource}
                         previewMode
                         onSmartDocProgress={handleClientSmartDocProgress}
+                        onVideoProgress={handleVideoProgress}
                       />
                       {isSmart && (
                         <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 1 }}>

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -162,9 +162,9 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
       .filter((b) => {
         const resourceId = b.resource_id!;
         const resource = resources[resourceId];
-        if (!resource || resource.type !== 'video') return false;
-        const url = resource.url?.toLowerCase();
-        return Boolean(url && url.includes('vimeo.com'));
+        if (!resource) return false;
+        const url = resource.url?.toLowerCase() ?? '';
+        return url.includes('vimeo.com');
       })
       .map((b) => b.id);
   }, [blocks, resources]);

--- a/src/hooks/useNodeProgress.ts
+++ b/src/hooks/useNodeProgress.ts
@@ -1,27 +1,117 @@
 import { useCallback, useRef } from 'react';
 
+async function extractErrorBody(response: Response): Promise<unknown> {
+  try {
+    return await response.clone().json();
+  } catch {
+    try {
+      return await response.clone().text();
+    } catch {
+      return null;
+    }
+  }
+}
+
+function formatProgressErrorDetail(body: unknown): string | undefined {
+  if (body == null || body === '') {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return undefined;
+  }
+}
+
 export function useNodeProgress(nodeId: number | null) {
   const startedRef = useRef(false);
   const completedRef = useRef(false);
 
-  const markStarted = useCallback(() => {
+  const markStarted = useCallback(async () => {
     if (!nodeId || startedRef.current) return;
     startedRef.current = true;
-    void fetch('/api/progress', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'start', nodeId }),
-    }).catch(() => {});
+    try {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markStarted', { nodeId });
+      }
+      const response = await fetch('/api/progress', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'start', nodeId }),
+      });
+      if (!response.ok) {
+        const errorBody = await extractErrorBody(response);
+        if (process.env.NODE_ENV !== 'production') {
+          console.error('[progress] markStarted failed', {
+            nodeId,
+            status: response.status,
+            statusText: response.statusText,
+            body: errorBody,
+          });
+        }
+        const detail = formatProgressErrorDetail(errorBody);
+        throw new Error(
+          `Failed to mark node ${nodeId} as started (${response.status} ${response.statusText})${
+            detail ? `: ${detail}` : ''
+          }`,
+        );
+      }
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markStarted succeeded', { nodeId });
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[progress] markStarted encountered an error', { nodeId, error });
+      }
+      startedRef.current = false;
+      throw error;
+    }
   }, [nodeId]);
 
-  const markCompleted = useCallback(() => {
+  const markCompleted = useCallback(async () => {
     if (!nodeId || completedRef.current) return;
     completedRef.current = true;
-    void fetch('/api/progress', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'complete', nodeId }),
-    }).catch(() => {});
+    try {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markCompleted', { nodeId });
+      }
+      const response = await fetch('/api/progress', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'complete', nodeId }),
+      });
+      if (!response.ok) {
+        const errorBody = await extractErrorBody(response);
+        if (process.env.NODE_ENV !== 'production') {
+          console.error('[progress] markCompleted failed', {
+            nodeId,
+            status: response.status,
+            statusText: response.statusText,
+            body: errorBody,
+          });
+        }
+        const detail = formatProgressErrorDetail(errorBody);
+        throw new Error(
+          `Failed to mark node ${nodeId} as completed (${response.status} ${response.statusText})${
+            detail ? `: ${detail}` : ''
+          }`,
+        );
+      }
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[progress] markCompleted succeeded', { nodeId });
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[progress] markCompleted encountered an error', { nodeId, error });
+      }
+      completedRef.current = false;
+      throw error;
+    }
   }, [nodeId]);
 
   return { markStarted, markCompleted };


### PR DESCRIPTION
## Summary
- integrate the Vimeo player API in the course block renderer so video time updates can bubble up to the lesson container
- track per-block Vimeo progress inside `LessonContent` and require 80% completion alongside any SmartDoc submissions before unlocking
- keep the scroll-based fallback only for lessons without SmartDocs or Vimeo videos

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f288e950888332928fd703af3a67ae