### PR TITLE
Resolve lesson slug to first course child and remove global slug map

### DIFF
--- a/src/app/api/courses/[courseSlug]/route.ts
+++ b/src/app/api/courses/[courseSlug]/route.ts
@@ -56,6 +56,7 @@ export async function GET(req: NextRequest, context: unknown) {
     const { data: courseRow, error: courseError } = await adminClient
       .from('content_nodes')
       .select('id, node_type, state')
+      .eq('node_type', 'course')
       .eq('slug', courseSlug)
       .maybeSingle();
 

--- a/src/components/course/CourseViewer.tsx
+++ b/src/components/course/CourseViewer.tsx
@@ -35,7 +35,6 @@ type CourseState =
 
 type Maps = {
   nodeById: Map<number, NodeSubtree>;
-  slugToId: Map<string, number>;
   parentById: Map<number, number | null>;
 };
 
@@ -51,22 +50,18 @@ function formatContentLabel(nodeType: string) {
 
 function buildMaps(course: NodeSubtree): Maps {
   const nodeById = new Map<number, NodeSubtree>();
-  const slugToId = new Map<string, number>();
   const parentById = new Map<number, number | null>();
 
   const visit = (subtree: NodeSubtree, parentId: number | null) => {
     nodeById.set(subtree.node.id, subtree);
     parentById.set(subtree.node.id, parentId);
-    if (subtree.node.slug) {
-      slugToId.set(subtree.node.slug, subtree.node.id);
-    }
     for (const child of subtree.children) {
       visit(child.subtree, subtree.node.id);
     }
   };
 
   visit(course, null);
-  return { nodeById, slugToId, parentById };
+  return { nodeById, parentById };
 }
 
 function toNestedLockMap(source: Record<number, ChildUnlockStatus[]>): Record<number, Record<number, ChildUnlockStatus>> {
@@ -91,6 +86,16 @@ function collectParentPath(nodeId: number, parentById: Map<number, number | null
     current = parent;
   }
   return path;
+}
+
+function findContentNodeBySlug(course: NodeSubtree, slug: string) {
+  for (const child of course.children) {
+    const node = child.subtree.node;
+    if (node.slug === slug && isContentNodeType(node.node_type)) {
+      return node.id;
+    }
+  }
+  return null;
 }
 
 function isNodeLocked(
@@ -334,10 +339,10 @@ export default function CourseViewer({ courseSlug, lessonSlug }: CourseViewerPro
   }, [state]);
 
   const nodeById = maps?.nodeById ?? null;
-  const slugToId = maps?.slugToId ?? null;
   const parentById = maps?.parentById ?? null;
 
-  const requestedContentId = lessonSlug && slugToId ? slugToId.get(lessonSlug) ?? null : null;
+  const requestedContentId =
+    lessonSlug && state.status === 'ready' ? findContentNodeBySlug(state.course, lessonSlug) : null;
   let selectedContent: NodeSubtree | null = null;
   let contentError: string | null = null;
 


### PR DESCRIPTION
### Motivation
- Restore predictable lesson routing by resolving a course lesson slug only among the course root's direct children and picking the first match when slugs collide.
- Remove reliance on a global slug-to-id map that could return nodes from other courses and cause incorrect lesson selection.

### Description
- Replace the previous DFS `findContentNodeBySlug` (which returned `matchId` and `matchCount`) with a simpler function that scans `course.children` and returns the first matching content node id or `null`.
- Remove the `slugToId` map and its population from `buildMaps`, so slug lookup is no longer global across the tree.
- Update selection logic to compute `requestedContentId` via `findContentNodeBySlug` and remove the duplicate-slug error path, falling back to a not-found error when appropriate.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ef096b6c83328c2388ae0ff26c22)