### PR TITLE
Add font and background controls for CourseBuilder text blocks

### DIFF
--- a/src/app/api/nodes/[nodeId]/blocks/route.ts
+++ b/src/app/api/nodes/[nodeId]/blocks/route.ts
@@ -17,7 +17,9 @@ export async function GET(request: NextRequest, { params }: { params: { nodeId: 
     // Load blocks (include updated_at so we can build a stable version/ETag)
     const { data, error } = await adminClient
       .from('content_blocks')
-      .select('id, node_id, block_type, position, text_md, resource_id, smart_doc_id, start_ms, end_ms, label, updated_at')
+      .select(
+        'id, node_id, block_type, position, text_md, resource_id, smart_doc_id, start_ms, end_ms, label, settings, updated_at',
+      )
       .eq('node_id', nodeIdNum)
       .order('position', { ascending: true });
 

--- a/src/components/admin/courseEditor/Canvas/Canvas.tsx
+++ b/src/components/admin/courseEditor/Canvas/Canvas.tsx
@@ -16,6 +16,7 @@ import type { RenderableResource } from '@/components/course/BlockRenderer';
 import { BlockRenderer } from '@/components/course/BlockRenderer';
 import BlockDndContext from '../dnd/dndContext';
 import TipTapHtmlEditor from '../text/TipTapHtmlEditor';
+import { parseTextBlockSettings } from '@/lib/textBlockSettings';
 
 export type CanvasProps = {
   subtree: NodeSubtree | null;
@@ -222,6 +223,9 @@ export default function Canvas({
                   const isSelected = selectedBlockId === block.id;
                   const isEditing = editingBlockId === block.id;
                   const resource = block.resource_id ? resources[block.resource_id] ?? null : null;
+                  const textSettings = block.block_type === 'text' ? parseTextBlockSettings(block.settings ?? null) : null;
+                  const fontFamily = textSettings?.fontFamily ?? null;
+                  const backgroundColor = textSettings?.backgroundColor ?? null;
                   return (
                     <Fragment key={block.id}>
                       {indicatorIndex === index ? <DropIndicator /> : null}
@@ -238,48 +242,50 @@ export default function Canvas({
                               onStartEdit(block.id);
                             }
                           }}
-                        >
-                          {block.block_type === 'text' && isEditing && canEditBlocks ? (
-                            <TipTapHtmlEditor
-                              value={
-                                editingSnapshot && editingSnapshot.blockId === block.id
-                                  ? editingSnapshot.draftHtml
-                                  : block.text_md ?? ''
-                              }
-                              onChange={(html) => {
-                                setEditingSnapshot((previous) => {
-                                  if (!previous || previous.blockId !== block.id) {
-                                    return previous;
-                                  }
-                                  return { ...previous, draftHtml: html };
-                                });
-                                onChangeText(block.id, html);
-                              }}
-                              onSubmit={(html) => {
-                                onChangeText(block.id, html, { debounce: false });
-                                onExitEdit();
-                              }}
-                              onCancel={() => {
-                                if (pendingCancelRef.current) return;
-                                pendingCancelRef.current = true;
-                                const snapshot =
+                          >
+                            {block.block_type === 'text' && isEditing && canEditBlocks ? (
+                              <TipTapHtmlEditor
+                                value={
+                                  editingSnapshot && editingSnapshot.blockId === block.id
+                                    ? editingSnapshot.draftHtml
+                                    : block.text_md ?? ''
+                                }
+                                onChange={(html) => {
+                                  setEditingSnapshot((previous) => {
+                                    if (!previous || previous.blockId !== block.id) {
+                                      return previous;
+                                    }
+                                    return { ...previous, draftHtml: html };
+                                  });
+                                  onChangeText(block.id, html);
+                                }}
+                                onSubmit={(html) => {
+                                  onChangeText(block.id, html, { debounce: false });
+                                  onExitEdit();
+                                }}
+                                onCancel={() => {
+                                  if (pendingCancelRef.current) return;
+                                  pendingCancelRef.current = true;
+                                  const snapshot =
+                                    editingSnapshot && editingSnapshot.blockId === block.id
+                                      ? editingSnapshot.initialHtml
+                                      : block.text_md ?? '';
+                                  onChangeText(block.id, snapshot, { debounce: false });
+                                  onExitEdit();
+                                }}
+                                initialValue={
                                   editingSnapshot && editingSnapshot.blockId === block.id
                                     ? editingSnapshot.initialHtml
-                                    : block.text_md ?? '';
-                                onChangeText(block.id, snapshot, { debounce: false });
-                                onExitEdit();
-                              }}
-                              initialValue={
-                                editingSnapshot && editingSnapshot.blockId === block.id
-                                  ? editingSnapshot.initialHtml
-                                  : block.text_md ?? ''
-                              }
-                              autoFocus
-                              onBlur={() => {
-                                if (pendingCancelRef.current) return;
-                                onExitEdit();
-                              }}
-                            />
+                                    : block.text_md ?? ''
+                                }
+                                autoFocus
+                                fontFamily={fontFamily}
+                                backgroundColor={backgroundColor}
+                                onBlur={() => {
+                                  if (pendingCancelRef.current) return;
+                                  onExitEdit();
+                                }}
+                              />
                           ) : (
                             <BlockRenderer
                               block={block}

--- a/src/components/admin/courseEditor/Sidebar/Properties.tsx
+++ b/src/components/admin/courseEditor/Sidebar/Properties.tsx
@@ -27,6 +27,12 @@ import type { SavingState } from '../state/editorStore';
 import type { RenderableResource } from '@/components/course/BlockRenderer';
 import { useUndoRedoInput } from '@/hooks/useUndoRedoInput';
 import { supabase } from '@/lib/supabaseClient';
+import {
+  parseTextBlockSettings,
+  serializeTextBlockSettings,
+  TEXT_BLOCK_FONT_OPTIONS,
+  type TextBlockSettings,
+} from '@/lib/textBlockSettings';
 
 export type NodeDraft = {
   title: string;
@@ -194,6 +200,13 @@ export default function Properties({
   const nodeScopeKey = subtree?.node.id ?? null;
   const blockScopeKey = selectedBlock?.id ?? null;
   const isPendingBlock = (selectedBlock?.id ?? 0) < 0;
+
+  const textBlockSettings = useMemo<TextBlockSettings>(() => {
+    if (!selectedBlock || selectedBlock.block_type !== 'text') {
+      return { fontFamily: null, backgroundColor: null };
+    }
+    return parseTextBlockSettings(selectedBlock.settings ?? null);
+  }, [selectedBlock]);
 
   const titleInput = useUndoRedoInput({
     value: nodeDraft?.title ?? '',
@@ -913,6 +926,20 @@ export default function Properties({
     scopeKey: blockScopeKey,
   });
 
+  const handleTextBlockSettingsChange = useCallback(
+    (patch: { fontFamily?: string | null; backgroundColor?: string | null }) => {
+      if (!selectedBlock || selectedBlock.block_type !== 'text') return;
+      const merged = {
+        fontFamily: textBlockSettings.fontFamily,
+        backgroundColor: textBlockSettings.backgroundColor,
+        ...patch,
+      };
+      const normalized = serializeTextBlockSettings(merged);
+      onUpdateBlock(selectedBlock.id, { settings: normalized });
+    },
+    [onUpdateBlock, selectedBlock, textBlockSettings],
+  );
+
   useEffect(() => {
     if (availableChildTypes.length > 0 && !availableChildTypes.includes(childType)) {
       setChildType(availableChildTypes[0]);
@@ -1103,7 +1130,50 @@ export default function Properties({
         )}
 
         {selectedBlock.block_type === 'text' ? (
-          <Alert severity="info">Text blocks are edited inline on the canvas.</Alert>
+          <Stack spacing={2}>
+            <Alert severity="info">Text blocks are edited inline on the canvas.</Alert>
+            <TextField
+              label="Font"
+              select
+              value={textBlockSettings.fontFamily ?? ''}
+              onChange={(event) =>
+                handleTextBlockSettingsChange({ fontFamily: event.target.value || null })
+              }
+              disabled={isPendingBlock}
+            >
+              {TEXT_BLOCK_FONT_OPTIONS.map((option) => (
+                <MenuItem key={option.value || 'default'} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Stack spacing={1}>
+              <TextField
+                label="Background color"
+                type="color"
+                value={textBlockSettings.backgroundColor ?? '#ffffff'}
+                onChange={(event) =>
+                  handleTextBlockSettingsChange({ backgroundColor: event.target.value })
+                }
+                InputLabelProps={{ shrink: true }}
+                disabled={isPendingBlock}
+              />
+              <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                <Typography variant="caption" color="text.secondary">
+                  {textBlockSettings.backgroundColor
+                    ? `Current: ${textBlockSettings.backgroundColor}`
+                    : 'No background color applied'}
+                </Typography>
+                <Button
+                  size="small"
+                  onClick={() => handleTextBlockSettingsChange({ backgroundColor: null })}
+                  disabled={!textBlockSettings.backgroundColor || isPendingBlock}
+                >
+                  Clear
+                </Button>
+              </Stack>
+            </Stack>
+          </Stack>
         ) : null}
 
         {selectedBlock.block_type === 'smart_doc'

--- a/src/components/admin/courseEditor/text/TipTapHtmlEditor.tsx
+++ b/src/components/admin/courseEditor/text/TipTapHtmlEditor.tsx
@@ -23,6 +23,8 @@ type TipTapHtmlEditorProps = {
   onCancel?: () => void;
   initialValue?: string;
   autoFocus?: boolean;
+  fontFamily?: string | null;
+  backgroundColor?: string | null;
 };
 
 export default function TipTapHtmlEditor({
@@ -33,6 +35,8 @@ export default function TipTapHtmlEditor({
   onCancel,
   initialValue,
   autoFocus,
+  fontFamily,
+  backgroundColor,
 }: TipTapHtmlEditorProps) {
   const editor = useEditor({
     extensions: [
@@ -157,9 +161,12 @@ export default function TipTapHtmlEditor({
           borderColor: 'divider',
           borderRadius: 2,
           p: 2,
+          backgroundColor: backgroundColor ?? 'background.paper',
           '& .ProseMirror': {
             outline: 'none',
             minHeight: 120,
+            fontFamily: fontFamily ?? undefined,
+            backgroundColor: 'transparent',
           },
         }}
       >

--- a/src/components/course/BlockRenderer.tsx
+++ b/src/components/course/BlockRenderer.tsx
@@ -27,6 +27,7 @@ import ImageIcon from '@mui/icons-material/Image';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
 
 import { supabase } from '@/lib/supabaseClient';
+import { parseTextBlockSettings } from '@/lib/textBlockSettings';
 
 export type RenderableBlock = {
   id: number;
@@ -38,6 +39,7 @@ export type RenderableBlock = {
   start_ms: number | null;
   end_ms: number | null;
   label: string | null;
+  settings?: Record<string, unknown> | null;
 };
 
 export type RenderableResource = {
@@ -862,7 +864,9 @@ export function BlockRenderer({
       );
     }
 
-    return (
+    const { fontFamily, backgroundColor } = parseTextBlockSettings(block.settings ?? null);
+
+    const content = (
       <Box
         sx={{
           '& h1, & h2, & h3, & h4, & h5, & h6': {
@@ -889,9 +893,18 @@ export function BlockRenderer({
             px: 0.5,
             borderRadius: 1,
           },
+          fontFamily: fontFamily ?? undefined,
         }}
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
       />
+    );
+
+    if (!backgroundColor) {
+      return content;
+    }
+
+    return (
+      <Box sx={{ backgroundColor, borderRadius: 2, px: { xs: 2, md: 3 }, py: { xs: 1.5, md: 2 } }}>{content}</Box>
     );
   }
 

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -41,6 +41,7 @@ function toRenderableBlock(block: ContentBlock): RenderableBlock {
     start_ms: block.start_ms,
     end_ms: block.end_ms,
     label: block.label,
+    settings: block.settings,
   };
 }
 

--- a/src/lib/textBlockSettings.ts
+++ b/src/lib/textBlockSettings.ts
@@ -1,0 +1,70 @@
+export type TextBlockSettings = {
+  fontFamily: string | null;
+  backgroundColor: string | null;
+};
+
+export type TextBlockSettingsInput = {
+  fontFamily?: string | null;
+  backgroundColor?: string | null;
+};
+
+export const TEXT_BLOCK_FONT_OPTIONS: Array<{ label: string; value: string }> = [
+  { label: 'Default', value: '' },
+  { label: 'Body (Poppins)', value: '"Poppins", "Roboto", "Helvetica", "Arial", sans-serif' },
+  { label: 'Heading (League Spartan)', value: '"League Spartan", "Roboto", "Helvetica", "Arial", sans-serif' },
+  {
+    label: 'Handwritten (Permanent Marker)',
+    value: '"Permanent Marker", "cursive", "Roboto", "Helvetica", "Arial", sans-serif',
+  },
+];
+
+function expandShorthandHex(value: string) {
+  const trimmed = value.trim();
+  if (/^#[0-9a-fA-F]{3}$/.test(trimmed)) {
+    const r = trimmed[1];
+    const g = trimmed[2];
+    const b = trimmed[3];
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+  return trimmed.toUpperCase();
+}
+
+function normalizeHexColor(value: string | null | undefined) {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('#')) return null;
+  if (/^#[0-9a-fA-F]{6}$/.test(trimmed)) {
+    return trimmed.toUpperCase();
+  }
+  if (/^#[0-9a-fA-F]{3}$/.test(trimmed)) {
+    return expandShorthandHex(trimmed);
+  }
+  return null;
+}
+
+export function parseTextBlockSettings(settings: Record<string, unknown> | null | undefined): TextBlockSettings {
+  if (!settings || typeof settings !== 'object') {
+    return { fontFamily: null, backgroundColor: null };
+  }
+
+  const record = settings as Record<string, unknown>;
+  const fontFamily = typeof record.fontFamily === 'string' && record.fontFamily.trim().length > 0 ? record.fontFamily : null;
+  const backgroundColor = normalizeHexColor(typeof record.backgroundColor === 'string' ? record.backgroundColor : null);
+
+  return { fontFamily, backgroundColor };
+}
+
+export function serializeTextBlockSettings(settings: TextBlockSettingsInput): Record<string, string> | null {
+  const fontFamily = typeof settings.fontFamily === 'string' && settings.fontFamily.trim().length > 0 ? settings.fontFamily : null;
+  const backgroundColor = normalizeHexColor(settings.backgroundColor);
+
+  const output: Record<string, string> = {};
+  if (fontFamily) {
+    output.fontFamily = fontFamily;
+  }
+  if (backgroundColor) {
+    output.backgroundColor = backgroundColor;
+  }
+
+  return Object.keys(output).length > 0 ? output : null;
+}


### PR DESCRIPTION
## Summary
- add shared helpers for reading and writing text block settings, including curated font options
- allow CourseBuilder admins to pick a font and background color for text blocks and show the styling while editing
- surface text block settings on the learner-facing renderer so custom styles appear in course content

## Testing
- npm run lint *(fails: pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68f697bf06c08332a30f4a15e569332f