### PR TITLE
Auto-complete short text-only lessons

### DIFF
--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -394,6 +394,7 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
   useEffect(() => {
     if (completedOnceRef.current) return;
     if (blocksState !== 'ready' || !nodeId) return;
+    if (assetBlockIds.length > 0 && resourceState !== 'ready') return;
 
     const hasSmartDocs = smartDocBlockIds.length > 0;
     const hasVideos = vimeoVideoBlockIds.length > 0;
@@ -439,6 +440,8 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     allSmartDocsSubmitted, // ⬅️ dependency changed
     vimeoVideoBlockIds.length,
     allVideosComplete,
+    assetBlockIds.length,
+    resourceState,
     completeLesson,
   ]);
 

--- a/src/components/course/LessonContent.tsx
+++ b/src/components/course/LessonContent.tsx
@@ -410,6 +410,13 @@ export default function LessonContent({ lesson, loading, error, onCompleted }: L
     }
 
     // Fallback: no SmartDocs and no trackable videos => complete on 80% scroll
+    const initialScrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    if (initialScrollHeight <= 0) {
+      completedOnceRef.current = true;
+      void completeLesson();
+      return;
+    }
+
     const onScroll = () => {
       const y = window.scrollY || document.documentElement.scrollTop;
       const h = document.documentElement.scrollHeight - document.documentElement.clientHeight;


### PR DESCRIPTION
### Motivation
- Ensure text-only lessons that fit entirely in the viewport auto-complete immediately without attaching a scroll listener, while preserving 80% scroll completion for longer lessons.

### Description
- In `src/components/course/LessonContent.tsx` added an early check that computes `initialScrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight` and if `initialScrollHeight <= 0` sets `completedOnceRef.current = true` and calls `void completeLesson()` and returns, otherwise the existing 80% scroll listener remains.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979523a2e8c83328a835fd28dd9fe77)