### PR TITLE
Add UI control to create courses from course builder list

### DIFF
--- a/src/components/admin/courseEditor/Sidebar/Tree.tsx
+++ b/src/components/admin/courseEditor/Sidebar/Tree.tsx
@@ -338,9 +338,17 @@ function CoursesList({
   return (
     <Stack spacing={2} sx={{ height: '100%', p: 3 }}>
       <Box>
-        <Typography variant="subtitle1" gutterBottom>
-          Courses
-        </Typography>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
+          <Typography variant="subtitle1">Courses</Typography>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AddIcon fontSize="small" />}
+            onClick={onCreateCourse}
+          >
+            New course
+          </Button>
+        </Stack>
         <TextField
           size="small"
           fullWidth


### PR DESCRIPTION
## Summary
- add a "New course" button to the course builder sidebar to open the existing creation dialog for courses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6c05bea848332bcee03e6617e65a4